### PR TITLE
add hover color highlighting for schematic traces

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -31,6 +31,7 @@ import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { useTraceHoverHighlighting } from "../hooks/useTraceHoverHighlighting"
 
 interface Props {
   circuitJson: CircuitJson
@@ -166,6 +167,8 @@ export const SchematicViewer = ({
 
   const svgDivRef = useRef<HTMLDivElement>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+
+  useTraceHoverHighlighting({ svgDivRef, circuitJsonKey })
 
   const schematicComponentIds = useMemo(() => {
     try {
@@ -399,6 +402,17 @@ export const SchematicViewer = ({
           {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
         </style>
       )}
+      <style>{`
+        g[data-schematic-trace-id].trace-hover path:not(.trace-invisible-hover-outline):not(.trace-crossing-outline) {
+          stroke: #3399ff !important;
+        }
+        g[data-schematic-trace-id].trace-hover circle.trace-junction {
+          fill: #3399ff !important;
+        }
+        g[data-schematic-trace-id] {
+          cursor: crosshair;
+        }
+      `}</style>
       <div
         ref={containerRef}
         style={{

--- a/lib/hooks/useTraceHoverHighlighting.ts
+++ b/lib/hooks/useTraceHoverHighlighting.ts
@@ -1,0 +1,95 @@
+import { useEffect } from "react"
+
+/**
+ * Adds hover highlighting to schematic traces.
+ *
+ * Traces are rendered as two sibling <g> elements (base layer and overlay
+ * layer) both sharing the same `data-schematic-trace-id`. A CSS :hover on
+ * one group won't affect the other, so we use JS to add/remove a
+ * `trace-hover` class on *all* groups that share the same trace id whenever
+ * the pointer enters or leaves any of them.
+ *
+ * A MutationObserver watches for SVG re-renders (e.g. on resize) and
+ * re-attaches listeners automatically.
+ */
+export function useTraceHoverHighlighting({
+  svgDivRef,
+  circuitJsonKey,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJsonKey: string
+}) {
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv) return
+
+    let cleanupListeners: (() => void) | null = null
+
+    function attachListeners() {
+      if (!svgDiv) return
+      if (cleanupListeners) cleanupListeners()
+
+      const handlers: Array<{
+        el: SVGGElement
+        enter: () => void
+        leave: () => void
+      }> = []
+
+      const groups = svgDiv.querySelectorAll<SVGGElement>(
+        "g[data-schematic-trace-id]",
+      )
+
+      for (const group of groups) {
+        const traceId = group.getAttribute("data-schematic-trace-id")
+        if (!traceId) continue
+
+        const handleEnter = () => {
+          const siblings = svgDiv!.querySelectorAll<SVGGElement>(
+            `g[data-schematic-trace-id="${traceId}"]`,
+          )
+          for (const sibling of siblings) {
+            sibling.classList.add("trace-hover")
+          }
+        }
+
+        const handleLeave = () => {
+          const siblings = svgDiv!.querySelectorAll<SVGGElement>(
+            `g[data-schematic-trace-id="${traceId}"]`,
+          )
+          for (const sibling of siblings) {
+            sibling.classList.remove("trace-hover")
+          }
+        }
+
+        group.addEventListener("mouseenter", handleEnter)
+        group.addEventListener("mouseleave", handleLeave)
+        handlers.push({ el: group, enter: handleEnter, leave: handleLeave })
+      }
+
+      cleanupListeners = () => {
+        for (const { el, enter, leave } of handlers) {
+          el.removeEventListener("mouseenter", enter)
+          el.removeEventListener("mouseleave", leave)
+        }
+      }
+    }
+
+    // Initial attach
+    attachListeners()
+
+    // Re-attach whenever the SVG is re-rendered (e.g. on window resize)
+    const observer =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(() => {
+            attachListeners()
+          })
+        : null
+
+    observer?.observe(svgDiv, { childList: true, subtree: false })
+
+    return () => {
+      observer?.disconnect()
+      cleanupListeners?.()
+    }
+  }, [svgDivRef, circuitJsonKey])
+}


### PR DESCRIPTION
Fixes tscircuit/tscircuit#1130

Hovering over a schematic trace now changes its stroke color to `#3399ff` and highlights junction dots to match.

## How it works
- New hook `useTraceHoverHighlighting` attaches `mouseenter`/`mouseleave` listeners to every `g[data-schematic-trace-id]` element in the SVG
- On hover, adds the `trace-hover` CSS class to **both** the base and overlay `<g>` groups that share the same `data-schematic-trace-id`
- CSS `.trace-hover` rule changes the stroke color and junction fill to `#3399ff`
- A `MutationObserver` re-attaches listeners after every SVG re-render (e.g. window resize)

## Changes
- `lib/hooks/useTraceHoverHighlighting.ts` — new hook (80 lines)
- `lib/components/SchematicViewer.tsx` — import hook + add CSS style tag