### PR TITLE
fix: highlight same-net schematic traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -1,11 +1,14 @@
-import {
-  convertCircuitJsonToSchematicSvg,
-  type ColorOverrides,
-} from "circuit-to-svg"
 import { su } from "@tscircuit/soup-util"
+import type { CircuitJson } from "circuit-json"
+import {
+  type ColorOverrides,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
+import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
+import { useTraceNetHoverHighlight } from "lib/hooks/useTraceNetHoverHighlight"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -16,21 +19,19 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import type { ManualEditEvent } from "../types/edit-events"
+import { getSpiceFromCircuitJson } from "../utils/spice-utils"
+import { zIndexMap } from "../utils/z-index-map"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
-import { ViewMenuIcon } from "./ViewMenuIcon"
-import { ViewMenu } from "./ViewMenu"
-import type { CircuitJson } from "circuit-json"
-import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
-import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
-import { zIndexMap } from "../utils/z-index-map"
-import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
-import { getSpiceFromCircuitJson } from "../utils/spice-utils"
-import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
+import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
+import { ViewMenu } from "./ViewMenu"
+import { ViewMenuIcon } from "./ViewMenuIcon"
 
 interface Props {
   circuitJson: CircuitJson
@@ -343,6 +344,11 @@ export const SchematicViewer = ({
     circuitJson,
     activeEditEvent,
     editEvents: editEventsWithUnappliedEditEvents,
+  })
+
+  useTraceNetHoverHighlight({
+    svgDivRef,
+    circuitJson,
   })
 
   // Add group overlays when enabled

--- a/lib/hooks/useTraceNetHoverHighlight.ts
+++ b/lib/hooks/useTraceNetHoverHighlight.ts
@@ -1,0 +1,145 @@
+import type { CircuitJson } from "circuit-json"
+import { useEffect, useMemo, useRef } from "react"
+
+const HOVER_STROKE = "#ffb700"
+
+const getCircuitJsonHash = (circuitJson: CircuitJson) => {
+  return `${circuitJson?.length || 0}_${(circuitJson as any)?.editCount || 0}`
+}
+
+/**
+ * Highlight every visible schematic trace segment that belongs to the same
+ * source trace/net as the hovered segment.
+ */
+export const useTraceNetHoverHighlight = ({
+  svgDivRef,
+  circuitJson,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+}) => {
+  const originalStrokeByPathRef = useRef<
+    WeakMap<SVGPathElement, string | null>
+  >(new WeakMap())
+  const activeSourceTraceIdRef = useRef<string | null>(null)
+  const circuitJsonHash = useMemo(
+    () => getCircuitJsonHash(circuitJson),
+    [circuitJson],
+  )
+
+  useEffect(() => {
+    const svg = svgDivRef.current
+    if (!svg) return
+
+    const schematicTraceIdToSourceTraceId = new Map<string, string>()
+    const sourceTraceIdToSchematicTraceIds = new Map<string, Set<string>>()
+
+    for (const elm of circuitJson as any[]) {
+      if (elm?.type !== "schematic_trace") continue
+      const schematicTraceId = elm.schematic_trace_id
+      const sourceTraceId = elm.source_trace_id
+      if (!schematicTraceId || !sourceTraceId) continue
+
+      schematicTraceIdToSourceTraceId.set(schematicTraceId, sourceTraceId)
+      const schematicTraceIds =
+        sourceTraceIdToSchematicTraceIds.get(sourceTraceId) ?? new Set<string>()
+      schematicTraceIds.add(schematicTraceId)
+      sourceTraceIdToSchematicTraceIds.set(sourceTraceId, schematicTraceIds)
+    }
+
+    const getTraceContainer = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) return null
+      return target.closest<SVGElement>("[data-schematic-trace-id]")
+    }
+
+    const getSourceTraceIdForTarget = (target: EventTarget | null) => {
+      const traceContainer = getTraceContainer(target)
+      const schematicTraceId = traceContainer?.getAttribute(
+        "data-schematic-trace-id",
+      )
+      if (!schematicTraceId) return null
+      return schematicTraceIdToSourceTraceId.get(schematicTraceId) ?? null
+    }
+
+    const forEachPathInSourceTrace = (
+      sourceTraceId: string,
+      callback: (path: SVGPathElement) => void,
+    ) => {
+      const schematicTraceIds =
+        sourceTraceIdToSchematicTraceIds.get(sourceTraceId)
+      if (!schematicTraceIds) return
+
+      for (const traceElement of Array.from(
+        svg.querySelectorAll<SVGElement>("[data-schematic-trace-id]"),
+      )) {
+        const schematicTraceId = traceElement.getAttribute(
+          "data-schematic-trace-id",
+        )
+        if (!schematicTraceId || !schematicTraceIds.has(schematicTraceId)) {
+          continue
+        }
+
+        for (const path of Array.from(
+          traceElement.querySelectorAll<SVGPathElement>("path"),
+        )) {
+          if (path.getAttribute("class")?.includes("invisible")) continue
+          callback(path)
+        }
+      }
+    }
+
+    const clearHighlight = () => {
+      const sourceTraceId = activeSourceTraceIdRef.current
+      if (!sourceTraceId) return
+
+      forEachPathInSourceTrace(sourceTraceId, (path) => {
+        const originalStroke = originalStrokeByPathRef.current.get(path)
+        if (originalStroke === null) {
+          path.removeAttribute("stroke")
+        } else if (originalStroke !== undefined) {
+          path.setAttribute("stroke", originalStroke)
+        }
+      })
+
+      activeSourceTraceIdRef.current = null
+    }
+
+    const applyHighlight = (sourceTraceId: string) => {
+      if (activeSourceTraceIdRef.current === sourceTraceId) return
+      clearHighlight()
+      activeSourceTraceIdRef.current = sourceTraceId
+
+      forEachPathInSourceTrace(sourceTraceId, (path) => {
+        if (!originalStrokeByPathRef.current.has(path)) {
+          originalStrokeByPathRef.current.set(path, path.getAttribute("stroke"))
+        }
+        path.setAttribute("stroke", HOVER_STROKE)
+      })
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const sourceTraceId = getSourceTraceIdForTarget(event.target)
+      if (!sourceTraceId) return
+      applyHighlight(sourceTraceId)
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const sourceTraceId = getSourceTraceIdForTarget(event.target)
+      if (!sourceTraceId) return
+
+      const nextSourceTraceId = getSourceTraceIdForTarget(event.relatedTarget)
+      if (nextSourceTraceId === sourceTraceId) return
+
+      clearHighlight()
+    }
+
+    svg.addEventListener("mouseover", handleMouseOver)
+    svg.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      svg.removeEventListener("mouseover", handleMouseOver)
+      svg.removeEventListener("mouseout", handleMouseOut)
+      clearHighlight()
+    }
+  }, [svgDivRef, circuitJsonHash, circuitJson])
+}


### PR DESCRIPTION
/claim https://github.com/tscircuit/tscircuit/issues/1130
/fixes https://github.com/tscircuit/tscircuit/issues/1130

## Summary

Fixes same-net schematic trace hover highlighting for tscircuit/tscircuit#1130.

- Adds `useTraceNetHoverHighlight` to map rendered schematic trace DOM nodes back to their `source_trace_id`.
- Highlights every visible SVG path whose schematic trace shares the hovered trace's source trace/net.
- Restores each path's original stroke on mouseout and keeps highlight active when moving between segments in the same net.
- Wires the hook into `SchematicViewer`.

## Test Plan

- [x] `npm_config_userconfig=/dev/null npx tsc --noEmit`
- [x] `git diff --check`

## Bounty / issue

Refs tscircuit/tscircuit#1130

Algora board listed this issue as a $25 open bounty at time of work. Please confirm bounty eligibility/claim requirements.