### PR TITLE
feat(spice): prevent spice simulation from autorunning

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -92,12 +92,18 @@ export const SchematicViewer = ({
     spiceSimOptions.duration,
   ])
 
+  const [hasSpiceSimRun, setHasSpiceSimRun] = useState(false)
+
+  useEffect(() => {
+    setHasSpiceSimRun(false)
+  }, [circuitJsonKey])
+
   const {
     plotData,
     nodes,
     isLoading: isSpiceSimLoading,
     error: spiceSimError,
-  } = useSpiceSimulation(spiceString)
+  } = useSpiceSimulation(hasSpiceSimRun ? spiceString : null)
 
   const [editModeEnabled, setEditModeEnabled] = useState(defaultEditMode)
   const [snapToGrid, setSnapToGrid] = useState(true)
@@ -412,7 +418,11 @@ export const SchematicViewer = ({
           isLoading={isSpiceSimLoading}
           error={spiceSimError}
           simOptions={spiceSimOptions}
-          onSimOptionsChange={setSpiceSimOptions}
+          onSimOptionsChange={(options) => {
+            setHasSpiceSimRun(true)
+            setSpiceSimOptions(options)
+          }}
+          hasRun={hasSpiceSimRun}
         />
       )}
       {svgDiv}

--- a/lib/components/SpicePlot.tsx
+++ b/lib/components/SpicePlot.tsx
@@ -56,11 +56,13 @@ export const SpicePlot = ({
   nodes,
   isLoading,
   error,
+  hasRun,
 }: {
   plotData: PlotPoint[]
   nodes: string[]
   isLoading: boolean
   error: string | null
+  hasRun: boolean
 }) => {
   const yAxisLabel = useMemo(() => {
     const hasVoltage = nodes.some((n) => n.toLowerCase().startsWith("v("))
@@ -83,6 +85,22 @@ export const SpicePlot = ({
         }}
       >
         Running simulation...
+      </div>
+    )
+  }
+
+  if (!hasRun) {
+    return (
+      <div
+        style={{
+          height: "300px",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        Click "Run" to start the simulation.
       </div>
     )
   }

--- a/lib/components/SpiceSimulationOverlay.tsx
+++ b/lib/components/SpiceSimulationOverlay.tsx
@@ -18,6 +18,7 @@ interface SpiceSimulationOverlayProps {
   onSimOptionsChange: (
     options: SpiceSimulationOverlayProps["simOptions"],
   ) => void
+  hasRun: boolean
 }
 
 export const SpiceSimulationOverlay = ({
@@ -29,6 +30,7 @@ export const SpiceSimulationOverlay = ({
   error,
   simOptions,
   onSimOptionsChange,
+  hasRun,
 }: SpiceSimulationOverlayProps) => {
   const [startTimeDraft, setStartTimeDraft] = useState(
     String(simOptions.startTime),
@@ -125,6 +127,7 @@ export const SpiceSimulationOverlay = ({
             nodes={filteredNodes}
             isLoading={isLoading}
             error={error}
+            hasRun={hasRun}
           />
         </div>
         <div
@@ -209,7 +212,7 @@ export const SpiceSimulationOverlay = ({
                 cursor: "pointer",
               }}
             >
-              Rerun
+              {hasRun ? "Rerun" : "Run"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
This PR prevents the SPICE simulation from running automatically when the overlay is opened.                                                                       
                                                                                                                                                                   
The simulation is now only triggered when the user clicks the "Run" button. This provides a better user experience by giving explicit control over when the potentially long-running simulation is executed. 