### PR TITLE
fix: highlight same-net traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -5,6 +5,7 @@ import {
 import { su } from "@tscircuit/soup-util"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
+import { useHighlightConnectedTracesOnHover } from "lib/hooks/use-highlight-connected-traces-on-hover"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -343,6 +344,11 @@ export const SchematicViewer = ({
     circuitJson,
     activeEditEvent,
     editEvents: editEventsWithUnappliedEditEvents,
+  })
+
+  useHighlightConnectedTracesOnHover({
+    svgDivRef,
+    circuitJson,
   })
 
   // Add group overlays when enabled

--- a/lib/hooks/use-highlight-connected-traces-on-hover.test.ts
+++ b/lib/hooks/use-highlight-connected-traces-on-hover.test.ts
@@ -48,13 +48,15 @@ test("groups schematic traces by net connectivity instead of source trace id", (
   ] as any
 
   const hoverKeys = getSchematicTraceHoverKeys(circuitJson)
+  const voutHoverKey = hoverKeys.get("schematic_trace_1")
+  const gndHoverKey = hoverKeys.get("schematic_trace_3")
 
-  expect(hoverKeys.get("schematic_trace_1")).toBe(
-    hoverKeys.get("schematic_trace_2"),
-  )
-  expect(hoverKeys.get("schematic_trace_1")).not.toBe(
-    hoverKeys.get("schematic_trace_3"),
-  )
+  if (!voutHoverKey || !gndHoverKey) {
+    throw new Error("Expected schematic traces to have hover keys")
+  }
+
+  expect(hoverKeys.get("schematic_trace_2")).toBe(voutHoverKey)
+  expect(voutHoverKey).not.toBe(gndHoverKey)
 })
 
 test("falls back to connected source net ids when no connectivity key exists", () => {
@@ -88,8 +90,11 @@ test("falls back to connected source net ids when no connectivity key exists", (
   ] as any
 
   const hoverKeys = getSchematicTraceHoverKeys(circuitJson)
+  const hoverKey = hoverKeys.get("schematic_trace_1")
 
-  expect(hoverKeys.get("schematic_trace_1")).toBe(
-    hoverKeys.get("schematic_trace_2"),
-  )
+  if (!hoverKey) {
+    throw new Error("Expected schematic trace to have a hover key")
+  }
+
+  expect(hoverKeys.get("schematic_trace_2")).toBe(hoverKey)
 })

--- a/lib/hooks/use-highlight-connected-traces-on-hover.test.ts
+++ b/lib/hooks/use-highlight-connected-traces-on-hover.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import { getSchematicTraceHoverKeys } from "./use-highlight-connected-traces-on-hover"
+
+test("groups schematic traces by net connectivity instead of source trace id", () => {
+  const circuitJson = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+      connected_source_net_ids: ["source_net_vout"],
+      subcircuit_connectivity_map_key: "main.vout",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2"],
+      connected_source_net_ids: ["source_net_vout"],
+      subcircuit_connectivity_map_key: "main.vout",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3"],
+      connected_source_net_ids: ["source_net_gnd"],
+      subcircuit_connectivity_map_key: "main.gnd",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+      edges: [],
+      junctions: [],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+      edges: [],
+      junctions: [],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_3",
+      source_trace_id: "source_trace_3",
+      edges: [],
+      junctions: [],
+    },
+  ] as any
+
+  const hoverKeys = getSchematicTraceHoverKeys(circuitJson)
+
+  expect(hoverKeys.get("schematic_trace_1")).toBe(
+    hoverKeys.get("schematic_trace_2"),
+  )
+  expect(hoverKeys.get("schematic_trace_1")).not.toBe(
+    hoverKeys.get("schematic_trace_3"),
+  )
+})
+
+test("falls back to connected source net ids when no connectivity key exists", () => {
+  const circuitJson = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+      connected_source_net_ids: ["source_net_vout"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2"],
+      connected_source_net_ids: ["source_net_vout"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+      edges: [],
+      junctions: [],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+      edges: [],
+      junctions: [],
+    },
+  ] as any
+
+  const hoverKeys = getSchematicTraceHoverKeys(circuitJson)
+
+  expect(hoverKeys.get("schematic_trace_1")).toBe(
+    hoverKeys.get("schematic_trace_2"),
+  )
+})

--- a/lib/hooks/use-highlight-connected-traces-on-hover.ts
+++ b/lib/hooks/use-highlight-connected-traces-on-hover.ts
@@ -1,0 +1,171 @@
+import type { CircuitJson } from "circuit-json"
+import { useEffect } from "react"
+
+const HOVER_KEY_ATTRIBUTE = "data-tscircuit-net-highlight-key"
+const HOVER_STYLE_ID = "tscircuit-net-trace-hover-style"
+const TRACE_HOVER_COLOR = "#ffb700"
+
+const cssString = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+
+export const getSchematicTraceHoverKeys = (circuitJson: CircuitJson) => {
+  const sourceTraceIdsByConnectivityKey = new Map<string, Set<string>>()
+  const sourceTraceParentById = new Map<string, string>()
+
+  const findSourceTraceRoot = (sourceTraceId: string): string => {
+    const parent = sourceTraceParentById.get(sourceTraceId)
+    if (!parent) {
+      sourceTraceParentById.set(sourceTraceId, sourceTraceId)
+      return sourceTraceId
+    }
+
+    if (parent === sourceTraceId) return sourceTraceId
+
+    const root = findSourceTraceRoot(parent)
+    sourceTraceParentById.set(sourceTraceId, root)
+    return root
+  }
+
+  const unionSourceTraces = (a: string, b: string) => {
+    const aRoot = findSourceTraceRoot(a)
+    const bRoot = findSourceTraceRoot(b)
+    if (aRoot !== bRoot) sourceTraceParentById.set(bRoot, aRoot)
+  }
+
+  const addConnectivityKey = (
+    sourceTraceId: string,
+    connectivityKey: string | undefined,
+  ) => {
+    if (!connectivityKey) return
+
+    const sourceTraceIds =
+      sourceTraceIdsByConnectivityKey.get(connectivityKey) ?? new Set<string>()
+    sourceTraceIds.add(sourceTraceId)
+    sourceTraceIdsByConnectivityKey.set(connectivityKey, sourceTraceIds)
+  }
+
+  for (const element of circuitJson as any[]) {
+    if (element.type !== "source_trace") continue
+
+    const sourceTraceId = element.source_trace_id
+    if (!sourceTraceId) continue
+
+    findSourceTraceRoot(sourceTraceId)
+
+    if (element.subcircuit_connectivity_map_key) {
+      addConnectivityKey(
+        sourceTraceId,
+        `net:${element.subcircuit_connectivity_map_key}`,
+      )
+    }
+
+    for (const connectedSourceNetId of element.connected_source_net_ids ?? []) {
+      addConnectivityKey(sourceTraceId, `net:${connectedSourceNetId}`)
+    }
+
+    for (const connectedSourcePortId of element.connected_source_port_ids ??
+      []) {
+      addConnectivityKey(sourceTraceId, `port:${connectedSourcePortId}`)
+    }
+  }
+
+  for (const sourceTraceIds of sourceTraceIdsByConnectivityKey.values()) {
+    const [firstSourceTraceId, ...restSourceTraceIds] = sourceTraceIds
+    for (const sourceTraceId of restSourceTraceIds) {
+      unionSourceTraces(firstSourceTraceId, sourceTraceId)
+    }
+  }
+
+  const schematicTraceHoverKeys = new Map<string, string>()
+  for (const element of circuitJson as any[]) {
+    if (element.type !== "schematic_trace") continue
+
+    const schematicTraceId = element.schematic_trace_id
+    if (!schematicTraceId) continue
+
+    const sourceTraceId = element.source_trace_id
+    schematicTraceHoverKeys.set(
+      schematicTraceId,
+      sourceTraceId
+        ? `source_trace:${findSourceTraceRoot(sourceTraceId)}`
+        : `schematic_trace:${schematicTraceId}`,
+    )
+  }
+
+  return schematicTraceHoverKeys
+}
+
+const getHoverStyleText = (hoverKeys: Iterable<string>) => {
+  const rules: string[] = []
+
+  for (const hoverKey of new Set(hoverKeys)) {
+    const keySelector = `[${HOVER_KEY_ATTRIBUTE}="${cssString(hoverKey)}"]`
+    const traceSelector = `:is(g.trace${keySelector}, g.trace-overlays${keySelector})`
+    const hoveredSelector = `${traceSelector}:hover`
+    const visiblePathSelector = `${traceSelector} path:not(.invisible):not(.trace-crossing-outline)`
+
+    rules.push(
+      `svg:has(${hoveredSelector}) ${visiblePathSelector} { stroke: ${TRACE_HOVER_COLOR}; filter: drop-shadow(0 0 1px ${TRACE_HOVER_COLOR}); }`,
+      `svg:has(${hoveredSelector}) g.trace-overlays${keySelector} .trace-crossing-outline { opacity: 0; }`,
+    )
+  }
+
+  return rules.join("\n")
+}
+
+export const useHighlightConnectedTracesOnHover = ({
+  svgDivRef,
+  circuitJson,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+}) => {
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv) return
+
+    const hoverKeys = getSchematicTraceHoverKeys(circuitJson)
+
+    const applyHoverMetadata = () => {
+      const traceGroups = svgDiv.querySelectorAll(
+        '[data-circuit-json-type="schematic_trace"][data-schematic-trace-id]',
+      )
+
+      for (const traceGroup of Array.from(traceGroups)) {
+        const schematicTraceId = traceGroup.getAttribute(
+          "data-schematic-trace-id",
+        )
+        const hoverKey = schematicTraceId
+          ? hoverKeys.get(schematicTraceId)
+          : undefined
+
+        if (hoverKey) {
+          traceGroup.setAttribute(HOVER_KEY_ATTRIBUTE, hoverKey)
+        } else {
+          traceGroup.removeAttribute(HOVER_KEY_ATTRIBUTE)
+        }
+      }
+
+      let style = svgDiv.querySelector<HTMLStyleElement>(`#${HOVER_STYLE_ID}`)
+      if (!style) {
+        style = document.createElement("style")
+        style.id = HOVER_STYLE_ID
+        svgDiv.appendChild(style)
+      }
+      style.textContent = getHoverStyleText(hoverKeys.values())
+    }
+
+    applyHoverMetadata()
+
+    const observer = new MutationObserver(applyHoverMetadata)
+    observer.observe(svgDiv, {
+      childList: true,
+      subtree: false,
+    })
+
+    return () => {
+      observer.disconnect()
+      svgDiv.querySelector(`#${HOVER_STYLE_ID}`)?.remove()
+    }
+  }, [svgDivRef, circuitJson])
+}


### PR DESCRIPTION
/claim https://github.com/tscircuit/tscircuit/issues/1130
/fixes https://github.com/tscircuit/tscircuit/issues/1130

## Summary

Adds same-net hover highlighting for schematic traces in `@tscircuit/schematic-viewer`.

- Adds a focused `useHighlightConnectedTracesOnHover` hook.
- Groups schematic traces through source trace connectivity keys, connected source nets, and connected source ports.
- Applies hover metadata to both trace and trace-overlay SVG groups so every segment in the same net highlights together.
- Uses CSS `:has()` for hover state, avoiding per-mousemove React state updates.
- Adds unit coverage for same-net grouping and connected source-net fallback.

## Test plan

- [x] `bun test`
- [x] `bun run build`
- [x] `git diff --check`

Note: `bun run build` still reports the existing `BaseManualEditEvent` unused-import warning in `lib/types/edit-events.ts`, unrelated to this change.