### PR TITLE
Fix schematic port rendering when showSchematicPorts is enabled

### DIFF
--- a/examples/example20-symbol-refdef.fixture.tsx
+++ b/examples/example20-symbol-refdef.fixture.tsx
@@ -85,6 +85,10 @@ export default () => {
     <SchematicViewer
       circuitJson={circuitJson}
       containerStyle={{ height: "100%" }}
+      showSchematicPorts
+      onSchematicPortClicked={({ schematicPortId }) => {
+        console.log("Port clicked:", schematicPortId)
+      }}
     />
   )
 }

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -265,6 +265,7 @@ export const SchematicViewer = ({
     return convertCircuitJsonToSchematicSvg(circuitJson as any, {
       width: containerWidth,
       height: containerHeight || 720,
+      drawPorts: showSchematicPorts,
       grid: !showGrid
         ? undefined
         : {
@@ -273,7 +274,13 @@ export const SchematicViewer = ({
           },
       colorOverrides,
     })
-  }, [circuitJsonKey, containerWidth, containerHeight, showGrid])
+  }, [
+    circuitJsonKey,
+    containerWidth,
+    containerHeight,
+    showGrid,
+    showSchematicPorts,
+  ])
 
   const containerBackgroundColor = useMemo(() => {
     const match = svgString.match(

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -70,7 +70,7 @@ export const SchematicViewer = ({
   spiceSimulationEnabled = false,
   disableGroups = false,
   onSchematicComponentClicked,
-  showSchematicPorts = false,
+  showSchematicPorts = true,
   onSchematicPortClicked,
 }: Props) => {
   if (debug) {

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -70,7 +70,7 @@ export const SchematicViewer = ({
   spiceSimulationEnabled = false,
   disableGroups = false,
   onSchematicComponentClicked,
-  showSchematicPorts = true,
+  showSchematicPorts = false,
   onSchematicPortClicked,
 }: Props) => {
   if (debug) {


### PR DESCRIPTION
Before: 

<img width="821" height="683" alt="image" src="https://github.com/user-attachments/assets/cdadab07-c035-41e5-9414-98c38bf87a62" />


After: 

<img width="818" height="603" alt="image" src="https://github.com/user-attachments/assets/82685316-5bb9-4fbd-9b2c-33c0b343b39a" />

REF Kicad Image,

<img width="207" height="195" alt="image" src="https://github.com/user-attachments/assets/376732bb-7dd8-41b2-940d-1f29e9576b23" />

--- 

**Issue**: Schematic ports were not rendering correctly when showSchematicPorts was toggled.  
**Motivation**: The viewer should match drawPorts: true behavior so ports appear in the SVG when enabled.  
**Fix**: Pass showSchematicPorts into convertCircuitJsonToSchematicSvg as drawPorts, ensuring ports render with the toggle.