### PR TITLE
Fix background color when panning schematic

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -127,6 +127,13 @@ export const SchematicViewer = ({
     })
   }, [circuitJson, containerWidth, containerHeight])
 
+  const containerBackgroundColor = useMemo(() => {
+    const match = svgString.match(
+      /<svg[^>]*style="[^"]*background-color:\s*([^;\"]+)/i,
+    )
+    return match?.[1] ?? "transparent"
+  }, [svgString])
+
   const realToSvgProjection = useMemo(() => {
     if (!svgString) return identity()
     const transformString = svgString.match(
@@ -203,7 +210,7 @@ export const SchematicViewer = ({
       ref={containerRef}
       style={{
         position: "relative",
-        backgroundColor: "transparent",
+        backgroundColor: containerBackgroundColor,
         overflow: "hidden",
         cursor: isDragging
           ? "grabbing"


### PR DESCRIPTION
## Summary
- parse background color from generated SVG
- apply background color to schematic viewer container so panning matches SVG background

## Testing
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_683a894e0a74832e91c823531e778451