### PR TITLE
Remove unused edit event type imports

### DIFF
--- a/lib/types/edit-events.ts
+++ b/lib/types/edit-events.ts
@@ -1,8 +1,4 @@
-import type {
-  BaseManualEditEvent,
-  EditSchematicComponentLocationEvent,
-  ManualEditEvent,
-} from "@tscircuit/props"
+import type { EditSchematicComponentLocationEvent } from "@tscircuit/props"
 
 export type EditSchematicComponentLocationEventWithElement =
   EditSchematicComponentLocationEvent & {
@@ -13,4 +9,4 @@ export type {
   BaseManualEditEvent,
   EditSchematicComponentLocationEvent,
   ManualEditEvent,
-}
+} from "@tscircuit/props"


### PR DESCRIPTION
## Summary

- Imports only the local edit-event type used by `EditSchematicComponentLocationEventWithElement`
- Re-exports the remaining edit-event types directly from `@tscircuit/props`
- Removes the tsup warning about unused `BaseManualEditEvent` / `ManualEditEvent` imports during declaration builds

## Validation

- `npx -y bun x biome format --write lib/types/edit-events.ts`
- `npx -y bun x tsc --noEmit`
- `npx -y bun run build`