### PR TITLE
Highlight connected schematic traces on hover

### DIFF
--- a/examples/example21-same-net-trace-hover.fixture.tsx
+++ b/examples/example21-same-net-trace-hover.fixture.tsx
@@ -1,0 +1,24 @@
+import { SchematicViewer } from "lib/components/SchematicViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+export default () => (
+  <SchematicViewer
+    circuitJson={renderToCircuitJson(
+      <board width="16mm" height="10mm">
+        <resistor name="R1" resistance="1k" schX={-5} schY={2} />
+        <resistor name="R2" resistance="10k" schX={0} schY={2} />
+        <capacitor name="C1" capacitance="1uF" schX={5} schY={2} />
+        <resistor name="R3" resistance="4.7k" schX={-2} schY={-2} />
+        <capacitor name="C2" capacitance="100nF" schX={4} schY={-2} />
+
+        <trace from=".R1 > .pin2" to="net.SIGNAL" />
+        <trace from=".R2 > .pin1" to="net.SIGNAL" />
+        <trace from=".C1 > .pin1" to="net.SIGNAL" />
+        <trace from=".R3 > .pin1" to="net.GND" />
+        <trace from=".C2 > .pin2" to="net.GND" />
+      </board>,
+    )}
+    containerStyle={{ height: "100%" }}
+    debugGrid
+  />
+)

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -6,6 +6,7 @@ import { su } from "@tscircuit/soup-util"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
+import { useHighlightConnectedSchematicTraces } from "lib/hooks/useHighlightConnectedSchematicTraces"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -345,6 +346,12 @@ export const SchematicViewer = ({
     editEvents: editEventsWithUnappliedEditEvents,
   })
 
+  useHighlightConnectedSchematicTraces({
+    svgDivRef,
+    circuitJson,
+    circuitJsonKey,
+  })
+
   // Add group overlays when enabled
   useSchematicGroupsOverlay({
     svgDivRef,
@@ -406,6 +413,10 @@ export const SchematicViewer = ({
           {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
         </style>
       )}
+      <style>
+        {`.schematic-trace-hovered { filter: invert(1); }
+          .schematic-trace-hovered .trace-crossing-outline { opacity: 0; }`}
+      </style>
       <div
         ref={containerRef}
         style={{

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -6,6 +6,9 @@ const HOVERED_TRACE_CLASS = "schematic-trace-hovered"
 
 type CircuitJsonElement = CircuitJson[number] & Record<string, any>
 
+const cssString = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+
 class UnionFind {
   parent = new Map<string, string>()
 
@@ -209,10 +212,12 @@ export const useHighlightConnectedSchematicTraces = ({
         schematicTraceIdsByConnectionKey.get(connectionKey) ?? new Set()
 
       for (const connectedSchematicTraceId of schematicTraceIds) {
-        const connectedTrace = svgDiv.querySelector(
-          `[data-schematic-trace-id="${connectedSchematicTraceId}"]`,
+        const connectedTraces = svgDiv.querySelectorAll(
+          `[data-schematic-trace-id="${cssString(connectedSchematicTraceId)}"]`,
         )
-        connectedTrace?.classList.add(HOVERED_TRACE_CLASS)
+        for (const connectedTrace of Array.from(connectedTraces)) {
+          connectedTrace.classList.add(HOVERED_TRACE_CLASS)
+        }
       }
     }
 

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -39,6 +39,97 @@ const addToMapSet = (
   map.set(key, values)
 }
 
+export const getSchematicTraceIdsByConnectionKey = (
+  circuitJson: CircuitJson,
+) => {
+  const idsByConnectionKey = new Map<string, Set<string>>()
+
+  try {
+    const unionFind = new UnionFind()
+    const sourceTraceIdsByNetId = new Map<string, Set<string>>()
+    const sourceTraceIdsByPortId = new Map<string, Set<string>>()
+    const sourceTraceIdBySchematicTraceId = new Map<string, string>()
+    const sourceTraces = su(circuitJson).source_trace.list()
+
+    for (const sourceTrace of sourceTraces) {
+      if (!sourceTrace.source_trace_id) continue
+
+      const sourceTraceId = sourceTrace.source_trace_id
+      unionFind.find(sourceTraceId)
+
+      for (const sourceNetId of sourceTrace.connected_source_net_ids ?? []) {
+        addToMapSet(sourceTraceIdsByNetId, String(sourceNetId), sourceTraceId)
+      }
+
+      for (const sourcePortId of sourceTrace.connected_source_port_ids ?? []) {
+        addToMapSet(sourceTraceIdsByPortId, String(sourcePortId), sourceTraceId)
+      }
+    }
+
+    for (const schematicTrace of su(circuitJson).schematic_trace.list()) {
+      if (
+        !schematicTrace.schematic_trace_id ||
+        !schematicTrace.source_trace_id
+      ) {
+        continue
+      }
+
+      sourceTraceIdBySchematicTraceId.set(
+        schematicTrace.schematic_trace_id,
+        schematicTrace.source_trace_id,
+      )
+      unionFind.find(schematicTrace.source_trace_id)
+    }
+
+    for (const element of circuitJson as CircuitJsonElement[]) {
+      if (element?.type !== "source_net" || !element.source_net_id) continue
+
+      const sourceNetId = String(element.source_net_id)
+
+      for (const sourceTraceId of element.connected_source_trace_ids ?? []) {
+        addToMapSet(sourceTraceIdsByNetId, sourceNetId, String(sourceTraceId))
+      }
+
+      for (const sourcePortId of element.connected_source_port_ids ?? []) {
+        const sourceTraceIds = sourceTraceIdsByPortId.get(String(sourcePortId))
+        if (!sourceTraceIds) continue
+
+        for (const sourceTraceId of sourceTraceIds) {
+          addToMapSet(sourceTraceIdsByNetId, sourceNetId, sourceTraceId)
+        }
+      }
+    }
+
+    for (const connectedTraceIds of [
+      ...sourceTraceIdsByNetId.values(),
+      ...sourceTraceIdsByPortId.values(),
+    ]) {
+      const [firstTraceId, ...restTraceIds] = Array.from(connectedTraceIds)
+      if (!firstTraceId) continue
+
+      for (const sourceTraceId of restTraceIds) {
+        unionFind.union(firstTraceId, sourceTraceId)
+      }
+    }
+
+    for (const [
+      schematicTraceId,
+      sourceTraceId,
+    ] of sourceTraceIdBySchematicTraceId) {
+      const connectionKey = `source-trace-group:${unionFind.find(
+        sourceTraceId,
+      )}`
+      const traceIds = idsByConnectionKey.get(connectionKey) ?? new Set()
+      traceIds.add(schematicTraceId)
+      idsByConnectionKey.set(connectionKey, traceIds)
+    }
+  } catch (err) {
+    console.error("Failed to derive connected schematic trace ids", err)
+  }
+
+  return idsByConnectionKey
+}
+
 export const useHighlightConnectedSchematicTraces = ({
   svgDivRef,
   circuitJson,
@@ -49,99 +140,7 @@ export const useHighlightConnectedSchematicTraces = ({
   circuitJsonKey: string
 }) => {
   const schematicTraceIdsByConnectionKey = useMemo(() => {
-    const idsByConnectionKey = new Map<string, Set<string>>()
-
-    try {
-      const unionFind = new UnionFind()
-      const sourceTraceIdsByNetId = new Map<string, Set<string>>()
-      const sourceTraceIdsByPortId = new Map<string, Set<string>>()
-      const sourceTraceIdBySchematicTraceId = new Map<string, string>()
-      const sourceTraces = su(circuitJson).source_trace.list()
-
-      for (const sourceTrace of sourceTraces) {
-        if (!sourceTrace.source_trace_id) continue
-
-        const sourceTraceId = sourceTrace.source_trace_id
-        unionFind.find(sourceTraceId)
-
-        for (const sourceNetId of sourceTrace.connected_source_net_ids ?? []) {
-          addToMapSet(sourceTraceIdsByNetId, String(sourceNetId), sourceTraceId)
-        }
-
-        for (const sourcePortId of sourceTrace.connected_source_port_ids ??
-          []) {
-          addToMapSet(
-            sourceTraceIdsByPortId,
-            String(sourcePortId),
-            sourceTraceId,
-          )
-        }
-      }
-
-      for (const schematicTrace of su(circuitJson).schematic_trace.list()) {
-        if (
-          !schematicTrace.schematic_trace_id ||
-          !schematicTrace.source_trace_id
-        ) {
-          continue
-        }
-
-        sourceTraceIdBySchematicTraceId.set(
-          schematicTrace.schematic_trace_id,
-          schematicTrace.source_trace_id,
-        )
-        unionFind.find(schematicTrace.source_trace_id)
-      }
-
-      for (const element of circuitJson as CircuitJsonElement[]) {
-        if (element?.type !== "source_net" || !element.source_net_id) continue
-
-        const sourceNetId = String(element.source_net_id)
-
-        for (const sourceTraceId of element.connected_source_trace_ids ?? []) {
-          addToMapSet(sourceTraceIdsByNetId, sourceNetId, String(sourceTraceId))
-        }
-
-        for (const sourcePortId of element.connected_source_port_ids ?? []) {
-          const sourceTraceIds = sourceTraceIdsByPortId.get(
-            String(sourcePortId),
-          )
-          if (!sourceTraceIds) continue
-
-          for (const sourceTraceId of sourceTraceIds) {
-            addToMapSet(sourceTraceIdsByNetId, sourceNetId, sourceTraceId)
-          }
-        }
-      }
-
-      for (const connectedTraceIds of [
-        ...sourceTraceIdsByNetId.values(),
-        ...sourceTraceIdsByPortId.values(),
-      ]) {
-        const [firstTraceId, ...restTraceIds] = Array.from(connectedTraceIds)
-        if (!firstTraceId) continue
-
-        for (const sourceTraceId of restTraceIds) {
-          unionFind.union(firstTraceId, sourceTraceId)
-        }
-      }
-
-      for (const [
-        schematicTraceId,
-        sourceTraceId,
-      ] of sourceTraceIdBySchematicTraceId) {
-        const connectionKey = `source-trace-group:${unionFind.find(
-          sourceTraceId,
-        )}`
-        const traceIds = idsByConnectionKey.get(connectionKey) ?? new Set()
-        traceIds.add(schematicTraceId)
-        idsByConnectionKey.set(connectionKey, traceIds)
-      }
-    } catch (err) {
-      console.error("Failed to derive connected schematic trace ids", err)
-    }
-
-    return idsByConnectionKey
+    return getSchematicTraceIdsByConnectionKey(circuitJson)
   }, [circuitJsonKey, circuitJson])
 
   const connectionKeyBySchematicTraceId = useMemo(() => {

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -4,6 +4,41 @@ import { su } from "@tscircuit/soup-util"
 
 const HOVERED_TRACE_CLASS = "schematic-trace-hovered"
 
+type CircuitJsonElement = CircuitJson[number] & Record<string, any>
+
+class UnionFind {
+  parent = new Map<string, string>()
+
+  find(id: string): string {
+    const parent = this.parent.get(id)
+    if (!parent) {
+      this.parent.set(id, id)
+      return id
+    }
+    if (parent === id) return id
+
+    const root = this.find(parent)
+    this.parent.set(id, root)
+    return root
+  }
+
+  union(a: string, b: string) {
+    const rootA = this.find(a)
+    const rootB = this.find(b)
+    if (rootA !== rootB) this.parent.set(rootB, rootA)
+  }
+}
+
+const addToMapSet = (
+  map: Map<string, Set<string>>,
+  key: string,
+  value: string,
+) => {
+  const values = map.get(key) ?? new Set<string>()
+  values.add(value)
+  map.set(key, values)
+}
+
 export const useHighlightConnectedSchematicTraces = ({
   svgDivRef,
   circuitJson,
@@ -17,11 +52,31 @@ export const useHighlightConnectedSchematicTraces = ({
     const idsByConnectionKey = new Map<string, Set<string>>()
 
     try {
-      const sourceTracesById = new Map(
-        su(circuitJson)
-          .source_trace.list()
-          .map((sourceTrace) => [sourceTrace.source_trace_id, sourceTrace]),
-      )
+      const unionFind = new UnionFind()
+      const sourceTraceIdsByNetId = new Map<string, Set<string>>()
+      const sourceTraceIdsByPortId = new Map<string, Set<string>>()
+      const sourceTraceIdBySchematicTraceId = new Map<string, string>()
+      const sourceTraces = su(circuitJson).source_trace.list()
+
+      for (const sourceTrace of sourceTraces) {
+        if (!sourceTrace.source_trace_id) continue
+
+        const sourceTraceId = sourceTrace.source_trace_id
+        unionFind.find(sourceTraceId)
+
+        for (const sourceNetId of sourceTrace.connected_source_net_ids ?? []) {
+          addToMapSet(sourceTraceIdsByNetId, String(sourceNetId), sourceTraceId)
+        }
+
+        for (const sourcePortId of sourceTrace.connected_source_port_ids ??
+          []) {
+          addToMapSet(
+            sourceTraceIdsByPortId,
+            String(sourcePortId),
+            sourceTraceId,
+          )
+        }
+      }
 
       for (const schematicTrace of su(circuitJson).schematic_trace.list()) {
         if (
@@ -31,15 +86,55 @@ export const useHighlightConnectedSchematicTraces = ({
           continue
         }
 
-        const sourceTrace = sourceTracesById.get(schematicTrace.source_trace_id)
-        const connectedNetIds = sourceTrace?.connected_source_net_ids ?? []
-        const connectionKey =
-          connectedNetIds.length > 0
-            ? `source-net:${[...connectedNetIds].sort().join(",")}`
-            : `source-trace:${schematicTrace.source_trace_id}`
+        sourceTraceIdBySchematicTraceId.set(
+          schematicTrace.schematic_trace_id,
+          schematicTrace.source_trace_id,
+        )
+        unionFind.find(schematicTrace.source_trace_id)
+      }
 
+      for (const element of circuitJson as CircuitJsonElement[]) {
+        if (element?.type !== "source_net" || !element.source_net_id) continue
+
+        const sourceNetId = String(element.source_net_id)
+
+        for (const sourceTraceId of element.connected_source_trace_ids ?? []) {
+          addToMapSet(sourceTraceIdsByNetId, sourceNetId, String(sourceTraceId))
+        }
+
+        for (const sourcePortId of element.connected_source_port_ids ?? []) {
+          const sourceTraceIds = sourceTraceIdsByPortId.get(
+            String(sourcePortId),
+          )
+          if (!sourceTraceIds) continue
+
+          for (const sourceTraceId of sourceTraceIds) {
+            addToMapSet(sourceTraceIdsByNetId, sourceNetId, sourceTraceId)
+          }
+        }
+      }
+
+      for (const connectedTraceIds of [
+        ...sourceTraceIdsByNetId.values(),
+        ...sourceTraceIdsByPortId.values(),
+      ]) {
+        const [firstTraceId, ...restTraceIds] = Array.from(connectedTraceIds)
+        if (!firstTraceId) continue
+
+        for (const sourceTraceId of restTraceIds) {
+          unionFind.union(firstTraceId, sourceTraceId)
+        }
+      }
+
+      for (const [
+        schematicTraceId,
+        sourceTraceId,
+      ] of sourceTraceIdBySchematicTraceId) {
+        const connectionKey = `source-trace-group:${unionFind.find(
+          sourceTraceId,
+        )}`
         const traceIds = idsByConnectionKey.get(connectionKey) ?? new Set()
-        traceIds.add(schematicTrace.schematic_trace_id)
+        traceIds.add(schematicTraceId)
         idsByConnectionKey.set(connectionKey, traceIds)
       }
     } catch (err) {

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -219,12 +219,18 @@ export const useHighlightConnectedSchematicTraces = ({
       clearHoveredTraces()
     }
 
+    const mutationObserver = new MutationObserver(() => {
+      clearHoveredTraces()
+    })
+
     svgDiv.addEventListener("mouseover", handleMouseOver)
     svgDiv.addEventListener("mouseout", handleMouseOut)
+    mutationObserver.observe(svgDiv, { childList: true, subtree: true })
 
     return () => {
       svgDiv.removeEventListener("mouseover", handleMouseOver)
       svgDiv.removeEventListener("mouseout", handleMouseOut)
+      mutationObserver.disconnect()
       clearHoveredTraces()
     }
   }, [

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -39,6 +39,20 @@ const addToMapSet = (
   map.set(key, values)
 }
 
+const getKnownNetKeys = (element: CircuitJsonElement | undefined) => {
+  if (!element) return []
+
+  return [
+    element.subcircuit_connectivity_map_key,
+    element.global_connectivity_map_key,
+    element.global_conn_net_id,
+    element.net_id,
+    element.pcb_net_id,
+  ]
+    .filter(Boolean)
+    .map((value) => `known-net:${String(value)}`)
+}
+
 export const getSchematicTraceIdsByConnectionKey = (
   circuitJson: CircuitJson,
 ) => {
@@ -59,6 +73,10 @@ export const getSchematicTraceIdsByConnectionKey = (
 
       for (const sourceNetId of sourceTrace.connected_source_net_ids ?? []) {
         addToMapSet(sourceTraceIdsByNetId, String(sourceNetId), sourceTraceId)
+      }
+
+      for (const knownNetKey of getKnownNetKeys(sourceTrace)) {
+        addToMapSet(sourceTraceIdsByNetId, knownNetKey, sourceTraceId)
       }
 
       for (const sourcePortId of sourceTrace.connected_source_port_ids ?? []) {
@@ -85,9 +103,16 @@ export const getSchematicTraceIdsByConnectionKey = (
       if (element?.type !== "source_net" || !element.source_net_id) continue
 
       const sourceNetId = String(element.source_net_id)
+      const sourceNetKeys = [sourceNetId, ...getKnownNetKeys(element)]
 
       for (const sourceTraceId of element.connected_source_trace_ids ?? []) {
-        addToMapSet(sourceTraceIdsByNetId, sourceNetId, String(sourceTraceId))
+        for (const sourceNetKey of sourceNetKeys) {
+          addToMapSet(
+            sourceTraceIdsByNetId,
+            sourceNetKey,
+            String(sourceTraceId),
+          )
+        }
       }
 
       for (const sourcePortId of element.connected_source_port_ids ?? []) {
@@ -95,7 +120,9 @@ export const getSchematicTraceIdsByConnectionKey = (
         if (!sourceTraceIds) continue
 
         for (const sourceTraceId of sourceTraceIds) {
-          addToMapSet(sourceTraceIdsByNetId, sourceNetId, sourceTraceId)
+          for (const sourceNetKey of sourceNetKeys) {
+            addToMapSet(sourceTraceIdsByNetId, sourceNetKey, sourceTraceId)
+          }
         }
       }
     }

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -1,0 +1,140 @@
+import type { CircuitJson } from "circuit-json"
+import { useEffect, useMemo } from "react"
+import { su } from "@tscircuit/soup-util"
+
+const HOVERED_TRACE_CLASS = "schematic-trace-hovered"
+
+export const useHighlightConnectedSchematicTraces = ({
+  svgDivRef,
+  circuitJson,
+  circuitJsonKey,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+  circuitJsonKey: string
+}) => {
+  const schematicTraceIdsByConnectionKey = useMemo(() => {
+    const idsByConnectionKey = new Map<string, Set<string>>()
+
+    try {
+      const sourceTracesById = new Map(
+        su(circuitJson)
+          .source_trace.list()
+          .map((sourceTrace) => [sourceTrace.source_trace_id, sourceTrace]),
+      )
+
+      for (const schematicTrace of su(circuitJson).schematic_trace.list()) {
+        if (
+          !schematicTrace.schematic_trace_id ||
+          !schematicTrace.source_trace_id
+        ) {
+          continue
+        }
+
+        const sourceTrace = sourceTracesById.get(schematicTrace.source_trace_id)
+        const connectedNetIds = sourceTrace?.connected_source_net_ids ?? []
+        const connectionKey =
+          connectedNetIds.length > 0
+            ? `source-net:${[...connectedNetIds].sort().join(",")}`
+            : `source-trace:${schematicTrace.source_trace_id}`
+
+        const traceIds = idsByConnectionKey.get(connectionKey) ?? new Set()
+        traceIds.add(schematicTrace.schematic_trace_id)
+        idsByConnectionKey.set(connectionKey, traceIds)
+      }
+    } catch (err) {
+      console.error("Failed to derive connected schematic trace ids", err)
+    }
+
+    return idsByConnectionKey
+  }, [circuitJsonKey, circuitJson])
+
+  const connectionKeyBySchematicTraceId = useMemo(() => {
+    const connectionKeyByTraceId = new Map<string, string>()
+
+    for (const [
+      connectionKey,
+      schematicTraceIds,
+    ] of schematicTraceIdsByConnectionKey.entries()) {
+      for (const schematicTraceId of schematicTraceIds) {
+        connectionKeyByTraceId.set(schematicTraceId, connectionKey)
+      }
+    }
+
+    return connectionKeyByTraceId
+  }, [schematicTraceIdsByConnectionKey])
+
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv) return
+
+    const clearHoveredTraces = () => {
+      for (const trace of Array.from(
+        svgDiv.querySelectorAll(`.${HOVERED_TRACE_CLASS}`),
+      )) {
+        trace.classList.remove(HOVERED_TRACE_CLASS)
+      }
+    }
+
+    const setHoveredTraceGroup = (schematicTraceId: string | null) => {
+      clearHoveredTraces()
+      if (!schematicTraceId) return
+
+      const connectionKey =
+        connectionKeyBySchematicTraceId.get(schematicTraceId)
+      if (!connectionKey) return
+
+      const schematicTraceIds =
+        schematicTraceIdsByConnectionKey.get(connectionKey) ?? new Set()
+
+      for (const connectedSchematicTraceId of schematicTraceIds) {
+        const connectedTrace = svgDiv.querySelector(
+          `[data-schematic-trace-id="${connectedSchematicTraceId}"]`,
+        )
+        connectedTrace?.classList.add(HOVERED_TRACE_CLASS)
+      }
+    }
+
+    const getTraceIdFromEvent = (event: MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Element)) return null
+
+      const traceElement = target.closest("[data-schematic-trace-id]")
+      return traceElement?.getAttribute("data-schematic-trace-id") ?? null
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      setHoveredTraceGroup(getTraceIdFromEvent(event))
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const relatedTarget = event.relatedTarget
+      if (relatedTarget instanceof Element) {
+        const nextTraceId =
+          relatedTarget
+            .closest("[data-schematic-trace-id]")
+            ?.getAttribute("data-schematic-trace-id") ?? null
+
+        if (nextTraceId) {
+          setHoveredTraceGroup(nextTraceId)
+          return
+        }
+      }
+
+      clearHoveredTraces()
+    }
+
+    svgDiv.addEventListener("mouseover", handleMouseOver)
+    svgDiv.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      svgDiv.removeEventListener("mouseover", handleMouseOver)
+      svgDiv.removeEventListener("mouseout", handleMouseOut)
+      clearHoveredTraces()
+    }
+  }, [
+    svgDivRef,
+    connectionKeyBySchematicTraceId,
+    schematicTraceIdsByConnectionKey,
+  ])
+}

--- a/tests/useHighlightConnectedSchematicTraces.test.ts
+++ b/tests/useHighlightConnectedSchematicTraces.test.ts
@@ -82,3 +82,44 @@ test("groups schematic traces connected through source net ports", () => {
     "schematic_trace_2",
   ])
 })
+
+test("groups schematic traces with the same subcircuit connectivity key", () => {
+  const groupedTraceIds = getGroupedTraceIds([
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      subcircuit_connectivity_map_key: "main.vout",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      subcircuit_connectivity_map_key: "main.vout",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      subcircuit_connectivity_map_key: "main.gnd",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_3",
+      source_trace_id: "source_trace_3",
+    },
+  ] as CircuitJson)
+
+  expect(groupedTraceIds).toContainEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+  expect(groupedTraceIds).toContainEqual(["schematic_trace_3"])
+})

--- a/tests/useHighlightConnectedSchematicTraces.test.ts
+++ b/tests/useHighlightConnectedSchematicTraces.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { getSchematicTraceIdsByConnectionKey } from "../lib/hooks/useHighlightConnectedSchematicTraces"
+
+const getGroupedTraceIds = (circuitJson: CircuitJson) =>
+  Array.from(getSchematicTraceIdsByConnectionKey(circuitJson).values()).map(
+    (traceIds) => Array.from(traceIds).sort(),
+  )
+
+test("groups schematic traces connected to the same source net", () => {
+  const groupedTraceIds = getGroupedTraceIds([
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_net_ids: ["source_net_1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_net_ids: ["source_net_1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_net_ids: ["source_net_2"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_3",
+      source_trace_id: "source_trace_3",
+    },
+  ] as CircuitJson)
+
+  expect(groupedTraceIds).toContainEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+  expect(groupedTraceIds).toContainEqual(["schematic_trace_3"])
+})
+
+test("groups schematic traces connected through source net ports", () => {
+  const groupedTraceIds = getGroupedTraceIds([
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2"],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+    },
+  ] as CircuitJson)
+
+  expect(groupedTraceIds).toContainEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+})


### PR DESCRIPTION
Fixes tscircuit/tscircuit#1130

/claim https://github.com/tscircuit/tscircuit/issues/1130
/fixes https://github.com/tscircuit/tscircuit/issues/1130

## Summary
- Add a hook that tracks hovered schematic traces and applies hover styling to every trace connected to the same source net.
- Group traces using source trace, source net, source port, and connectivity-map metadata so same-net traces are highlighted together across Circuit JSON variants.
- Add focused tests for source-net, source-port, and subcircuit connectivity-key trace grouping.
- Add a same-net hover fixture so the behavior can be checked in the preview.
- Reuse the existing hover visual behavior by applying the same invert filter and crossing-outline opacity styling.

## Validation
- `npm exec -- biome format --write examples/example21-same-net-trace-hover.fixture.tsx lib/components/SchematicViewer.tsx lib/hooks/useHighlightConnectedSchematicTraces.ts tests/useHighlightConnectedSchematicTraces.test.ts`
- `npx -y bun test tests/useHighlightConnectedSchematicTraces.test.ts`
- `npx -y -p typescript@5.9.3 tsc --noEmit`
- `npm exec -- tsup --config tsup-webworker.config.ts && npx -y tsx scripts/build-worker-blob-url.ts && npm exec -- tsup-node ./lib/index.ts --dts --format esm --sourcemap`
