### PR TITLE
feat: highlight same-net schematic traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -16,6 +16,7 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useHighlightSchematicTracesOnHover } from "../hooks/useHighlightSchematicTracesOnHover"
 import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
@@ -343,6 +344,11 @@ export const SchematicViewer = ({
     circuitJson,
     activeEditEvent,
     editEvents: editEventsWithUnappliedEditEvents,
+  })
+
+  useHighlightSchematicTracesOnHover({
+    svgDivRef,
+    circuitJson,
   })
 
   // Add group overlays when enabled

--- a/lib/hooks/useHighlightSchematicTracesOnHover.ts
+++ b/lib/hooks/useHighlightSchematicTracesOnHover.ts
@@ -1,0 +1,182 @@
+import { su } from "@tscircuit/soup-util"
+import type { CircuitJson } from "circuit-json"
+import { useEffect, useMemo } from "react"
+
+interface UseHighlightSchematicTracesOnHoverOptions {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+}
+
+export const useHighlightSchematicTracesOnHover = ({
+  svgDivRef,
+  circuitJson,
+}: UseHighlightSchematicTracesOnHoverOptions) => {
+  const relatedTraceIdsBySchematicTraceId = useMemo(() => {
+    try {
+      const schematicTraces = su(circuitJson).schematic_trace?.list() ?? []
+      const sourceTraces = su(circuitJson).source_trace?.list() ?? []
+
+      const sourceTraceById = new Map(
+        sourceTraces.map((sourceTrace) => [
+          sourceTrace.source_trace_id,
+          sourceTrace,
+        ]),
+      )
+
+      const schematicTraceIdsByNetId = new Map<string, Set<string>>()
+
+      for (const schematicTrace of schematicTraces) {
+        if (!schematicTrace.source_trace_id) continue
+
+        const sourceTrace = sourceTraceById.get(schematicTrace.source_trace_id)
+        const netIds = sourceTrace?.connected_source_net_ids ?? []
+
+        if (netIds.length === 0) continue
+
+        for (const netId of netIds) {
+          if (!schematicTraceIdsByNetId.has(netId)) {
+            schematicTraceIdsByNetId.set(netId, new Set())
+          }
+          schematicTraceIdsByNetId
+            .get(netId)!
+            .add(schematicTrace.schematic_trace_id)
+        }
+      }
+
+      const relatedTraceIds = new Map<string, string[]>()
+
+      for (const schematicTrace of schematicTraces) {
+        if (!schematicTrace.source_trace_id) continue
+
+        const sourceTrace = sourceTraceById.get(schematicTrace.source_trace_id)
+        const netIds = sourceTrace?.connected_source_net_ids ?? []
+
+        if (netIds.length === 0) continue
+
+        const peerTraceIds = new Set<string>()
+
+        for (const netId of netIds) {
+          for (const peerTraceId of schematicTraceIdsByNetId.get(netId) ?? []) {
+            peerTraceIds.add(peerTraceId)
+          }
+        }
+
+        if (peerTraceIds.size > 0) {
+          relatedTraceIds.set(
+            schematicTrace.schematic_trace_id,
+            Array.from(peerTraceIds),
+          )
+        }
+      }
+
+      return relatedTraceIds
+    } catch (error) {
+      console.error("Failed to derive same-net schematic trace groups", error)
+      return new Map<string, string[]>()
+    }
+  }, [circuitJson])
+
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv || relatedTraceIdsBySchematicTraceId.size === 0) return
+
+    let activeTraceIds: string[] = []
+    let activeSchematicTraceId: string | null = null
+
+    const getTraceGroupById = (traceId: string) => {
+      const escapedTraceId =
+        typeof CSS !== "undefined" && typeof CSS.escape === "function"
+          ? CSS.escape(traceId)
+          : traceId
+
+      return svgDiv.querySelector<HTMLElement>(
+        `[data-schematic-trace-id="${escapedTraceId}"]`,
+      )
+    }
+
+    const clearActiveHighlight = () => {
+      for (const traceId of activeTraceIds) {
+        const traceGroup = getTraceGroupById(traceId)
+        if (traceGroup) {
+          traceGroup.style.filter = ""
+        }
+      }
+      activeTraceIds = []
+      activeSchematicTraceId = null
+    }
+
+    const getTraceGroup = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) return null
+      return target.closest<HTMLElement>(
+        '[data-circuit-json-type="schematic_trace"]',
+      )
+    }
+
+    const setActiveHighlight = (schematicTraceId: string | null) => {
+      if (!schematicTraceId) {
+        clearActiveHighlight()
+        return
+      }
+
+      if (activeSchematicTraceId === schematicTraceId) return
+
+      clearActiveHighlight()
+
+      const relatedTraceIds =
+        relatedTraceIdsBySchematicTraceId.get(schematicTraceId)
+      if (!relatedTraceIds) return
+
+      for (const traceId of relatedTraceIds) {
+        const traceGroup = getTraceGroupById(traceId)
+        if (traceGroup) {
+          traceGroup.style.filter = "invert(1)"
+        }
+      }
+
+      activeTraceIds = relatedTraceIds
+      activeSchematicTraceId = schematicTraceId
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const traceGroup = getTraceGroup(event.target)
+      if (!traceGroup) return
+
+      const schematicTraceId = traceGroup.getAttribute(
+        "data-schematic-trace-id",
+      )
+      if (!schematicTraceId) return
+
+      if (!relatedTraceIdsBySchematicTraceId.has(schematicTraceId)) return
+
+      setActiveHighlight(schematicTraceId)
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const traceGroup = getTraceGroup(event.target)
+      if (!traceGroup) return
+
+      const nextTraceGroup = getTraceGroup(event.relatedTarget)
+      const nextSchematicTraceId =
+        nextTraceGroup?.getAttribute("data-schematic-trace-id") ?? null
+
+      if (
+        nextSchematicTraceId &&
+        relatedTraceIdsBySchematicTraceId.has(nextSchematicTraceId)
+      ) {
+        setActiveHighlight(nextSchematicTraceId)
+        return
+      }
+
+      clearActiveHighlight()
+    }
+
+    svgDiv.addEventListener("mouseover", handleMouseOver)
+    svgDiv.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      clearActiveHighlight()
+      svgDiv.removeEventListener("mouseover", handleMouseOver)
+      svgDiv.removeEventListener("mouseout", handleMouseOut)
+    }
+  }, [relatedTraceIdsBySchematicTraceId, svgDivRef])
+}


### PR DESCRIPTION
Fixes tscircuit/schematic-viewer#149
References tscircuit/tscircuit#1130

## Summary

Add net-level hover highlighting for schematic traces in `@tscircuit/schematic-viewer`.

Before this change, only the directly hovered trace got the SVG's existing hover treatment. With this change, hovering a schematic trace highlights all rendered schematic traces that belong to the same logical net.

## Implementation

* Added a small hook: `useHighlightSchematicTracesOnHover`
* The hook derives same-net groups from `circuitJson` using:

  * `schematic_trace.source_trace_id`
  * `source_trace.connected_source_net_ids`
* Grouping is based on `connected_source_net_ids`, not only `source_trace_id`
* Highlighting is applied only within the current rendered SVG container
* Fallback remains conservative:

  * if a `schematic_trace` has no `source_trace_id`, no extra grouping is applied
  * if a `source_trace` has no `connected_source_net_ids`, no extra grouping is applied

## Checks run

* `bun install`
* `bunx tsc --noEmit`
* `bun run format:check`
* `bun run build`

All checks passed locally.
