### PR TITLE
Avoid redundant circuit-to-svg calls during interaction

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -162,7 +162,13 @@ export const SchematicViewer = ({
           },
       colorOverrides,
     })
-  }, [circuitJson, containerWidth, containerHeight])
+  }, [
+    circuitJsonKey,
+    containerWidth,
+    containerHeight,
+    colorOverrides,
+    debugGrid,
+  ])
 
   const containerBackgroundColor = useMemo(() => {
     const match = svgString.match(

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -162,13 +162,7 @@ export const SchematicViewer = ({
           },
       colorOverrides,
     })
-  }, [
-    circuitJsonKey,
-    containerWidth,
-    containerHeight,
-    colorOverrides,
-    debugGrid,
-  ])
+  }, [circuitJsonKey, containerWidth, containerHeight])
 
   const containerBackgroundColor = useMemo(() => {
     const match = svgString.match(


### PR DESCRIPTION
## Summary
- memoize circuit-to-svg rendering on a stable circuit hash

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68b4b5911b24832eb07867c4ca6777ff