### PR TITLE
REF: replaceing core.ts types with circuit-json exported types

### DIFF
--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -5,7 +5,6 @@ import {
   PcbTrace,
   PcbComponent,
   PcbPort,
-  SchematicComponent,
   SourceGroup,
 } from "circuit-json"
 
@@ -25,6 +24,26 @@ export interface SchematicGroup {
   size: Size
   children_schematic_component_ids: string[]
   children_schematic_trace_ids: string[]
+}
+
+export interface SchematicComponent {
+  type: "schematic_component"
+  rotation: number
+  size: Size
+  center: Point
+  source_component_id: string
+  schematic_component_id: string
+
+  // TODO only for schematic-bug
+  port_arrangement?: {
+    left_size: number
+    right_size: number
+    top_size?: number
+    bottom_size?: number
+  }
+  port_labels?: {
+    [port_number: string]: string
+  }
 }
 
 export interface SchematicBox {

--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -1,17 +1,16 @@
 import { AnySourceComponent, SourceComponent } from "./source-component"
+import {
+  Size,
+  Point,
+  PcbTrace,
+  PcbComponent,
+  PcbPort,
+  SchematicComponent,
+  SourceGroup,
+} from "circuit-json"
 
 export interface SchematicConfig {
   type: "schematic_config"
-}
-
-export interface Point {
-  x: number
-  y: number
-}
-
-export interface Size {
-  width: number
-  height: number
 }
 
 export interface SourceConfig {
@@ -26,26 +25,6 @@ export interface SchematicGroup {
   size: Size
   children_schematic_component_ids: string[]
   children_schematic_trace_ids: string[]
-}
-
-export interface SchematicComponent {
-  type: "schematic_component"
-  rotation: number
-  size: Size
-  center: Point
-  source_component_id: string
-  schematic_component_id: string
-
-  // TODO only for schematic-bug
-  port_arrangement?: {
-    left_size: number
-    right_size: number
-    top_size?: number
-    bottom_size?: number
-  }
-  port_labels?: {
-    [port_number: string]: string
-  }
 }
 
 export interface SchematicBox {
@@ -111,32 +90,6 @@ export interface SchematicPort {
   facing_direction?: "up" | "down" | "left" | "right"
 }
 
-export interface PCBTrace {
-  type: "pcb_trace"
-  source_trace_id: string
-  pcb_trace_id: string
-  route: Array<{
-    x: number
-    y: number
-    strokeWidth: number
-    cap: "butt" | "round" | "square"
-    start_pcb_port_id?: string
-    end_pcb_port_id?: string
-  }>
-}
-
-export interface PCBComponent {
-  type: "pcb_component"
-  pcb_component_id: string
-  source_component_id: string
-}
-
-export interface PCBPort {
-  type: "pcb_port"
-  pcb_port_id: string
-  source_port_id: string
-}
-
 export interface PCBGroup {
   type: "pcb_group"
   source_group_id: string
@@ -151,13 +104,6 @@ export interface SourceTrace {
   type: "source_trace"
   source_trace_id: string
   connected_source_port_ids: string[]
-}
-
-export interface SourceGroup {
-  type: "source_group"
-  source_group_id: string
-  name: string
-  children_source_component_ids: string[]
 }
 
 export interface SourcePort {
@@ -178,9 +124,9 @@ export interface Project {
   schematic_ports: SchematicPort[]
   pcb_config: PCBConfig
   pcb_groups: PCBGroup[]
-  pcb_components: PCBComponent[]
-  pcb_traces: PCBTrace[]
-  pcb_ports: PCBPort[]
+  pcb_components: PcbComponent[]
+  pcb_traces: PcbTrace[]
+  pcb_ports: PcbPort[]
   source_config: SourceConfig
   source_traces: SourceTrace[]
   source_groups: SourceGroup[]
@@ -195,11 +141,11 @@ export type AnyElement =
   | SourceGroup
   | SourceTrace
   | SourcePort
-  | PCBTrace
-  | PCBComponent
+  | PcbTrace
+  | PcbComponent
   | PCBGroup
   | PCBConfig
-  | PCBPort
+  | PcbPort
   | SchematicGroup
   | SchematicComponent
   | SchematicTrace


### PR DESCRIPTION
-> Replaced the types in core.ts files with those exported from the `circuit-json` package.
-> closes #63 

cc: @seveibar 