### PR TITLE
Highlight connected schematic traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -1,10 +1,13 @@
-import {
-  convertCircuitJsonToSchematicSvg,
-  type ColorOverrides,
-} from "circuit-to-svg"
 import { su } from "@tscircuit/soup-util"
+import type { CircuitJson } from "circuit-json"
+import {
+  type ColorOverrides,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
+import { useHighlightConnectedTracesOnHover } from "lib/hooks/use-highlight-connected-traces-on-hover"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
+import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -16,21 +19,19 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import type { ManualEditEvent } from "../types/edit-events"
+import { getSpiceFromCircuitJson } from "../utils/spice-utils"
+import { zIndexMap } from "../utils/z-index-map"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
-import { ViewMenuIcon } from "./ViewMenuIcon"
-import { ViewMenu } from "./ViewMenu"
-import type { CircuitJson } from "circuit-json"
-import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
-import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
-import { zIndexMap } from "../utils/z-index-map"
-import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
-import { getSpiceFromCircuitJson } from "../utils/spice-utils"
-import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
+import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
+import { ViewMenu } from "./ViewMenu"
+import { ViewMenuIcon } from "./ViewMenuIcon"
 
 interface Props {
   circuitJson: CircuitJson
@@ -345,6 +346,13 @@ export const SchematicViewer = ({
     editEvents: editEventsWithUnappliedEditEvents,
   })
 
+  useHighlightConnectedTracesOnHover({
+    svgDivRef,
+    circuitJson,
+    circuitJsonKey,
+    enabled: !editModeEnabled,
+  })
+
   // Add group overlays when enabled
   useSchematicGroupsOverlay({
     svgDivRef,
@@ -398,12 +406,14 @@ export const SchematicViewer = ({
     <MouseTracker>
       {onSchematicComponentClicked && (
         <style>
-          {`.schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }`}
+          {
+            ".schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }"
+          }
         </style>
       )}
       {onSchematicPortClicked && (
         <style>
-          {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
+          {"[data-schematic-port-id]:hover { cursor: pointer !important; }"}
         </style>
       )}
       <div

--- a/lib/hooks/use-highlight-connected-traces-on-hover.ts
+++ b/lib/hooks/use-highlight-connected-traces-on-hover.ts
@@ -1,0 +1,128 @@
+import { useEffect, useMemo } from "react"
+import type { CircuitJson } from "circuit-json"
+import { getConnectedSchematicTraceIdsByTraceId } from "lib/utils/get-connected-schematic-trace-ids"
+
+const highlightClassName = "schematic-connected-trace-hover"
+
+const escapeAttributeValue = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+
+const getTraceElement = (element: EventTarget | null): Element | null => {
+  if (!(element instanceof Element)) return null
+
+  return element.closest(
+    '[data-circuit-json-type="schematic_trace"][data-schematic-trace-id]',
+  )
+}
+
+const getTraceId = (element: Element | null): string | null =>
+  element?.getAttribute("data-schematic-trace-id") ?? null
+
+const ensureHighlightStyle = (svgDiv: HTMLDivElement) => {
+  const existingStyle = svgDiv.querySelector(
+    "style#schematic-connected-trace-hover-style",
+  )
+  if (existingStyle) return null
+
+  const style = document.createElement("style")
+  style.id = "schematic-connected-trace-hover-style"
+  style.textContent = `
+    [data-circuit-json-type="schematic_trace"].${highlightClassName} {
+      filter: none !important;
+    }
+
+    [data-circuit-json-type="schematic_trace"].${highlightClassName} path:not(.trace-invisible-hover-outline) {
+      filter: drop-shadow(0 0 3px rgba(255, 107, 53, 0.55));
+      stroke: #ff6b35 !important;
+      transition: filter 120ms ease, stroke 120ms ease, stroke-width 120ms ease;
+    }
+
+    [data-circuit-json-type="schematic_trace"] {
+      cursor: pointer;
+    }
+  `
+  svgDiv.appendChild(style)
+
+  return style
+}
+
+export const useHighlightConnectedTracesOnHover = ({
+  svgDivRef,
+  circuitJson,
+  circuitJsonKey,
+  enabled,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+  circuitJsonKey: string
+  enabled: boolean
+}) => {
+  const connectedTraceIdsByTraceId = useMemo(
+    () => getConnectedSchematicTraceIdsByTraceId(circuitJson),
+    [circuitJson, circuitJsonKey],
+  )
+
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv) return
+
+    const clearHighlights = () => {
+      for (const trace of Array.from(
+        svgDiv.querySelectorAll(`.${highlightClassName}`),
+      )) {
+        trace.classList.remove(highlightClassName)
+      }
+    }
+
+    if (!enabled) {
+      clearHighlights()
+      return
+    }
+
+    const style = ensureHighlightStyle(svgDiv)
+    let activeTraceIds = new Set<string>()
+
+    const highlightConnectedTraces = (traceId: string) => {
+      const nextTraceIds =
+        connectedTraceIdsByTraceId.get(traceId) ?? new Set([traceId])
+
+      clearHighlights()
+      activeTraceIds = nextTraceIds
+
+      for (const connectedTraceId of nextTraceIds) {
+        const trace = svgDiv.querySelector(
+          `[data-schematic-trace-id="${escapeAttributeValue(
+            connectedTraceId,
+          )}"]`,
+        )
+        trace?.classList.add(highlightClassName)
+      }
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const traceId = getTraceId(getTraceElement(event.target))
+      if (!traceId) return
+
+      highlightConnectedTraces(traceId)
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const nextTraceId = getTraceId(getTraceElement(event.relatedTarget))
+      if (nextTraceId && activeTraceIds.has(nextTraceId)) return
+
+      activeTraceIds = new Set()
+      clearHighlights()
+    }
+
+    svgDiv.addEventListener("mouseover", handleMouseOver)
+    svgDiv.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      svgDiv.removeEventListener("mouseover", handleMouseOver)
+      svgDiv.removeEventListener("mouseout", handleMouseOut)
+      activeTraceIds = new Set()
+      clearHighlights()
+      style?.remove()
+    }
+  }, [svgDivRef, connectedTraceIdsByTraceId, enabled])
+}

--- a/lib/utils/get-connected-schematic-trace-ids.ts
+++ b/lib/utils/get-connected-schematic-trace-ids.ts
@@ -1,0 +1,153 @@
+import type { CircuitJson } from "circuit-json"
+
+type CircuitElement = CircuitJson[number] & Record<string, unknown>
+
+const getStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+const getElementId = (element: CircuitElement, key: string): string | null => {
+  const value = element[key]
+  return typeof value === "string" ? value : null
+}
+
+const getSourceTraceConnectivityKeys = (sourceTrace: CircuitElement) => [
+  ...getStringList(sourceTrace.connected_source_port_ids).map(
+    (portId) => `port:${portId}`,
+  ),
+  ...getStringList(sourceTrace.connected_source_net_ids).map(
+    (netId) => `net:${netId}`,
+  ),
+]
+
+export const getConnectedSchematicTraceIdsByTraceId = (
+  circuitJson: CircuitJson,
+): Map<string, Set<string>> => {
+  const schematicTraces = circuitJson.filter(
+    (element): element is CircuitElement =>
+      (element as CircuitElement).type === "schematic_trace",
+  )
+  const sourceTraces = circuitJson.filter(
+    (element): element is CircuitElement =>
+      (element as CircuitElement).type === "source_trace",
+  )
+
+  const sourceTraceById = new Map<string, CircuitElement>()
+  const connectivityKeysBySourceTraceId = new Map<string, string[]>()
+  const sourceTraceIdsByConnectivityKey = new Map<string, Set<string>>()
+  const schematicTraceIdsBySourceTraceId = new Map<string, Set<string>>()
+  const connectedIdsBySchematicTraceId = new Map<string, Set<string>>()
+
+  for (const sourceTrace of sourceTraces) {
+    const sourceTraceId = getElementId(sourceTrace, "source_trace_id")
+    if (!sourceTraceId) continue
+
+    sourceTraceById.set(sourceTraceId, sourceTrace)
+
+    const connectivityKeys = getSourceTraceConnectivityKeys(sourceTrace)
+    connectivityKeysBySourceTraceId.set(sourceTraceId, connectivityKeys)
+
+    for (const key of connectivityKeys) {
+      const traceIds =
+        sourceTraceIdsByConnectivityKey.get(key) ?? new Set<string>()
+      traceIds.add(sourceTraceId)
+      sourceTraceIdsByConnectivityKey.set(key, traceIds)
+    }
+  }
+
+  for (const schematicTrace of schematicTraces) {
+    const schematicTraceId = getElementId(schematicTrace, "schematic_trace_id")
+    const sourceTraceId = getElementId(schematicTrace, "source_trace_id")
+
+    if (!schematicTraceId) continue
+
+    if (!sourceTraceId) {
+      connectedIdsBySchematicTraceId.set(
+        schematicTraceId,
+        new Set([schematicTraceId]),
+      )
+      continue
+    }
+
+    const traceIds =
+      schematicTraceIdsBySourceTraceId.get(sourceTraceId) ?? new Set<string>()
+    traceIds.add(schematicTraceId)
+    schematicTraceIdsBySourceTraceId.set(sourceTraceId, traceIds)
+  }
+
+  const visitedSourceTraceIds = new Set<string>()
+
+  for (const sourceTraceId of sourceTraceById.keys()) {
+    if (visitedSourceTraceIds.has(sourceTraceId)) continue
+
+    const connectedSourceTraceIds = new Set<string>()
+    const sourceTraceIdsToVisit = [sourceTraceId]
+
+    while (sourceTraceIdsToVisit.length > 0) {
+      const currentSourceTraceId = sourceTraceIdsToVisit.pop()
+      if (
+        !currentSourceTraceId ||
+        visitedSourceTraceIds.has(currentSourceTraceId)
+      ) {
+        continue
+      }
+
+      visitedSourceTraceIds.add(currentSourceTraceId)
+      connectedSourceTraceIds.add(currentSourceTraceId)
+
+      const connectivityKeys =
+        connectivityKeysBySourceTraceId.get(currentSourceTraceId) ?? []
+
+      for (const key of connectivityKeys) {
+        const nextSourceTraceIds = sourceTraceIdsByConnectivityKey.get(key)
+        if (!nextSourceTraceIds) continue
+
+        for (const nextSourceTraceId of nextSourceTraceIds) {
+          if (!visitedSourceTraceIds.has(nextSourceTraceId)) {
+            sourceTraceIdsToVisit.push(nextSourceTraceId)
+          }
+        }
+      }
+    }
+
+    const connectedSchematicTraceIds = new Set<string>()
+
+    for (const connectedSourceTraceId of connectedSourceTraceIds) {
+      const schematicTraceIds =
+        schematicTraceIdsBySourceTraceId.get(connectedSourceTraceId) ??
+        new Set<string>()
+
+      for (const schematicTraceId of schematicTraceIds) {
+        connectedSchematicTraceIds.add(schematicTraceId)
+      }
+    }
+
+    for (const connectedSourceTraceId of connectedSourceTraceIds) {
+      const schematicTraceIds =
+        schematicTraceIdsBySourceTraceId.get(connectedSourceTraceId) ??
+        new Set<string>()
+
+      for (const schematicTraceId of schematicTraceIds) {
+        connectedIdsBySchematicTraceId.set(
+          schematicTraceId,
+          connectedSchematicTraceIds,
+        )
+      }
+    }
+  }
+
+  for (const schematicTrace of schematicTraces) {
+    const schematicTraceId = getElementId(schematicTrace, "schematic_trace_id")
+
+    if (!schematicTraceId) continue
+    if (!connectedIdsBySchematicTraceId.has(schematicTraceId)) {
+      connectedIdsBySchematicTraceId.set(
+        schematicTraceId,
+        new Set([schematicTraceId]),
+      )
+    }
+  }
+
+  return connectedIdsBySchematicTraceId
+}


### PR DESCRIPTION
Fixes tscircuit/tscircuit#1130
Closes #149

## Summary

- Adds hover highlighting for schematic traces connected to the hovered trace.
- Groups connected traces using both `connected_source_port_ids` and `connected_source_net_ids`.
- Walks connectivity transitively so multi-segment nets and traces connected through shared ports highlight together.
- Disables trace-hover highlighting while edit mode is active to avoid conflicting with drag/edit trace styling.

## Verification

- `npm exec -- biome lint lib/components/SchematicViewer.tsx lib/hooks/use-highlight-connected-traces-on-hover.ts lib/utils/get-connected-schematic-trace-ids.ts`
- `npm exec --package typescript@5.8.3 -- tsc --noEmit`
- Functional connected-trace grouping check returned `{"sch1":["sch1","sch2"],"sch3":["sch3","sch4"]}`
