### PR TITLE
Reset schematic view when circuit changes

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   fromString,
   identity,
+  type Matrix,
   toString as transformToString,
 } from "transformation-matrix"
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
@@ -235,6 +236,11 @@ export const SchematicViewer = ({
   >([])
   const circuitJsonRef = useRef<CircuitJson>(circuitJson)
 
+  const handleSetTransform = useCallback((transform: Matrix) => {
+    if (!svgDivRef.current) return
+    svgDivRef.current.style.transform = transformToString(transform)
+  }, [])
+
   useEffect(() => {
     const circuitHash = getCircuitHash(circuitJson)
     const circuitHashRef = getCircuitHash(circuitJsonRef.current)
@@ -249,14 +255,16 @@ export const SchematicViewer = ({
     ref: containerRef,
     cancelDrag,
     transform: svgToScreenProjection,
+    setTransform: setSvgToScreenProjection,
   } = useMouseMatrixTransform({
-    onSetTransform(transform) {
-      if (!svgDivRef.current) return
-      svgDivRef.current.style.transform = transformToString(transform)
-    },
+    onSetTransform: handleSetTransform,
     // @ts-ignore disabled is a valid prop but not typed
     enabled: isInteractionEnabled && !showSpiceOverlay,
   })
+
+  useEffect(() => {
+    setSvgToScreenProjection(identity())
+  }, [circuitJsonKey, setSvgToScreenProjection])
 
   const { containerWidth, containerHeight } = useResizeHandling(containerRef)
   const svgString = useMemo(() => {


### PR DESCRIPTION
Fixes #15

## Summary

- Keep the pan/zoom transform setter stable so it can be reused outside the mouse handler
- Reset the viewer transform back to the fitted default when the provided circuit changes
- Preserve normal user pan/zoom behavior while viewing the same schematic

## Validation

- `npx -y bun x biome format --write lib/components/SchematicViewer.tsx`
- `npx -y bun x tsc --noEmit`
- `npx -y bun run build`