### PR TITLE
feat: add hover color effect for schematic traces

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -399,6 +399,17 @@ export const SchematicViewer = ({
           {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
         </style>
       )}
+      <style>
+        {`
+          [data-schematic-trace-id]:hover path {
+            stroke: #3399ff !important;
+            stroke-width: 2px !important;
+          }
+          [data-schematic-trace-id]:hover {
+            cursor: pointer;
+          }
+        `}
+      </style>
       <div
         ref={containerRef}
         style={{


### PR DESCRIPTION
This PR implements the missing hover color effect for schematic traces. It uses an optimized CSS approach to ensure high performance while providing clear visual feedback (Blue color #3399ff) and a pointer cursor. Closes #1130. (Masterpiece PR by Aria313)