### PR TITLE
Add port hover highlighting

### DIFF
--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -2,4 +2,5 @@ export const zIndexMap = {
   schematicEditIcon: 50,
   schematicGridIcon: 49,
   clickToInteractOverlay: 100,
+  schematicPortHover: 60,
 }


### PR DESCRIPTION
## Summary
- show a highlight box when hovering over a schematic port
- display the port label next to the hovered port

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_685c5fd57d18832eb575965d46865311