### PR TITLE
feat: allow double-click on components

### DIFF
--- a/examples/example14-double-click.fixture.tsx
+++ b/examples/example14-double-click.fixture.tsx
@@ -1,0 +1,19 @@
+import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+export default () => (
+  <ControlledSchematicViewer
+    circuitJson={renderToCircuitJson(
+      <board width="10mm" height="10mm">
+        <resistor name="R1" resistance={1000} schX={-2} />
+        <capacitor name="C1" capacitance="1uF" schX={2} />
+        <trace from=".R1 .pin2" to=".C1 .pin1" />
+      </board>,
+    )}
+    onClickComponent={(componentId, component) => {
+      alert(`Double-clicked component ${componentId}: ${component?.name || 'Unknown'}`)
+      // Here you could open an editing dialog
+    }}
+    containerStyle={{ height: "100%" }}
+  />
+)

--- a/lib/components/ControlledSchematicViewer.tsx
+++ b/lib/components/ControlledSchematicViewer.tsx
@@ -9,6 +9,7 @@ export const ControlledSchematicViewer = ({
   editingEnabled = false,
   debug = false,
   clickToInteractEnabled = false,
+  onClickComponent,
 }: {
   circuitJson: any[]
   containerStyle?: React.CSSProperties
@@ -16,6 +17,7 @@ export const ControlledSchematicViewer = ({
   editingEnabled?: boolean
   debug?: boolean
   clickToInteractEnabled?: boolean
+  onClickComponent?: (componentId: string, component: any) => void
 }) => {
   const [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
 
@@ -29,6 +31,7 @@ export const ControlledSchematicViewer = ({
       editingEnabled={editingEnabled}
       debug={debug}
       clickToInteractEnabled={clickToInteractEnabled}
+      onClickComponent={onClickComponent}
     />
   )
 }

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -281,12 +281,14 @@ export const SchematicViewer = ({
         {shouldShowPointerCursor && (
           <style>
             {`
-              [data-circuit-json-type="schematic_component"]:hover {
-                filter: drop-shadow(0 0 4px rgba(59, 130, 246, 0.5));
+              [data-circuit-json-type="schematic_component"]:hover g:not([data-text-group]) {
+                filter: drop-shadow(0 0 12px rgba(59, 130, 246, 0.9)) drop-shadow(0 0 6px rgba(59, 130, 246, 0.7));
               }
-              [data-circuit-json-type="schematic_component"]:hover * {
-                stroke: #3b82f6 !important;
-                stroke-width: 2 !important;
+              [data-circuit-json-type="schematic_component"]:hover path:not([data-text-path]),
+              [data-circuit-json-type="schematic_component"]:hover rect:not([data-text-rect]),
+              [data-circuit-json-type="schematic_component"]:hover circle:not([data-text-circle]),
+              [data-circuit-json-type="schematic_component"]:hover line:not([data-text-line]) {
+                filter: drop-shadow(0 0 10px rgba(59, 130, 246, 0.8)) drop-shadow(0 0 4px rgba(59, 130, 246, 0.9));
               }
             `}
           </style>

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -277,27 +277,42 @@ export const SchematicViewer = ({
 
   const svgDiv = useMemo(
     () => (
-      <div
-        ref={svgDivRef}
-        style={{
-          pointerEvents: clickToInteractEnabled
-            ? isInteractionEnabled
-              ? "auto"
-              : "none"
-            : "auto",
-          transformOrigin: "0 0",
-          cursor: shouldShowPointerCursor ? "pointer" : "inherit",
-        }}
-        onClick={handleComponentClick}
-        onTouchStart={(e) => {
-          if (editModeEnabled && isInteractionEnabled && !showSpiceOverlay) {
-            handleComponentTouchStartRef.current(e)
-          }
-        }}
-        onTouchEnd={handleComponentClick}
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-        dangerouslySetInnerHTML={{ __html: svgString }}
-      />
+      <>
+        {shouldShowPointerCursor && (
+          <style>
+            {`
+              [data-circuit-json-type="schematic_component"]:hover {
+                filter: drop-shadow(0 0 4px rgba(59, 130, 246, 0.5));
+              }
+              [data-circuit-json-type="schematic_component"]:hover * {
+                stroke: #3b82f6 !important;
+                stroke-width: 2 !important;
+              }
+            `}
+          </style>
+        )}
+        <div
+          ref={svgDivRef}
+          style={{
+            pointerEvents: clickToInteractEnabled
+              ? isInteractionEnabled
+                ? "auto"
+                : "none"
+              : "auto",
+            transformOrigin: "0 0",
+            cursor: shouldShowPointerCursor ? "pointer" : "inherit",
+          }}
+          onClick={handleComponentClick}
+          onTouchStart={(e) => {
+            if (editModeEnabled && isInteractionEnabled && !showSpiceOverlay) {
+              handleComponentTouchStartRef.current(e)
+            }
+          }}
+          onTouchEnd={handleComponentClick}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+          dangerouslySetInnerHTML={{ __html: svgString }}
+        />
+      </>
     ),
     [
       svgString,

--- a/lib/hooks/useComponentDoubleClick.ts
+++ b/lib/hooks/useComponentDoubleClick.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef } from "react"
+import { su } from "@tscircuit/soup-util"
+
+export const useComponentDoubleClick = ({
+  onClickComponent,
+  circuitJson,
+  enabled = true,
+}: {
+  onClickComponent?: (componentId: string, component: any) => void
+  circuitJson: any[]
+  enabled?: boolean
+}) => {
+  const lastClickRef = useRef<{
+    componentId: string
+    timestamp: number
+  } | null>(null)
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      if (!enabled || !onClickComponent) return
+
+      const target = e.target as Element
+      const componentGroup = target.closest(
+        '[data-circuit-json-type="schematic_component"]',
+      )
+      
+      if (!componentGroup) return
+
+      const componentId = componentGroup.getAttribute(
+        "data-schematic-component-id",
+      )
+      
+      if (!componentId) return
+
+      const now = Date.now()
+      const lastClick = lastClickRef.current
+
+      if (
+        lastClick &&
+        lastClick.componentId === componentId &&
+        now - lastClick.timestamp < 500
+      ) {
+        e.preventDefault()
+        e.stopPropagation()
+        
+        const component = su(circuitJson).schematic_component.get(componentId)
+        onClickComponent(componentId, component)
+        
+        lastClickRef.current = null
+      } else {
+        lastClickRef.current = {
+          componentId,
+          timestamp: now,
+        }
+      }
+    },
+    [onClickComponent, circuitJson, enabled],
+  )
+
+  return { handleClick }
+}


### PR DESCRIPTION
## PR Description

- **Double-click component interaction** - Users can now double-click on schematic components to trigger custom actions
- **Pointer cursor** - Shows pointer cursor when onClickComponent is provided and interaction is enabled
- **Touch support** - Double-tap functionality works on mobile/touch devices

## Video Demo

https://github.com/user-attachments/assets/d17f7e74-5070-4f61-8947-e5d7897470cd




Fixes #132 
/claim #132 