### PR TITLE
Highlight connected schematic traces on hover

### DIFF
--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -1,10 +1,16 @@
-import {
-  convertCircuitJsonToSchematicSvg,
-  type ColorOverrides,
-} from "circuit-to-svg"
 import { su } from "@tscircuit/soup-util"
+import type { CircuitJson } from "circuit-json"
+import {
+  type ColorOverrides,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
+import {
+  HOVERED_TRACE_CLASS,
+  useHighlightConnectedSchematicTraces,
+} from "lib/hooks/useHighlightConnectedSchematicTraces"
+import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -16,21 +22,19 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import type { ManualEditEvent } from "../types/edit-events"
+import { getSpiceFromCircuitJson } from "../utils/spice-utils"
+import { zIndexMap } from "../utils/z-index-map"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
-import { ViewMenuIcon } from "./ViewMenuIcon"
-import { ViewMenu } from "./ViewMenu"
-import type { CircuitJson } from "circuit-json"
-import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
-import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
-import { zIndexMap } from "../utils/z-index-map"
-import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
-import { getSpiceFromCircuitJson } from "../utils/spice-utils"
-import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
+import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
+import { ViewMenu } from "./ViewMenu"
+import { ViewMenuIcon } from "./ViewMenuIcon"
 
 interface Props {
   circuitJson: CircuitJson
@@ -345,6 +349,13 @@ export const SchematicViewer = ({
     editEvents: editEventsWithUnappliedEditEvents,
   })
 
+  useHighlightConnectedSchematicTraces({
+    svgDivRef,
+    circuitJson,
+    circuitJsonKey,
+    svgString,
+  })
+
   // Add group overlays when enabled
   useSchematicGroupsOverlay({
     svgDivRef,
@@ -396,14 +407,19 @@ export const SchematicViewer = ({
 
   return (
     <MouseTracker>
+      <style>
+        {`.${HOVERED_TRACE_CLASS} path:not(.trace-invisible-hover-outline) { stroke: #ff8c00 !important; }`}
+      </style>
       {onSchematicComponentClicked && (
         <style>
-          {`.schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }`}
+          {
+            ".schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }"
+          }
         </style>
       )}
       {onSchematicPortClicked && (
         <style>
-          {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
+          {"[data-schematic-port-id]:hover { cursor: pointer !important; }"}
         </style>
       )}
       <div

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -26,7 +26,7 @@ export function useHighlightConnectedSchematicTraces({
     if (traceGroups.length === 0) return
 
     const schematicTraces = circuitJson.filter(isSchematicTrace)
-    const netKeyByTraceId = getNetKeyByTraceId(schematicTraces)
+    const netKeyByTraceId = getSchematicTraceNetKeyByTraceId(schematicTraces)
     if (netKeyByTraceId.size === 0) return
 
     const clearHoveredTraces = () => {
@@ -75,7 +75,7 @@ function isSchematicTrace(
   return element.type === "schematic_trace"
 }
 
-function getNetKeyByTraceId(
+export function getSchematicTraceNetKeyByTraceId(
   schematicTraces: Array<
     Extract<CircuitJson[number], { type: "schematic_trace" }>
   >,

--- a/lib/hooks/useHighlightConnectedSchematicTraces.ts
+++ b/lib/hooks/useHighlightConnectedSchematicTraces.ts
@@ -1,0 +1,142 @@
+import type { CircuitJson } from "circuit-json"
+import { type RefObject, useEffect } from "react"
+
+export const HOVERED_TRACE_CLASS = "schematic-trace-net-hover"
+
+export function useHighlightConnectedSchematicTraces({
+  svgDivRef,
+  circuitJson,
+  circuitJsonKey,
+  svgString,
+}: {
+  svgDivRef: RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+  circuitJsonKey: string
+  svgString: string
+}) {
+  useEffect(() => {
+    const svgDiv = svgDivRef.current
+    if (!svgDiv) return
+
+    const traceGroups = Array.from(
+      svgDiv.querySelectorAll<SVGGElement>(
+        '.trace[data-circuit-json-type="schematic_trace"][data-schematic-trace-id]',
+      ),
+    )
+    if (traceGroups.length === 0) return
+
+    const schematicTraces = circuitJson.filter(isSchematicTrace)
+    const netKeyByTraceId = getNetKeyByTraceId(schematicTraces)
+    if (netKeyByTraceId.size === 0) return
+
+    const clearHoveredTraces = () => {
+      for (const group of traceGroups) {
+        group.classList.remove(HOVERED_TRACE_CLASS)
+      }
+    }
+
+    const cleanupFns: Array<() => void> = []
+    for (const group of traceGroups) {
+      const traceId = group.dataset.schematicTraceId
+      const netKey = traceId ? netKeyByTraceId.get(traceId) : undefined
+      if (!netKey) continue
+
+      const onMouseEnter = () => {
+        clearHoveredTraces()
+        for (const candidate of traceGroups) {
+          const candidateTraceId = candidate.dataset.schematicTraceId
+          if (
+            candidateTraceId &&
+            netKeyByTraceId.get(candidateTraceId) === netKey
+          ) {
+            candidate.classList.add(HOVERED_TRACE_CLASS)
+          }
+        }
+      }
+
+      group.addEventListener("mouseenter", onMouseEnter)
+      group.addEventListener("mouseleave", clearHoveredTraces)
+      cleanupFns.push(() => {
+        group.removeEventListener("mouseenter", onMouseEnter)
+        group.removeEventListener("mouseleave", clearHoveredTraces)
+      })
+    }
+
+    return () => {
+      clearHoveredTraces()
+      for (const cleanup of cleanupFns) cleanup()
+    }
+  }, [svgDivRef, circuitJson, circuitJsonKey, svgString])
+}
+
+function isSchematicTrace(
+  element: CircuitJson[number],
+): element is Extract<CircuitJson[number], { type: "schematic_trace" }> {
+  return element.type === "schematic_trace"
+}
+
+function getNetKeyByTraceId(
+  schematicTraces: Array<
+    Extract<CircuitJson[number], { type: "schematic_trace" }>
+  >,
+): Map<string, string> {
+  const netKeyByTraceId = new Map<string, string>()
+  const tracesWithoutNetKey: typeof schematicTraces = []
+
+  for (const trace of schematicTraces) {
+    const traceId = trace.schematic_trace_id
+    if (!traceId) continue
+
+    const explicitNetKey = (trace as any).subcircuit_connectivity_map_key
+    if (explicitNetKey) {
+      netKeyByTraceId.set(traceId, explicitNetKey)
+    } else {
+      tracesWithoutNetKey.push(trace)
+    }
+  }
+
+  const parent = new Map<string, string>()
+  const find = (traceId: string): string => {
+    const currentParent = parent.get(traceId) ?? traceId
+    if (currentParent === traceId) return traceId
+    const root = find(currentParent)
+    parent.set(traceId, root)
+    return root
+  }
+  const union = (a: string, b: string) => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA !== rootB) parent.set(rootB, rootA)
+  }
+
+  const traceIdsByPoint = new Map<string, string[]>()
+  for (const trace of tracesWithoutNetKey) {
+    const traceId = trace.schematic_trace_id
+    if (!traceId) continue
+    parent.set(traceId, traceId)
+
+    for (const edge of trace.edges ?? []) {
+      for (const point of [edge.from, edge.to]) {
+        const pointKey = `${roundPoint(point.x)},${roundPoint(point.y)}`
+        const traceIds = traceIdsByPoint.get(pointKey) ?? []
+        for (const connectedTraceId of traceIds) {
+          union(traceId, connectedTraceId)
+        }
+        traceIds.push(traceId)
+        traceIdsByPoint.set(pointKey, traceIds)
+      }
+    }
+  }
+
+  for (const trace of tracesWithoutNetKey) {
+    const traceId = trace.schematic_trace_id
+    if (!traceId) continue
+    netKeyByTraceId.set(traceId, `connected:${find(traceId)}`)
+  }
+
+  return netKeyByTraceId
+}
+
+function roundPoint(value: number): string {
+  return value.toFixed(6)
+}

--- a/tests/trace-net-key.test.ts
+++ b/tests/trace-net-key.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { getSchematicTraceNetKeyByTraceId } from "../lib/hooks/useHighlightConnectedSchematicTraces"
+
+test("uses explicit connectivity keys for schematic traces", () => {
+  const keys = getSchematicTraceNetKeyByTraceId([
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_1",
+      subcircuit_connectivity_map_key: "net.GND",
+      edges: [],
+    } as any,
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_2",
+      subcircuit_connectivity_map_key: "net.GND",
+      edges: [],
+    } as any,
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_3",
+      subcircuit_connectivity_map_key: "net.VCC",
+      edges: [],
+    } as any,
+  ])
+
+  expect(keys.get("trace_1")).toBe("net.GND")
+  expect(keys.get("trace_2")).toBe("net.GND")
+  expect(keys.get("trace_3")).toBe("net.VCC")
+})
+
+test("falls back to shared endpoints when traces do not have connectivity keys", () => {
+  const keys = getSchematicTraceNetKeyByTraceId([
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_1",
+      edges: [{ from: { x: 0, y: 0 }, to: { x: 1, y: 0 } }],
+    } as any,
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_2",
+      edges: [{ from: { x: 1, y: 0 }, to: { x: 2, y: 0 } }],
+    } as any,
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "trace_3",
+      edges: [{ from: { x: 5, y: 5 }, to: { x: 6, y: 5 } }],
+    } as any,
+  ])
+
+  const firstTraceKey = keys.get("trace_1")
+  const secondTraceKey = keys.get("trace_2")
+  const thirdTraceKey = keys.get("trace_3")
+
+  if (!firstTraceKey || !secondTraceKey || !thirdTraceKey) {
+    throw new Error("Expected every test trace to receive a net key")
+  }
+
+  expect(firstTraceKey).toBe(secondTraceKey)
+  expect(firstTraceKey).not.toBe(thirdTraceKey)
+})


### PR DESCRIPTION
Fixes tscircuit/tscircuit#1130.

Adds hover highlighting for schematic traces so every rendered trace segment on the same connected schematic net changes color together. The hook uses explicit schematic connectivity keys when available and falls back to grouping traces by shared edge endpoints.

Demo proof:
- Strong connected trace hover MP4: https://github.com/digzrow-coder/schematic-viewer/releases/download/pr-197-demo-20260514/pr-197-connected-trace-hover-strong-demo.mp4
- Strong connected trace hover GIF: https://github.com/digzrow-coder/schematic-viewer/releases/download/pr-197-demo-20260514/pr-197-connected-trace-hover-strong-demo.gif
- Strong contact sheet: https://github.com/digzrow-coder/schematic-viewer/releases/download/pr-197-demo-20260514/pr-197-strong-contact-sheet.jpg
- Original MP4: https://github.com/digzrow-coder/schematic-viewer/releases/download/pr-197-demo-20260514/pr-197-connected-trace-hover-demo.mp4

Validation:
- bun test tests/trace-net-key.test.ts
- bunx biome check lib/hooks/useHighlightConnectedSchematicTraces.ts tests/trace-net-key.test.ts
- bunx tsc --noEmit
- bun run build
- git diff --check
- Verified in Cosmos with Playwright that hovering one schematic trace marks both same-net traces as highlighted while unrelated traces stay unchanged.

/claim tscircuit/tscircuit#1130

AI-assisted with OpenAI Codex; I reviewed the diff, proof assets, and validation output before posting.