### PR TITLE
Add double-click component interaction and hover highlight

### DIFF
--- a/examples/example14-double-click-edit.fixture.tsx
+++ b/examples/example14-double-click-edit.fixture.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useState } from "react"
+import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+export default function Example14DoubleClickEdit() {
+  const [lastDoubleClickedComponent, setLastDoubleClickedComponent] = useState<
+    string | null
+  >(null)
+
+  const handleDoubleClick = useCallback(
+    ({ schematicComponentId }: { schematicComponentId: string }) => {
+      setLastDoubleClickedComponent(schematicComponentId)
+
+      if (typeof window !== "undefined") {
+        window.alert(`Open edit dialog for ${schematicComponentId}`)
+      }
+    },
+    [],
+  )
+
+  return (
+    <div
+      style={{
+        padding: "1rem",
+        height: "400px",
+        boxSizing: "border-box",
+      }}
+    >
+      <ControlledSchematicViewer
+        circuitJson={renderToCircuitJson(
+          <board width="12mm" height="12mm">
+            <resistor name="R1" resistance={220} schX={-2} schY={0} />
+            <capacitor name="C1" capacitance="10uF" schX={2} schY={0} />
+            <trace from=".R1 .pin2" to=".C1 .pin1" />
+          </board>,
+        )}
+        containerStyle={{ height: "100%" }}
+        onClickComponent={handleDoubleClick}
+      />
+      <p>
+        Double-click any component to simulate opening its editing dialog. The
+        cursor becomes a pointer to indicate interactivity.
+      </p>
+      {lastDoubleClickedComponent ? (
+        <p>
+          Last double-clicked component:{" "}
+          <strong>{lastDoubleClickedComponent}</strong>
+        </p>
+      ) : (
+        <p>Double-click a component to see its identifier here.</p>
+      )}
+    </div>
+  )
+}

--- a/lib/components/ControlledSchematicViewer.tsx
+++ b/lib/components/ControlledSchematicViewer.tsx
@@ -9,6 +9,7 @@ export const ControlledSchematicViewer = ({
   editingEnabled = false,
   debug = false,
   clickToInteractEnabled = false,
+  onClickComponent,
 }: {
   circuitJson: any[]
   containerStyle?: React.CSSProperties
@@ -16,6 +17,10 @@ export const ControlledSchematicViewer = ({
   editingEnabled?: boolean
   debug?: boolean
   clickToInteractEnabled?: boolean
+  onClickComponent?: (args: {
+    schematicComponentId: string
+    event: MouseEvent
+  }) => void
 }) => {
   const [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
 
@@ -29,6 +34,7 @@ export const ControlledSchematicViewer = ({
       editingEnabled={editingEnabled}
       debug={debug}
       clickToInteractEnabled={clickToInteractEnabled}
+      onClickComponent={onClickComponent}
     />
   )
 }

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -15,6 +15,7 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useComponentDoubleClick } from "../hooks/useComponentDoubleClick"
 import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
@@ -41,6 +42,10 @@ interface Props {
   colorOverrides?: ColorOverrides
   spiceSimulationEnabled?: boolean
   disableGroups?: boolean
+  onClickComponent?: (args: {
+    schematicComponentId: string
+    event: MouseEvent
+  }) => void
 }
 
 export const SchematicViewer = ({
@@ -56,6 +61,7 @@ export const SchematicViewer = ({
   colorOverrides,
   spiceSimulationEnabled = false,
   disableGroups = false,
+  onClickComponent,
 }: Props) => {
   if (debug) {
     enableDebug()
@@ -256,6 +262,15 @@ export const SchematicViewer = ({
     circuitJson,
     circuitJsonKey,
     showGroups: showSchematicGroups && !disableGroups,
+  })
+
+  useComponentDoubleClick({
+    svgDivRef,
+    svgString,
+    onClickComponent,
+    clickToInteractEnabled,
+    isInteractionEnabled,
+    showSpiceOverlay,
   })
 
   // keep the latest touch handler without re-rendering the svg div

--- a/lib/hooks/useComponentDoubleClick.ts
+++ b/lib/hooks/useComponentDoubleClick.ts
@@ -1,0 +1,124 @@
+
+import { useEffect, useRef } from "react"
+
+interface UseComponentDoubleClickProps {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  svgString: string
+  onClickComponent?: (args: {
+    schematicComponentId: string
+    event: MouseEvent
+  }) => void
+  clickToInteractEnabled: boolean
+  isInteractionEnabled: boolean
+  showSpiceOverlay: boolean
+}
+
+export const useComponentDoubleClick = ({
+  svgDivRef,
+  svgString,
+  onClickComponent,
+  clickToInteractEnabled,
+  isInteractionEnabled,
+  showSpiceOverlay,
+}: UseComponentDoubleClickProps) => {
+  const previousCursorMap = useRef(new Map<HTMLElement, string | null>())
+
+  useEffect(() => {
+    const svgContainer = svgDivRef.current
+    if (!svgContainer || !onClickComponent) return
+
+    const handleDoubleClick = (event: MouseEvent) => {
+      if (
+        (clickToInteractEnabled && !isInteractionEnabled) ||
+        showSpiceOverlay
+      ) {
+        return
+      }
+
+      const target = event.target as Element | null
+      const componentGroup = target?.closest(
+        '[data-circuit-json-type="schematic_component"]',
+      ) as HTMLElement | null
+
+      if (!componentGroup) return
+
+      const schematicComponentId = componentGroup.getAttribute(
+        "data-schematic-component-id",
+      )
+
+      if (!schematicComponentId) return
+
+      onClickComponent({ schematicComponentId, event })
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const target = event.target as Element | null
+      const componentGroup = target?.closest(
+        '[data-circuit-json-type="schematic_component"]',
+      ) as HTMLElement | null
+
+      if (componentGroup) {
+        const rect = componentGroup.getBoundingClientRect()
+        const svgRect = svgContainer.getBoundingClientRect()
+        const highlight = document.createElement("div")
+        highlight.style.position = "absolute"
+        highlight.style.left = `${rect.left - svgRect.left}px`
+        highlight.style.top = `${rect.top - svgRect.top}px`
+        highlight.style.width = `${rect.width}px`
+        highlight.style.height = `${rect.height}px`
+        highlight.style.backgroundColor = "rgba(0, 100, 255, 0.2)"
+        highlight.style.border = "1px solid rgba(0, 100, 255, 0.5)"
+        highlight.style.borderRadius = "2px"
+        highlight.style.pointerEvents = "none"
+        highlight.classList.add("component-hover-highlight")
+        svgContainer.appendChild(highlight)
+      }
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const highlight = svgContainer.querySelector(".component-hover-highlight")
+      if (highlight) {
+        highlight.remove()
+      }
+    }
+
+    svgContainer.addEventListener("dblclick", handleDoubleClick)
+    svgContainer.addEventListener("mouseover", handleMouseOver)
+    svgContainer.addEventListener("mouseout", handleMouseOut)
+
+    const componentElements = Array.from(
+      svgContainer.querySelectorAll(
+        '[data-circuit-json-type="schematic_component"]',
+      ),
+    ) as HTMLElement[]
+
+    componentElements.forEach((element) => {
+      previousCursorMap.current.set(element, element.style.cursor || null)
+      element.style.cursor = "pointer"
+    })
+
+    return () => {
+      svgContainer.removeEventListener("dblclick", handleDoubleClick)
+      svgContainer.removeEventListener("mouseover", handleMouseOver)
+      svgContainer.removeEventListener("mouseout", handleMouseOut)
+      const highlight = svgContainer.querySelector(".component-hover-highlight")
+      if (highlight) {
+        highlight.remove()
+      }
+      componentElements.forEach((element) => {
+        const previousCursor = previousCursorMap.current.get(element)
+        if (previousCursor) {
+          element.style.cursor = previousCursor
+        } else {
+          element.style.removeProperty("cursor")
+        }
+      })
+    }
+  }, [
+    svgString,
+    onClickComponent,
+    clickToInteractEnabled,
+    isInteractionEnabled,
+    showSpiceOverlay,
+  ])
+}


### PR DESCRIPTION
- Enables double-clicking schematic components via `onClickComponent` prop for edit dialog triggers.
- Adds pointer cursor and improved hover highlight for clickable components.

Both checklists mentioned in the issue are taken care of:
- [ ] Show pointer cursor
- [ ] Only when user provides prop

Preview:

https://github.com/user-attachments/assets/9ebf3818-333e-4474-a24d-c4b4d1177e9d

closes #132
claim #132 