### PR TITLE
fix: highlight same-net traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -353,6 +353,50 @@ export const SchematicViewer = ({
     showGroups: showSchematicGroups && !disableGroups,
   })
 
+  // Trace hover: highlight all same-net traces when any trace is hovered
+  useEffect(() => {
+    const div = svgDivRef.current
+    if (!div) return
+
+    const clearNetHighlight = () => {
+      div
+        .querySelectorAll("[data-net-hovered]")
+        .forEach((el) => el.removeAttribute("data-net-hovered"))
+    }
+
+    const handleTraceMouseEnter = (e: Event) => {
+      clearNetHighlight()
+      const target = e.currentTarget as Element
+      const key = target.getAttribute("data-subcircuit-connectivity-map-key")
+      if (!key) return
+      const escaped = CSS.escape(key)
+      div
+        .querySelectorAll(
+          `[data-circuit-json-type="schematic_trace"][data-subcircuit-connectivity-map-key="${escaped}"]`,
+        )
+        .forEach((el) => el.setAttribute("data-net-hovered", "true"))
+    }
+
+    const handleTraceMouseLeave = () => {
+      clearNetHighlight()
+    }
+
+    const traces = div.querySelectorAll(
+      '[data-circuit-json-type="schematic_trace"][data-layer="base"]',
+    )
+    traces.forEach((el) => {
+      el.addEventListener("mouseenter", handleTraceMouseEnter)
+      el.addEventListener("mouseleave", handleTraceMouseLeave)
+    })
+
+    return () => {
+      traces.forEach((el) => {
+        el.removeEventListener("mouseenter", handleTraceMouseEnter)
+        el.removeEventListener("mouseleave", handleTraceMouseLeave)
+      })
+    }
+  }, [svgString])
+
   // keep the latest touch handler without re-rendering the svg div
   const handleComponentTouchStartRef = useRef(handleComponentTouchStart)
   useEffect(() => {
@@ -396,6 +440,9 @@ export const SchematicViewer = ({
 
   return (
     <MouseTracker>
+      <style>
+        {`[data-circuit-json-type="schematic_trace"][data-net-hovered="true"] > path:first-child { opacity: 0.3 !important; transition: opacity 0.1s; }`}
+      </style>
       {onSchematicComponentClicked && (
         <style>
           {`.schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }`}


### PR DESCRIPTION
## Problem

Fixes tscircuit/tscircuit#1130 — when hovering over a trace in the schematic view, connected traces on the same net do not highlight together.

## Solution

Added a `useEffect` in `SchematicViewer.tsx` that attaches `mouseenter`/`mouseleave` handlers to all trace base group elements. When a trace is hovered:

1. Get its `data-subcircuit-connectivity-map-key` (the net identifier)
2. Set `data-net-hovered="true"` on all trace elements sharing the same net key
3. CSS shows the existing invisible 8x-stroke hover outline (`opacity: 0.3`) for all highlighted traces
4. On `mouseleave`, clear all `data-net-hovered` attributes

The SVG trace elements already include an invisible 8x-stroke hover outline path (in `circuit-to-svg`) — this fix just reveals it for all same-net traces simultaneously.

## Before/After

- **Before**: Hovering a trace shows no visual feedback; other connected traces don't react
- **After**: All traces on the same net show a semi-transparent highlight overlay when any one is hovered