### PR TITLE
Add grid snap toggle in edit mode

### DIFF
--- a/lib/components/GridIcon.tsx
+++ b/lib/components/GridIcon.tsx
@@ -1,0 +1,38 @@
+import { zIndexMap } from "../utils/z-index-map"
+
+export const GridIcon = ({
+  onClick,
+  active,
+}: { onClick: () => void; active: boolean }) => {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        position: "absolute",
+        top: "56px",
+        right: "16px",
+        backgroundColor: active ? "#4CAF50" : "#fff",
+        color: active ? "#fff" : "#000",
+        padding: "8px",
+        borderRadius: "4px",
+        cursor: "pointer",
+        boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+        display: "flex",
+        alignItems: "center",
+        gap: "4px",
+        zIndex: zIndexMap.schematicGridIcon,
+      }}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z" />
+      </svg>
+    </div>
+  )
+}

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -16,6 +16,7 @@ import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
 import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
+import { GridIcon } from "./GridIcon"
 import type { CircuitJson } from "circuit-json"
 import { zIndexMap } from "../utils/z-index-map"
 
@@ -48,6 +49,7 @@ export const SchematicViewer = ({
     enableDebug()
   }
   const [editModeEnabled, setEditModeEnabled] = useState(defaultEditMode)
+  const [snapToGrid, setSnapToGrid] = useState(true)
   const [isInteractionEnabled, setIsInteractionEnabled] = useState<boolean>(
     !clickToInteractEnabled,
   )
@@ -168,6 +170,7 @@ export const SchematicViewer = ({
       circuitJson,
       editEvents: editEventsWithUnappliedEditEvents,
       enabled: editModeEnabled && isInteractionEnabled,
+      snapToGrid,
     },
   )
 
@@ -279,6 +282,12 @@ export const SchematicViewer = ({
         <EditIcon
           active={editModeEnabled}
           onClick={() => setEditModeEnabled(!editModeEnabled)}
+        />
+      )}
+      {editingEnabled && editModeEnabled && (
+        <GridIcon
+          active={snapToGrid}
+          onClick={() => setSnapToGrid(!snapToGrid)}
         />
       )}
       {svgDiv}

--- a/lib/hooks/useComponentDragging.ts
+++ b/lib/hooks/useComponentDragging.ts
@@ -18,6 +18,7 @@ export const useComponentDragging = ({
   svgToScreenProjection,
   realToSvgProjection,
   enabled = false,
+  snapToGrid = false,
 }: {
   circuitJson: any[]
   editEvents: ManualEditEvent[]
@@ -28,6 +29,7 @@ export const useComponentDragging = ({
   onEditEvent?: (event: ManualEditEvent) => void
   cancelDrag?: () => void
   enabled?: boolean
+  snapToGrid?: boolean
 }): {
   handleMouseDown: (e: React.MouseEvent) => void
   isDragging: boolean
@@ -158,18 +160,24 @@ export const useComponentDragging = ({
         y: screenDelta.y / realToScreenProjection.d,
       }
 
+      let newCenter = {
+        x: activeEditEventRef.current.original_center.x + mmDelta.x,
+        y: activeEditEventRef.current.original_center.y + mmDelta.y,
+      }
+      if (snapToGrid) {
+        const snap = (v: number) => Math.round(v * 10) / 10
+        newCenter = { x: snap(newCenter.x), y: snap(newCenter.y) }
+      }
+
       const newEditEvent = {
         ...activeEditEventRef.current,
-        new_center: {
-          x: activeEditEventRef.current.original_center.x + mmDelta.x,
-          y: activeEditEventRef.current.original_center.y + mmDelta.y,
-        },
+        new_center: newCenter,
       }
 
       activeEditEventRef.current = newEditEvent
       setActiveEditEvent(newEditEvent)
     },
-    [realToScreenProjection],
+    [realToScreenProjection, snapToGrid],
   )
 
   const handleMouseUp = useCallback(() => {

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -1,4 +1,5 @@
 export const zIndexMap = {
   schematicEditIcon: 50,
+  schematicGridIcon: 49,
   clickToInteractOverlay: 100,
 }


### PR DESCRIPTION
## Summary
- add a grid icon and z-index entry
- allow component dragging to snap to a 0.1 grid when enabled
- expose snap toggle in `SchematicViewer`

## Testing
- `bun update --latest debug` *(fails: 403)*
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6851e988b6f0832eae8903c9666c7ea6