### PR TITLE
Add hover bounding boxes and mouse tracker for schematic components

### DIFF
--- a/examples/example14-schematic-component-click.fixture.tsx
+++ b/examples/example14-schematic-component-click.fixture.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react"
+import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+const circuitJson = renderToCircuitJson(
+  <board width="12mm" height="12mm">
+    <resistor name="R1" resistance={1000} schX={-2} schY={0} />
+    <capacitor name="C1" capacitance="1uF" schX={2} schY={0} />
+    <trace from=".R1 .pin2" to=".C1 .pin1" />
+    <trace from=".R1 .pin1" to=".C1 .pin2" />
+  </board>,
+)
+
+export default function Example() {
+  const [clickedComponentId, setClickedComponentId] = useState<string | null>(
+    null,
+  )
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        padding: "16px",
+        height: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ fontFamily: "sans-serif" }}>
+        {clickedComponentId
+          ? `Last clicked component: ${clickedComponentId}`
+          : "Click a component to highlight it"}
+      </div>
+      <div style={{ flex: 1, minHeight: 320 }}>
+        <ControlledSchematicViewer
+          circuitJson={circuitJson}
+          containerStyle={{ height: "100%" }}
+          onSchematicComponentClicked={({ schematicComponentId }) => {
+            setClickedComponentId(schematicComponentId)
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/lib/components/ControlledSchematicViewer.tsx
+++ b/lib/components/ControlledSchematicViewer.tsx
@@ -9,6 +9,7 @@ export const ControlledSchematicViewer = ({
   editingEnabled = false,
   debug = false,
   clickToInteractEnabled = false,
+  onSchematicComponentClicked,
 }: {
   circuitJson: any[]
   containerStyle?: React.CSSProperties
@@ -16,6 +17,10 @@ export const ControlledSchematicViewer = ({
   editingEnabled?: boolean
   debug?: boolean
   clickToInteractEnabled?: boolean
+  onSchematicComponentClicked?: (options: {
+    schematicComponentId: string
+    event: MouseEvent
+  }) => void
 }) => {
   const [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
 
@@ -29,6 +34,7 @@ export const ControlledSchematicViewer = ({
       editingEnabled={editingEnabled}
       debug={debug}
       clickToInteractEnabled={clickToInteractEnabled}
+      onSchematicComponentClicked={onSchematicComponentClicked}
     />
   )
 }

--- a/lib/components/MouseTracker.tsx
+++ b/lib/components/MouseTracker.tsx
@@ -1,0 +1,227 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react"
+
+export interface BoundingBoxBounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+interface BoundingBoxRegistration {
+  bounds: BoundingBoxBounds | null
+  onClick?: ((event: MouseEvent) => void) | undefined
+}
+
+export interface MouseTrackerContextValue {
+  registerBoundingBox: (
+    id: string,
+    registration: BoundingBoxRegistration,
+  ) => void
+  updateBoundingBox: (id: string, registration: BoundingBoxRegistration) => void
+  unregisterBoundingBox: (id: string) => void
+  subscribe: (listener: () => void) => () => void
+  isHovering: (id: string) => boolean
+}
+
+export const MouseTrackerContext =
+  createContext<MouseTrackerContextValue | null>(null)
+
+const boundsAreEqual = (
+  a: BoundingBoxBounds | null | undefined,
+  b: BoundingBoxBounds | null | undefined,
+) => {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return (
+    a.minX === b.minX &&
+    a.maxX === b.maxX &&
+    a.minY === b.minY &&
+    a.maxY === b.maxY
+  )
+}
+
+export const MouseTracker = ({ children }: { children: ReactNode }) => {
+  const existingContext = useContext(MouseTrackerContext)
+
+  if (existingContext) {
+    return <>{children}</>
+  }
+
+  const storeRef = useRef({
+    pointer: null as { x: number; y: number } | null,
+    boundingBoxes: new Map<string, BoundingBoxRegistration>(),
+    hoveringIds: new Set<string>(),
+    subscribers: new Set<() => void>(),
+  })
+
+  const notifySubscribers = useCallback(() => {
+    for (const callback of storeRef.current.subscribers) {
+      callback()
+    }
+  }, [])
+
+  const updateHovering = useCallback(() => {
+    const pointer = storeRef.current.pointer
+    const newHovering = new Set<string>()
+
+    if (pointer) {
+      for (const [id, registration] of storeRef.current.boundingBoxes) {
+        const bounds = registration.bounds
+        if (!bounds) continue
+        if (
+          pointer.x >= bounds.minX &&
+          pointer.x <= bounds.maxX &&
+          pointer.y >= bounds.minY &&
+          pointer.y <= bounds.maxY
+        ) {
+          newHovering.add(id)
+        }
+      }
+    }
+
+    const prevHovering = storeRef.current.hoveringIds
+    if (
+      newHovering.size === prevHovering.size &&
+      [...newHovering].every((id) => prevHovering.has(id))
+    ) {
+      return
+    }
+
+    storeRef.current.hoveringIds = newHovering
+    notifySubscribers()
+  }, [notifySubscribers])
+
+  const registerBoundingBox = useCallback(
+    (id: string, registration: BoundingBoxRegistration) => {
+      storeRef.current.boundingBoxes.set(id, registration)
+      updateHovering()
+    },
+    [updateHovering],
+  )
+
+  const updateBoundingBox = useCallback(
+    (id: string, registration: BoundingBoxRegistration) => {
+      const existing = storeRef.current.boundingBoxes.get(id)
+      if (
+        existing &&
+        boundsAreEqual(existing.bounds, registration.bounds) &&
+        existing.onClick === registration.onClick
+      ) {
+        return
+      }
+      storeRef.current.boundingBoxes.set(id, registration)
+      updateHovering()
+    },
+    [updateHovering],
+  )
+
+  const unregisterBoundingBox = useCallback(
+    (id: string) => {
+      const removed = storeRef.current.boundingBoxes.delete(id)
+      if (removed) {
+        updateHovering()
+      }
+    },
+    [updateHovering],
+  )
+
+  const subscribe = useCallback((listener: () => void) => {
+    storeRef.current.subscribers.add(listener)
+    return () => {
+      storeRef.current.subscribers.delete(listener)
+    }
+  }, [])
+
+  const isHovering = useCallback((id: string) => {
+    return storeRef.current.hoveringIds.has(id)
+  }, [])
+
+  useEffect(() => {
+    const handlePointerPosition = (event: PointerEvent | MouseEvent) => {
+      const { clientX, clientY } = event
+      const pointer = storeRef.current.pointer
+      if (pointer && pointer.x === clientX && pointer.y === clientY) {
+        return
+      }
+      storeRef.current.pointer = { x: clientX, y: clientY }
+      updateHovering()
+    }
+
+    const handlePointerLeave = () => {
+      if (storeRef.current.pointer === null) return
+      storeRef.current.pointer = null
+      updateHovering()
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      const { clientX, clientY } = event
+      for (const registration of storeRef.current.boundingBoxes.values()) {
+        const bounds = registration.bounds
+        if (!bounds) continue
+        if (
+          clientX >= bounds.minX &&
+          clientX <= bounds.maxX &&
+          clientY >= bounds.minY &&
+          clientY <= bounds.maxY
+        ) {
+          registration.onClick?.(event)
+        }
+      }
+    }
+
+    window.addEventListener("pointermove", handlePointerPosition, {
+      passive: true,
+    })
+    window.addEventListener("pointerdown", handlePointerPosition, {
+      passive: true,
+    })
+    window.addEventListener("pointerup", handlePointerPosition, {
+      passive: true,
+    })
+    window.addEventListener("pointerleave", handlePointerLeave)
+    window.addEventListener("pointercancel", handlePointerLeave)
+    window.addEventListener("blur", handlePointerLeave)
+    window.addEventListener("click", handleClick, { passive: true })
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerPosition)
+      window.removeEventListener("pointerdown", handlePointerPosition)
+      window.removeEventListener("pointerup", handlePointerPosition)
+      window.removeEventListener("pointerleave", handlePointerLeave)
+      window.removeEventListener("pointercancel", handlePointerLeave)
+      window.removeEventListener("blur", handlePointerLeave)
+      window.removeEventListener("click", handleClick)
+    }
+  }, [updateHovering])
+
+  const value = useMemo<MouseTrackerContextValue>(
+    () => ({
+      registerBoundingBox,
+      updateBoundingBox,
+      unregisterBoundingBox,
+      subscribe,
+      isHovering,
+    }),
+    [
+      registerBoundingBox,
+      updateBoundingBox,
+      unregisterBoundingBox,
+      subscribe,
+      isHovering,
+    ],
+  )
+
+  return (
+    <MouseTrackerContext.Provider value={value}>
+      {children}
+    </MouseTrackerContext.Provider>
+  )
+}

--- a/lib/components/SchematicComponentMouseTarget.tsx
+++ b/lib/components/SchematicComponentMouseTarget.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useMouseEventsOverBoundingBox } from "../hooks/useMouseEventsOverBoundingBox"
+import type { BoundingBoxBounds } from "./MouseTracker"
+import { zIndexMap } from "../utils/z-index-map"
+
+interface RelativeRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+interface Measurement {
+  bounds: BoundingBoxBounds
+  rect: RelativeRect
+}
+
+const areMeasurementsEqual = (a: Measurement | null, b: Measurement | null) => {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return (
+    Math.abs(a.bounds.minX - b.bounds.minX) < 0.5 &&
+    Math.abs(a.bounds.maxX - b.bounds.maxX) < 0.5 &&
+    Math.abs(a.bounds.minY - b.bounds.minY) < 0.5 &&
+    Math.abs(a.bounds.maxY - b.bounds.maxY) < 0.5 &&
+    Math.abs(a.rect.left - b.rect.left) < 0.5 &&
+    Math.abs(a.rect.top - b.rect.top) < 0.5 &&
+    Math.abs(a.rect.width - b.rect.width) < 0.5 &&
+    Math.abs(a.rect.height - b.rect.height) < 0.5
+  )
+}
+
+interface Props {
+  componentId: string
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  containerRef: React.RefObject<HTMLDivElement | null>
+  onComponentClick?: (componentId: string, event: MouseEvent) => void
+  showOutline: boolean
+  circuitJsonKey: string
+}
+
+export const SchematicComponentMouseTarget = ({
+  componentId,
+  svgDivRef,
+  containerRef,
+  onComponentClick,
+  showOutline,
+  circuitJsonKey,
+}: Props) => {
+  const [measurement, setMeasurement] = useState<Measurement | null>(null)
+  const frameRef = useRef<number | null>(null)
+
+  const measure = useCallback(() => {
+    frameRef.current = null
+    const svgDiv = svgDivRef.current
+    const container = containerRef.current
+    if (!svgDiv || !container) {
+      setMeasurement((prev) => (prev ? null : prev))
+      return
+    }
+    const element = svgDiv.querySelector<SVGGraphicsElement | HTMLElement>(
+      `[data-schematic-component-id="${componentId}"]`,
+    )
+    if (!element) {
+      setMeasurement((prev) => (prev ? null : prev))
+      return
+    }
+
+    const elementRect = element.getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+
+    const nextMeasurement: Measurement = {
+      bounds: {
+        minX: elementRect.left,
+        maxX: elementRect.right,
+        minY: elementRect.top,
+        maxY: elementRect.bottom,
+      },
+      rect: {
+        left: elementRect.left - containerRect.left,
+        top: elementRect.top - containerRect.top,
+        width: elementRect.width,
+        height: elementRect.height,
+      },
+    }
+
+    setMeasurement((prev) =>
+      areMeasurementsEqual(prev, nextMeasurement) ? prev : nextMeasurement,
+    )
+  }, [componentId, containerRef, svgDivRef])
+
+  const scheduleMeasure = useCallback(() => {
+    if (frameRef.current !== null) return
+    frameRef.current = window.requestAnimationFrame(measure)
+  }, [measure])
+
+  useEffect(() => {
+    scheduleMeasure()
+  }, [scheduleMeasure, circuitJsonKey])
+
+  useEffect(() => {
+    scheduleMeasure()
+    const svgDiv = svgDivRef.current
+    const container = containerRef.current
+    if (!svgDiv || !container) return
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            scheduleMeasure()
+          })
+        : null
+    resizeObserver?.observe(container)
+    resizeObserver?.observe(svgDiv)
+
+    const mutationObserver =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(() => {
+            scheduleMeasure()
+          })
+        : null
+    mutationObserver?.observe(svgDiv, {
+      attributes: true,
+      attributeFilter: ["style", "transform"],
+      subtree: true,
+      childList: true,
+    })
+
+    window.addEventListener("scroll", scheduleMeasure, true)
+    window.addEventListener("resize", scheduleMeasure)
+
+    return () => {
+      resizeObserver?.disconnect()
+      mutationObserver?.disconnect()
+      window.removeEventListener("scroll", scheduleMeasure, true)
+      window.removeEventListener("resize", scheduleMeasure)
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+    }
+  }, [scheduleMeasure, svgDivRef, containerRef])
+
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      if (onComponentClick) {
+        onComponentClick(componentId, event)
+      }
+    },
+    [componentId, onComponentClick],
+  )
+
+  const bounds = measurement?.bounds ?? null
+
+  const { hovering } = useMouseEventsOverBoundingBox({
+    bounds,
+    onClick: onComponentClick ? handleClick : undefined,
+  })
+
+  if (!measurement || !hovering || !showOutline) {
+    return null
+  }
+
+  const rect = measurement.rect
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        border: "1.5px solid rgba(51, 153, 255, 0.9)",
+        borderRadius: "6px",
+        pointerEvents: "none",
+        zIndex: zIndexMap.schematicComponentHoverOutline,
+        boxShadow: "0 0 6px rgba(51, 153, 255, 0.35)",
+      }}
+    />
+  )
+}

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -2,6 +2,7 @@ import {
   convertCircuitJsonToSchematicSvg,
   type ColorOverrides,
 } from "circuit-to-svg"
+import { su } from "@tscircuit/soup-util"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
@@ -27,6 +28,8 @@ import { zIndexMap } from "../utils/z-index-map"
 import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import { getSpiceFromCircuitJson } from "../utils/spice-utils"
 import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
+import { MouseTracker } from "./MouseTracker"
+import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 
 interface Props {
   circuitJson: CircuitJson
@@ -41,6 +44,10 @@ interface Props {
   colorOverrides?: ColorOverrides
   spiceSimulationEnabled?: boolean
   disableGroups?: boolean
+  onSchematicComponentClicked?: (options: {
+    schematicComponentId: string
+    event: MouseEvent
+  }) => void
 }
 
 export const SchematicViewer = ({
@@ -56,6 +63,7 @@ export const SchematicViewer = ({
   colorOverrides,
   spiceSimulationEnabled = false,
   disableGroups = false,
+  onSchematicComponentClicked,
 }: Props) => {
   if (debug) {
     enableDebug()
@@ -117,6 +125,19 @@ export const SchematicViewer = ({
   })
   const svgDivRef = useRef<HTMLDivElement>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+
+  const schematicComponentIds = useMemo(() => {
+    try {
+      return (
+        su(circuitJson)
+          .schematic_component?.list()
+          ?.map((component) => component.schematic_component_id as string) ?? []
+      )
+    } catch (err) {
+      console.error("Failed to derive schematic component ids", err)
+      return []
+    }
+  }, [circuitJsonKey, circuitJson])
 
   const handleTouchStart = (e: React.TouchEvent) => {
     const touch = e.touches[0]
@@ -295,137 +316,156 @@ export const SchematicViewer = ({
   )
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        position: "relative",
-        backgroundColor: containerBackgroundColor,
-        overflow: "hidden",
-        cursor: showSpiceOverlay
-          ? "auto"
-          : isDragging
-            ? "grabbing"
-            : clickToInteractEnabled && !isInteractionEnabled
-              ? "pointer"
-              : "grab",
-        minHeight: "300px",
-        ...containerStyle,
-      }}
-      onWheelCapture={(e) => {
-        if (showSpiceOverlay) {
-          e.stopPropagation()
-        }
-      }}
-      onMouseDown={(e) => {
-        if (clickToInteractEnabled && !isInteractionEnabled) {
-          e.preventDefault()
-          e.stopPropagation()
-          return
-        }
-        handleMouseDown(e)
-      }}
-      onMouseDownCapture={(e) => {
-        if (clickToInteractEnabled && !isInteractionEnabled) {
-          e.preventDefault()
-          e.stopPropagation()
-          return
-        }
-      }}
-      onTouchStart={(e) => {
-        if (showSpiceOverlay) return
-        handleTouchStart(e)
-      }}
-      onTouchEnd={(e) => {
-        if (showSpiceOverlay) return
-        handleTouchEnd(e)
-      }}
-    >
-      {!isInteractionEnabled && clickToInteractEnabled && (
-        <div
-          onClick={(e) => {
-            e.preventDefault()
+    <MouseTracker>
+      <div
+        ref={containerRef}
+        style={{
+          position: "relative",
+          backgroundColor: containerBackgroundColor,
+          overflow: "hidden",
+          cursor: showSpiceOverlay
+            ? "auto"
+            : isDragging
+              ? "grabbing"
+              : clickToInteractEnabled && !isInteractionEnabled
+                ? "pointer"
+                : "grab",
+          minHeight: "300px",
+          ...containerStyle,
+        }}
+        onWheelCapture={(e) => {
+          if (showSpiceOverlay) {
             e.stopPropagation()
-            setIsInteractionEnabled(true)
-          }}
-          style={{
-            position: "absolute",
-            inset: 0,
-            cursor: "pointer",
-            zIndex: zIndexMap.clickToInteractOverlay,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            pointerEvents: "all",
-            touchAction: "pan-x pan-y pinch-zoom",
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: "rgba(0, 0, 0, 0.8)",
-              color: "white",
-              padding: "12px 24px",
-              borderRadius: "8px",
-              fontSize: "16px",
-              fontFamily: "sans-serif",
-              pointerEvents: "none",
-            }}
-          >
-            {typeof window !== "undefined" &&
-            ("ontouchstart" in window || navigator.maxTouchPoints > 0)
-              ? "Touch to Interact"
-              : "Click to Interact"}
-          </div>
-        </div>
-      )}
-      <ViewMenuIcon
-        active={showViewMenu}
-        onClick={() => setShowViewMenu(!showViewMenu)}
-      />
-      {editingEnabled && (
-        <EditIcon
-          active={editModeEnabled}
-          onClick={() => setEditModeEnabled(!editModeEnabled)}
-        />
-      )}
-      {editingEnabled && editModeEnabled && (
-        <GridIcon
-          active={snapToGrid}
-          onClick={() => setSnapToGrid(!snapToGrid)}
-        />
-      )}
-      <ViewMenu
-        circuitJson={circuitJson}
-        circuitJsonKey={circuitJsonKey}
-        isVisible={showViewMenu}
-        onClose={() => setShowViewMenu(false)}
-        showGroups={showSchematicGroups}
-        onToggleGroups={(value) => {
-          if (!disableGroups) {
-            setShowSchematicGroups(value)
-            setStoredBoolean("schematic_viewer_show_groups", value)
           }
         }}
-      />
-      {spiceSimulationEnabled && (
-        <SpiceSimulationIcon onClick={() => setShowSpiceOverlay(true)} />
-      )}
-      {showSpiceOverlay && (
-        <SpiceSimulationOverlay
-          spiceString={spiceString}
-          onClose={() => setShowSpiceOverlay(false)}
-          plotData={plotData}
-          nodes={nodes}
-          isLoading={isSpiceSimLoading}
-          error={spiceSimError}
-          simOptions={spiceSimOptions}
-          onSimOptionsChange={(options) => {
-            setHasSpiceSimRun(true)
-            setSpiceSimOptions(options)
-          }}
-          hasRun={hasSpiceSimRun}
+        onMouseDown={(e) => {
+          if (clickToInteractEnabled && !isInteractionEnabled) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+          }
+          handleMouseDown(e)
+        }}
+        onMouseDownCapture={(e) => {
+          if (clickToInteractEnabled && !isInteractionEnabled) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+          }
+        }}
+        onTouchStart={(e) => {
+          if (showSpiceOverlay) return
+          handleTouchStart(e)
+        }}
+        onTouchEnd={(e) => {
+          if (showSpiceOverlay) return
+          handleTouchEnd(e)
+        }}
+      >
+        {!isInteractionEnabled && clickToInteractEnabled && (
+          <div
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setIsInteractionEnabled(true)
+            }}
+            style={{
+              position: "absolute",
+              inset: 0,
+              cursor: "pointer",
+              zIndex: zIndexMap.clickToInteractOverlay,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              pointerEvents: "all",
+              touchAction: "pan-x pan-y pinch-zoom",
+            }}
+          >
+            <div
+              style={{
+                backgroundColor: "rgba(0, 0, 0, 0.8)",
+                color: "white",
+                padding: "12px 24px",
+                borderRadius: "8px",
+                fontSize: "16px",
+                fontFamily: "sans-serif",
+                pointerEvents: "none",
+              }}
+            >
+              {typeof window !== "undefined" &&
+              ("ontouchstart" in window || navigator.maxTouchPoints > 0)
+                ? "Touch to Interact"
+                : "Click to Interact"}
+            </div>
+          </div>
+        )}
+        <ViewMenuIcon
+          active={showViewMenu}
+          onClick={() => setShowViewMenu(!showViewMenu)}
         />
-      )}
-      {svgDiv}
-    </div>
+        {editingEnabled && (
+          <EditIcon
+            active={editModeEnabled}
+            onClick={() => setEditModeEnabled(!editModeEnabled)}
+          />
+        )}
+        {editingEnabled && editModeEnabled && (
+          <GridIcon
+            active={snapToGrid}
+            onClick={() => setSnapToGrid(!snapToGrid)}
+          />
+        )}
+        <ViewMenu
+          circuitJson={circuitJson}
+          circuitJsonKey={circuitJsonKey}
+          isVisible={showViewMenu}
+          onClose={() => setShowViewMenu(false)}
+          showGroups={showSchematicGroups}
+          onToggleGroups={(value) => {
+            if (!disableGroups) {
+              setShowSchematicGroups(value)
+              setStoredBoolean("schematic_viewer_show_groups", value)
+            }
+          }}
+        />
+        {spiceSimulationEnabled && (
+          <SpiceSimulationIcon onClick={() => setShowSpiceOverlay(true)} />
+        )}
+        {showSpiceOverlay && (
+          <SpiceSimulationOverlay
+            spiceString={spiceString}
+            onClose={() => setShowSpiceOverlay(false)}
+            plotData={plotData}
+            nodes={nodes}
+            isLoading={isSpiceSimLoading}
+            error={spiceSimError}
+            simOptions={spiceSimOptions}
+            onSimOptionsChange={(options) => {
+              setHasSpiceSimRun(true)
+              setSpiceSimOptions(options)
+            }}
+            hasRun={hasSpiceSimRun}
+          />
+        )}
+        {onSchematicComponentClicked &&
+          schematicComponentIds.map((componentId) => (
+            <SchematicComponentMouseTarget
+              key={componentId}
+              componentId={componentId}
+              svgDivRef={svgDivRef}
+              containerRef={containerRef}
+              showOutline={true}
+              circuitJsonKey={circuitJsonKey}
+              onComponentClick={(id, event) => {
+                onSchematicComponentClicked?.({
+                  schematicComponentId: id,
+                  event,
+                })
+              }}
+            />
+          ))}
+        {svgDiv}
+      </div>
+    </MouseTracker>
   )
 }

--- a/lib/hooks/useMouseEventsOverBoundingBox.ts
+++ b/lib/hooks/useMouseEventsOverBoundingBox.ts
@@ -1,0 +1,74 @@
+import {
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react"
+import {
+  MouseTrackerContext,
+  type BoundingBoxBounds,
+} from "../components/MouseTracker"
+
+interface UseMouseEventsOverBoundingBoxOptions {
+  bounds: BoundingBoxBounds | null
+  onClick?: (event: MouseEvent) => void
+}
+
+export const useMouseEventsOverBoundingBox = (
+  options: UseMouseEventsOverBoundingBoxOptions,
+) => {
+  const context = useContext(MouseTrackerContext)
+
+  if (!context) {
+    throw new Error(
+      "useMouseEventsOverBoundingBox must be used within a MouseTracker",
+    )
+  }
+
+  const id = useId()
+  const latestOptionsRef = useRef(options)
+  latestOptionsRef.current = options
+
+  const handleClick = useMemo(
+    () => (event: MouseEvent) => {
+      latestOptionsRef.current.onClick?.(event)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    context.registerBoundingBox(id, {
+      bounds: latestOptionsRef.current.bounds,
+      onClick: latestOptionsRef.current.onClick ? handleClick : undefined,
+    })
+    return () => {
+      context.unregisterBoundingBox(id)
+    }
+  }, [context, handleClick, id])
+
+  useEffect(() => {
+    context.updateBoundingBox(id, {
+      bounds: latestOptionsRef.current.bounds,
+      onClick: latestOptionsRef.current.onClick ? handleClick : undefined,
+    })
+  }, [
+    context,
+    handleClick,
+    id,
+    options.bounds?.minX,
+    options.bounds?.maxX,
+    options.bounds?.minY,
+    options.bounds?.maxY,
+    options.onClick,
+  ])
+
+  const hovering = useSyncExternalStore(
+    context.subscribe,
+    () => context.isHovering(id),
+    () => false,
+  )
+
+  return { hovering }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,3 @@
 export { SchematicViewer } from "./components/SchematicViewer"
+export { MouseTracker } from "./components/MouseTracker"
+export { useMouseEventsOverBoundingBox } from "./hooks/useMouseEventsOverBoundingBox"

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -6,4 +6,5 @@ export const zIndexMap = {
   viewMenu: 55,
   viewMenuBackdrop: 54,
   clickToInteractOverlay: 100,
+  schematicComponentHoverOutline: 47,
 }


### PR DESCRIPTION
## Summary
- add a MouseTracker context and useMouseEventsOverBoundingBox hook for registering bounding boxes
- introduce a SchematicComponentMouseTarget overlay that highlights components and reports clicks
- update SchematicViewer to expose an onSchematicComponentClicked prop and render hover outlines when supplied

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d0204698b4832ea08883cf8ecea939