### PR TITLE
Refactor z-index values in EditIcon and SchematicViewer components

### DIFF
--- a/lib/components/EditIcon.tsx
+++ b/lib/components/EditIcon.tsx
@@ -1,3 +1,5 @@
+import { zIndexMap } from "../utils/z-index-map"
+
 export const EditIcon = ({
   onClick,
   active,
@@ -18,7 +20,7 @@ export const EditIcon = ({
         display: "flex",
         alignItems: "center",
         gap: "4px",
-        zIndex: 1000,
+        zIndex: zIndexMap.schematicEditIcon,
       }}
     >
       <svg

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -17,6 +17,7 @@ import { useComponentDragging } from "../hooks/useComponentDragging"
 import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
 import type { CircuitJson } from "circuit-json"
+import { zIndexMap } from "../utils/z-index-map"
 
 interface Props {
   circuitJson: CircuitJson
@@ -241,7 +242,7 @@ export const SchematicViewer = ({
             position: "absolute",
             inset: 0,
             cursor: "pointer",
-            zIndex: 10,
+            zIndex: zIndexMap.clickToInteractOverlay,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -1,0 +1,4 @@
+export const zIndexMap = {
+  schematicEditIcon: 50,
+  clickToInteractOverlay: 100,
+}


### PR DESCRIPTION
- Introduced a new utility file `z-index-map.ts` to manage z-index values.
- Updated `EditIcon` to use `zIndexMap.schematicEditIcon` instead of a hardcoded value.
- Updated `SchematicViewer` to use `zIndexMap.clickToInteractOverlay` for the overlay z-index.