### PR TITLE
Highlight connected schematic traces on hover

### DIFF
--- a/examples/example21-connected-trace-hover.fixture.tsx
+++ b/examples/example21-connected-trace-hover.fixture.tsx
@@ -1,0 +1,62 @@
+import type { CircuitJson } from "circuit-json"
+import { SchematicViewer } from "lib/components/SchematicViewer"
+
+const circuitJson = [
+  {
+    type: "source_net",
+    source_net_id: "source_net_gnd",
+    name: "GND",
+  },
+  {
+    type: "source_net",
+    source_net_id: "source_net_signal",
+    name: "SIGNAL",
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_gnd_left",
+    connected_source_net_ids: ["source_net_gnd"],
+    connected_source_port_ids: [],
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_gnd_right",
+    connected_source_net_ids: ["source_net_gnd"],
+    connected_source_port_ids: [],
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_signal",
+    connected_source_net_ids: ["source_net_signal"],
+    connected_source_port_ids: [],
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_gnd_left",
+    source_trace_id: "source_trace_gnd_left",
+    edges: [{ from: { x: -4, y: 1 }, to: { x: -1, y: 1 } }],
+    junctions: [{ x: -1, y: 1 }],
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_gnd_right",
+    source_trace_id: "source_trace_gnd_right",
+    edges: [{ from: { x: 1, y: 1 }, to: { x: 4, y: 1 } }],
+    junctions: [{ x: 1, y: 1 }],
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_signal",
+    source_trace_id: "source_trace_signal",
+    edges: [{ from: { x: -4, y: -1 }, to: { x: 4, y: -1 } }],
+    junctions: [],
+  },
+] as CircuitJson
+
+export default () => (
+  <SchematicViewer
+    circuitJson={circuitJson}
+    containerStyle={{ height: "100%" }}
+    debugGrid
+  />
+)

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -1,10 +1,16 @@
-import {
-  convertCircuitJsonToSchematicSvg,
-  type ColorOverrides,
-} from "circuit-to-svg"
 import { su } from "@tscircuit/soup-util"
+import type { CircuitJson } from "circuit-json"
+import {
+  type ColorOverrides,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
 import { useChangeSchematicComponentLocationsInSvg } from "lib/hooks/useChangeSchematicComponentLocationsInSvg"
 import { useChangeSchematicTracesForMovedComponents } from "lib/hooks/useChangeSchematicTracesForMovedComponents"
+import {
+  schematicTraceHoverStyle,
+  useHighlightConnectedTracesOnHover,
+} from "lib/hooks/useHighlightConnectedTracesOnHover"
+import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { useSchematicGroupsOverlay } from "lib/hooks/useSchematicGroupsOverlay"
 import { enableDebug } from "lib/utils/debug"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -16,21 +22,19 @@ import {
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useComponentDragging } from "../hooks/useComponentDragging"
+import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import type { ManualEditEvent } from "../types/edit-events"
+import { getSpiceFromCircuitJson } from "../utils/spice-utils"
+import { zIndexMap } from "../utils/z-index-map"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
-import { ViewMenuIcon } from "./ViewMenuIcon"
-import { ViewMenu } from "./ViewMenu"
-import type { CircuitJson } from "circuit-json"
-import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
-import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
-import { zIndexMap } from "../utils/z-index-map"
-import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
-import { getSpiceFromCircuitJson } from "../utils/spice-utils"
-import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
+import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
+import { ViewMenu } from "./ViewMenu"
+import { ViewMenuIcon } from "./ViewMenuIcon"
 
 interface Props {
   circuitJson: CircuitJson
@@ -345,6 +349,12 @@ export const SchematicViewer = ({
     editEvents: editEventsWithUnappliedEditEvents,
   })
 
+  useHighlightConnectedTracesOnHover({
+    svgDivRef,
+    circuitJson,
+    circuitJsonKey,
+  })
+
   // Add group overlays when enabled
   useSchematicGroupsOverlay({
     svgDivRef,
@@ -398,14 +408,17 @@ export const SchematicViewer = ({
     <MouseTracker>
       {onSchematicComponentClicked && (
         <style>
-          {`.schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }`}
+          {
+            ".schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }"
+          }
         </style>
       )}
       {onSchematicPortClicked && (
         <style>
-          {`[data-schematic-port-id]:hover { cursor: pointer !important; }`}
+          {"[data-schematic-port-id]:hover { cursor: pointer !important; }"}
         </style>
       )}
+      <style>{schematicTraceHoverStyle}</style>
       <div
         ref={containerRef}
         style={{

--- a/lib/hooks/useHighlightConnectedTracesOnHover.ts
+++ b/lib/hooks/useHighlightConnectedTracesOnHover.ts
@@ -1,0 +1,104 @@
+import type { CircuitJson } from "circuit-json"
+import { useEffect } from "react"
+import { getConnectedSchematicTraceIdsByHoveredTrace } from "../utils/getConnectedSchematicTraceIdsByHoveredTrace"
+
+const HOVER_ATTR = "data-schematic-trace-net-hover"
+const TRACE_SELECTOR =
+  '[data-circuit-json-type="schematic_trace"][data-schematic-trace-id]'
+
+export const schematicTraceHoverStyle = `
+  [data-circuit-json-type="schematic_trace"][${HOVER_ATTR}="true"] path:not(.trace-invisible-hover-outline):not([class*="invisible"]) {
+    stroke: var(--tscircuit-schematic-trace-hover-color, #3b82f6) !important;
+  }
+
+  [data-circuit-json-type="schematic_trace"][${HOVER_ATTR}="true"] circle {
+    stroke: var(--tscircuit-schematic-trace-hover-color, #3b82f6) !important;
+    fill: var(--tscircuit-schematic-trace-hover-color, #3b82f6) !important;
+  }
+
+  [data-circuit-json-type="schematic_trace"][${HOVER_ATTR}="true"] .trace-crossing-outline {
+    opacity: 0;
+  }
+`
+
+const getTraceElement = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) return null
+  return target.closest(TRACE_SELECTOR)
+}
+
+export const useHighlightConnectedTracesOnHover = ({
+  svgDivRef,
+  circuitJson,
+  circuitJsonKey,
+}: {
+  svgDivRef: React.RefObject<HTMLDivElement | null>
+  circuitJson: CircuitJson
+  circuitJsonKey: string
+}) => {
+  useEffect(() => {
+    const svg = svgDivRef.current
+    if (!svg) return
+
+    const connectedSchematicTraceIdsByTraceId =
+      getConnectedSchematicTraceIdsByHoveredTrace(circuitJson)
+
+    let currentHoveredTraceId: string | null = null
+
+    const clearHighlightedTraces = () => {
+      currentHoveredTraceId = null
+      for (const traceElement of Array.from(
+        svg.querySelectorAll(`[${HOVER_ATTR}]`),
+      )) {
+        traceElement.removeAttribute(HOVER_ATTR)
+      }
+    }
+
+    const highlightConnectedTraces = (schematicTraceId: string) => {
+      if (schematicTraceId === currentHoveredTraceId) return
+
+      currentHoveredTraceId = schematicTraceId
+      const connectedSchematicTraceIds =
+        connectedSchematicTraceIdsByTraceId.get(schematicTraceId) ??
+        new Set([schematicTraceId])
+
+      for (const traceElement of Array.from(
+        svg.querySelectorAll(TRACE_SELECTOR),
+      )) {
+        const traceId = traceElement.getAttribute("data-schematic-trace-id")
+        if (traceId && connectedSchematicTraceIds.has(traceId)) {
+          traceElement.setAttribute(HOVER_ATTR, "true")
+        } else {
+          traceElement.removeAttribute(HOVER_ATTR)
+        }
+      }
+    }
+
+    const handlePointerOver = (event: PointerEvent) => {
+      const traceElement = getTraceElement(event.target)
+      const schematicTraceId = traceElement?.getAttribute(
+        "data-schematic-trace-id",
+      )
+      if (!schematicTraceId) return
+
+      highlightConnectedTraces(schematicTraceId)
+    }
+
+    const handlePointerOut = (event: PointerEvent) => {
+      const nextTraceElement = getTraceElement(event.relatedTarget)
+      if (!nextTraceElement) {
+        clearHighlightedTraces()
+      }
+    }
+
+    svg.addEventListener("pointerover", handlePointerOver)
+    svg.addEventListener("pointerout", handlePointerOut)
+    svg.addEventListener("pointerleave", clearHighlightedTraces)
+
+    return () => {
+      svg.removeEventListener("pointerover", handlePointerOver)
+      svg.removeEventListener("pointerout", handlePointerOut)
+      svg.removeEventListener("pointerleave", clearHighlightedTraces)
+      clearHighlightedTraces()
+    }
+  }, [svgDivRef, circuitJson, circuitJsonKey])
+}

--- a/lib/utils/getConnectedSchematicTraceIdsByHoveredTrace.ts
+++ b/lib/utils/getConnectedSchematicTraceIdsByHoveredTrace.ts
@@ -1,0 +1,316 @@
+import type { CircuitJson } from "circuit-json"
+
+type CircuitJsonElement = Record<string, any>
+
+const addToSetMap = (
+  map: Map<string, Set<string>>,
+  key: string | undefined,
+  value: string | undefined,
+) => {
+  if (!key || !value) return
+  const values = map.get(key) ?? new Set<string>()
+  values.add(value)
+  map.set(key, values)
+}
+
+const getElementsByType = (circuitJson: CircuitJson, type: string) =>
+  (circuitJson as CircuitJsonElement[]).filter((elm) => elm.type === type)
+
+const getStringArray = (value: any) =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
+
+const normalizeSelector = (selector: string) =>
+  selector
+    .trim()
+    .replace(/^\.*/, "")
+    .replace(/\s*>\s*/g, ".")
+    .replace(/\s+/g, ".")
+    .replace(/^\.+|\.+$/g, "")
+
+const getSourcePortSelectorsFromSolverTraceId = (sourceTraceId: string) => {
+  if (!sourceTraceId.startsWith("solver_")) return []
+  return sourceTraceId
+    .replace(/^solver_/, "")
+    .split("-")
+    .map(normalizeSelector)
+    .filter(Boolean)
+}
+
+const addTraceConnectivityKey = (
+  traceIdToKeys: Map<string, Set<string>>,
+  keyToTraceIds: Map<string, Set<string>>,
+  traceId: string | undefined,
+  key: string | undefined,
+) => {
+  if (!traceId || !key) return
+  addToSetMap(traceIdToKeys, traceId, key)
+  addToSetMap(keyToTraceIds, key, traceId)
+}
+
+const addSourcePortKey = (
+  sourcePortSelectorToPortId: Map<string, string>,
+  componentName: string | undefined,
+  selector: unknown,
+  sourcePortId: string,
+) => {
+  if (!componentName || selector === undefined || selector === null) return
+  const normalizedSelector = normalizeSelector(String(selector))
+  if (!normalizedSelector) return
+
+  sourcePortSelectorToPortId.set(
+    `${componentName}.${normalizedSelector}`,
+    sourcePortId,
+  )
+
+  if (normalizedSelector.startsWith("pin")) {
+    sourcePortSelectorToPortId.set(
+      `${componentName}.${normalizedSelector.replace(/^pin/, "")}`,
+      sourcePortId,
+    )
+  } else if (/^\d+$/.test(normalizedSelector)) {
+    sourcePortSelectorToPortId.set(
+      `${componentName}.pin${normalizedSelector}`,
+      sourcePortId,
+    )
+  }
+}
+
+const getConnectedSourceTraceIds = (
+  hoveredSourceTraceId: string,
+  traceIdToKeys: Map<string, Set<string>>,
+  keyToTraceIds: Map<string, Set<string>>,
+) => {
+  const connectedSourceTraceIds = new Set<string>()
+  const queue = [hoveredSourceTraceId]
+
+  while (queue.length > 0) {
+    const sourceTraceId = queue.pop()
+    if (!sourceTraceId || connectedSourceTraceIds.has(sourceTraceId)) continue
+
+    connectedSourceTraceIds.add(sourceTraceId)
+
+    for (const key of traceIdToKeys.get(sourceTraceId) ?? []) {
+      for (const nextTraceId of keyToTraceIds.get(key) ?? []) {
+        if (!connectedSourceTraceIds.has(nextTraceId)) {
+          queue.push(nextTraceId)
+        }
+      }
+    }
+  }
+
+  return connectedSourceTraceIds
+}
+
+export const getConnectedSchematicTraceIdsByHoveredTrace = (
+  circuitJson: CircuitJson,
+) => {
+  const sourceTraceIdToSchematicTraceIds = new Map<string, Set<string>>()
+  const schematicTraceIdToSourceTraceId = new Map<string, string>()
+  const traceIdToKeys = new Map<string, Set<string>>()
+  const keyToTraceIds = new Map<string, Set<string>>()
+  const sourcePortSelectorToPortId = new Map<string, string>()
+  const sourcePortIdToConnectivityKey = new Map<string, string>()
+
+  const sourceComponentNameById = new Map<string, string>()
+
+  for (const sourceComponent of getElementsByType(
+    circuitJson,
+    "source_component",
+  )) {
+    if (sourceComponent.source_component_id && sourceComponent.name) {
+      sourceComponentNameById.set(
+        sourceComponent.source_component_id,
+        sourceComponent.name,
+      )
+    }
+  }
+
+  for (const sourcePort of getElementsByType(circuitJson, "source_port")) {
+    const sourcePortId = sourcePort.source_port_id as string | undefined
+    if (!sourcePortId) continue
+
+    const sourceComponentName = sourceComponentNameById.get(
+      sourcePort.source_component_id,
+    )
+
+    for (const selector of [
+      sourcePort.name,
+      sourcePort.pin_number,
+      ...(sourcePort.port_hints ?? []),
+    ]) {
+      addSourcePortKey(
+        sourcePortSelectorToPortId,
+        sourceComponentName,
+        selector,
+        sourcePortId,
+      )
+    }
+
+    if (sourcePort.subcircuit_connectivity_map_key) {
+      sourcePortIdToConnectivityKey.set(
+        sourcePortId,
+        sourcePort.subcircuit_connectivity_map_key,
+      )
+    }
+  }
+
+  for (const sourceTrace of getElementsByType(circuitJson, "source_trace")) {
+    const sourceTraceId = sourceTrace.source_trace_id as string | undefined
+    if (!sourceTraceId) continue
+
+    addTraceConnectivityKey(
+      traceIdToKeys,
+      keyToTraceIds,
+      sourceTraceId,
+      `source-trace:${sourceTraceId}`,
+    )
+
+    for (const sourceNetId of getStringArray(
+      sourceTrace.connected_source_net_ids,
+    )) {
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `source-net:${sourceNetId}`,
+      )
+    }
+
+    if (sourceTrace.subcircuit_connectivity_map_key) {
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `connectivity:${sourceTrace.subcircuit_connectivity_map_key}`,
+      )
+    }
+
+    for (const sourcePortId of getStringArray(
+      sourceTrace.connected_source_port_ids,
+    )) {
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `source-port:${sourcePortId}`,
+      )
+      const connectivityKey = sourcePortIdToConnectivityKey.get(sourcePortId)
+      if (connectivityKey) {
+        addTraceConnectivityKey(
+          traceIdToKeys,
+          keyToTraceIds,
+          sourceTraceId,
+          `connectivity:${connectivityKey}`,
+        )
+      }
+    }
+  }
+
+  for (const schematicTrace of getElementsByType(
+    circuitJson,
+    "schematic_trace",
+  )) {
+    const schematicTraceId = schematicTrace.schematic_trace_id as
+      | string
+      | undefined
+    const sourceTraceId = schematicTrace.source_trace_id as string | undefined
+    if (!schematicTraceId || !sourceTraceId) continue
+
+    schematicTraceIdToSourceTraceId.set(schematicTraceId, sourceTraceId)
+    addToSetMap(
+      sourceTraceIdToSchematicTraceIds,
+      sourceTraceId,
+      schematicTraceId,
+    )
+
+    addTraceConnectivityKey(
+      traceIdToKeys,
+      keyToTraceIds,
+      sourceTraceId,
+      `source-trace:${sourceTraceId}`,
+    )
+
+    if (schematicTrace.subcircuit_connectivity_map_key) {
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `connectivity:${schematicTrace.subcircuit_connectivity_map_key}`,
+      )
+    }
+
+    for (const sourceNetId of getStringArray(
+      schematicTrace.connected_source_net_ids,
+    )) {
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `source-net:${sourceNetId}`,
+      )
+    }
+
+    for (const sourcePortSelector of getSourcePortSelectorsFromSolverTraceId(
+      sourceTraceId,
+    )) {
+      const sourcePortId =
+        sourcePortSelectorToPortId.get(sourcePortSelector) ??
+        (sourcePortIdToConnectivityKey.has(sourcePortSelector)
+          ? sourcePortSelector
+          : undefined)
+      if (!sourcePortId) continue
+
+      addTraceConnectivityKey(
+        traceIdToKeys,
+        keyToTraceIds,
+        sourceTraceId,
+        `source-port:${sourcePortId}`,
+      )
+
+      const connectivityKey = sourcePortIdToConnectivityKey.get(sourcePortId)
+      if (connectivityKey) {
+        addTraceConnectivityKey(
+          traceIdToKeys,
+          keyToTraceIds,
+          sourceTraceId,
+          `connectivity:${connectivityKey}`,
+        )
+      }
+    }
+  }
+
+  const connectedSchematicTraceIdsByTraceId = new Map<string, Set<string>>()
+
+  for (const [
+    schematicTraceId,
+    sourceTraceId,
+  ] of schematicTraceIdToSourceTraceId) {
+    const connectedSchematicTraceIds = new Set<string>()
+    const connectedSourceTraceIds = getConnectedSourceTraceIds(
+      sourceTraceId,
+      traceIdToKeys,
+      keyToTraceIds,
+    )
+
+    for (const connectedSourceTraceId of connectedSourceTraceIds) {
+      for (const connectedSchematicTraceId of sourceTraceIdToSchematicTraceIds.get(
+        connectedSourceTraceId,
+      ) ?? []) {
+        connectedSchematicTraceIds.add(connectedSchematicTraceId)
+      }
+    }
+
+    if (connectedSchematicTraceIds.size === 0) {
+      connectedSchematicTraceIds.add(schematicTraceId)
+    }
+
+    connectedSchematicTraceIdsByTraceId.set(
+      schematicTraceId,
+      connectedSchematicTraceIds,
+    )
+  }
+
+  return connectedSchematicTraceIdsByTraceId
+}

--- a/tests/use-highlight-connected-traces-on-hover.test.ts
+++ b/tests/use-highlight-connected-traces-on-hover.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "bun:test"
+import { getConnectedSchematicTraceIdsByHoveredTrace } from "../lib/utils/getConnectedSchematicTraceIdsByHoveredTrace"
+
+const sorted = (values: Set<string> | undefined) =>
+  Array.from(values ?? []).sort()
+
+test("groups schematic traces through shared source net ids", () => {
+  const groups = getConnectedSchematicTraceIdsByHoveredTrace([
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_net_ids: ["source_net_gnd"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_net_ids: ["source_net_gnd"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_net_ids: ["source_net_vcc"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_3",
+      source_trace_id: "source_trace_3",
+    },
+  ] as any)
+
+  expect(sorted(groups.get("schematic_trace_1"))).toEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+  expect(sorted(groups.get("schematic_trace_3"))).toEqual(["schematic_trace_3"])
+})
+
+test("falls back to connected source ports when source nets are missing", () => {
+  const groups = getConnectedSchematicTraceIdsByHoveredTrace([
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_shared", "source_port_a"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_shared", "source_port_b"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_2",
+    },
+  ] as any)
+
+  expect(sorted(groups.get("schematic_trace_1"))).toEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+})
+
+test("groups multiple schematic segments from the same source trace", () => {
+  const groups = getConnectedSchematicTraceIdsByHoveredTrace([
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_1",
+      source_trace_id: "source_trace_1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_2",
+      source_trace_id: "source_trace_1",
+    },
+  ] as any)
+
+  expect(sorted(groups.get("schematic_trace_1"))).toEqual([
+    "schematic_trace_1",
+    "schematic_trace_2",
+  ])
+})
+
+test("resolves solver-generated source trace ids through source port connectivity", () => {
+  const groups = getConnectedSchematicTraceIdsByHoveredTrace([
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      name: "R1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_c1",
+      name: "C1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      subcircuit_connectivity_map_key: "connectivity_gnd",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_c1_1",
+      source_component_id: "source_component_c1",
+      name: "pin1",
+      pin_number: 1,
+      subcircuit_connectivity_map_key: "connectivity_gnd",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_direct",
+      connected_source_port_ids: ["source_port_c1_1"],
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_solver",
+      source_trace_id: "solver_R1.1-C1.1",
+    },
+    {
+      type: "schematic_trace",
+      schematic_trace_id: "schematic_trace_direct",
+      source_trace_id: "source_trace_direct",
+    },
+  ] as any)
+
+  expect(sorted(groups.get("schematic_trace_solver"))).toEqual([
+    "schematic_trace_direct",
+    "schematic_trace_solver",
+  ])
+})


### PR DESCRIPTION
## Summary

Fixes trace hover highlighting so hovering a schematic trace highlights every rendered trace segment connected to the same source net/connectivity group, instead of only the hovered trace element.

Linked issue: tscircuit/tscircuit#1130

## Changes

- Added a schematic trace hover hook that delegates pointer events from the SVG container and toggles a data attribute on all same-net schematic trace elements.
- Added a connectivity utility that groups schematic traces by source trace, source net, connected source ports, subcircuit connectivity keys, and solver-generated source trace ids.
- Added a focused Cosmos fixture with split GND traces and an unrelated signal trace for manual/browser verification.
- Added unit coverage for shared source nets, source-port fallback, same source trace segments, and solver-generated source trace ids.

## Validation

- `biome check lib/components/SchematicViewer.tsx lib/hooks/useHighlightConnectedTracesOnHover.ts lib/utils/getConnectedSchematicTraceIdsByHoveredTrace.ts tests/use-highlight-connected-traces-on-hover.test.ts examples/example21-connected-trace-hover.fixture.tsx`
- Focused TypeScript check over touched files with `tsc --noEmit --skipLibCheck --moduleResolution bundler --module ESNext --target ES2020 --jsx react-jsx --lib ESNext,DOM --baseUrl . ...`
- Browser verification in Cosmos: hovering `schematic_trace_gnd_left` marks `schematic_trace_gnd_left` and `schematic_trace_gnd_right`, while `schematic_trace_signal` remains unhighlighted; moving away clears hover state.

Note: full repo `tsc --noEmit` is currently blocked locally by an unrelated existing error in `examples/example15-analog-simulation-viewer.fixture.tsx` around `simSwitchFrequency`.