### PR TITLE
Render ammeter transient current graphs in AnalogSimulationViewer

### DIFF
--- a/examples/example22-ammeter-current-probe.fixture.tsx
+++ b/examples/example22-ammeter-current-probe.fixture.tsx
@@ -1,0 +1,142 @@
+import React from "react"
+import { AnalogSimulationViewer } from "../lib/components/AnalogSimulationViewer"
+import * as Core from "@tscircuit/core"
+import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
+
+// TSX circuit definition
+const AmmeterCircuitElement = (
+  <board width="10mm" height="10mm" schMaxTraceDistance={10} routingDisabled>
+    <voltagesource name="V1" voltage="15V" schX={-3} />
+    <ammeter
+      name="AM1"
+      color="#ff0000"
+      connections={{
+        pos: ".V1 > .pin1",
+        neg: ".R1 > .pin1",
+      }}
+    />
+    <resistor name="R1" resistance="2" schX={3} />
+    <trace from=".R1 > .pin2" to=".V1 > .pin2" />
+    <voltageprobe
+      name="VOUT"
+      color="#315cff"
+      connectsTo=".R1 > .pin1"
+      referenceTo=".V1 > .pin2"
+    />
+    <analogsimulation
+      duration="1ms"
+      timePerStep="100us"
+      spiceEngine="ngspice"
+    />
+  </board>
+)
+
+// Convert TSX to CircuitJSON and add simulation data
+const createSimulatedCircuitJson = async () => {
+  try {
+    // Step 1: Create circuit with platform configuration
+    const circuit = new Core.Circuit()
+
+    const ngspiceEngine = await createNgspiceSpiceEngine()
+    circuit.setPlatform({
+      spiceEngineMap: {
+        ngspice: ngspiceEngine,
+      },
+    })
+
+    // Step 2: Add the circuit element
+    circuit.add(AmmeterCircuitElement)
+    await circuit.renderUntilSettled()
+
+    // Step 3: Get CircuitJSON (includes simulation data if produced by the platform)
+    return circuit.getCircuitJson()
+  } catch (error) {
+    console.error("Simulation failed:", error)
+    // Return basic CircuitJSON if simulation fails
+    const fallbackCircuit = new Core.Circuit()
+    fallbackCircuit.add(AmmeterCircuitElement)
+    await fallbackCircuit.renderUntilSettled()
+    return fallbackCircuit.getCircuitJson()
+  }
+}
+
+export default () => {
+  const [simulatedCircuitJson, setSimulatedCircuitJson] = React.useState<
+    any[] | null
+  >(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const loadAndSimulateCircuit = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+
+        const result = await createSimulatedCircuitJson()
+        setSimulatedCircuitJson(result)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load circuit")
+        console.error("Error loading circuit:", err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadAndSimulateCircuit()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <h2>Ammeter & Current Probe Example</h2>
+        <p>Converting TSX to CircuitJSON and running SPICE simulation...</p>
+        <div
+          style={{
+            display: "inline-block",
+            padding: "20px",
+            backgroundColor: "#f5f5f5",
+            borderRadius: "8px",
+            marginTop: "20px",
+          }}
+        >
+          Loading and simulating circuit...
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <h2>Ammeter & Current Probe Example</h2>
+        <div
+          style={{
+            display: "inline-block",
+            padding: "20px",
+            backgroundColor: "#fef2f2",
+            borderRadius: "8px",
+            border: "1px solid #fecaca",
+            color: "#dc2626",
+            marginTop: "20px",
+          }}
+        >
+          <h4>Error:</h4>
+          <p>{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    simulatedCircuitJson && (
+      <AnalogSimulationViewer
+        circuitJson={simulatedCircuitJson}
+        containerStyle={{
+          width: "100vw",
+          height: "100vh",
+        }}
+      />
+    )
+  )
+}

--- a/lib/components/AnalogSimulationViewer.tsx
+++ b/lib/components/AnalogSimulationViewer.tsx
@@ -79,11 +79,18 @@ export const AnalogSimulationViewer = ({
   }, [circuitJson])
 
   // Find simulation graph IDs from circuit JSON
-  const simulationGraphIds = useMemo(() => {
+  const simulationVoltageGraphIds = useMemo(() => {
     if (!circuitJson) return []
     return circuitJson
       .filter((el) => el.type === "simulation_transient_voltage_graph")
       .map((el) => el.simulation_transient_voltage_graph_id)
+  }, [circuitJson])
+
+  const simulationCurrentGraphIds = useMemo(() => {
+    if (!circuitJson) return []
+    return circuitJson
+      .filter((el) => el.type === "simulation_transient_current_graph")
+      .map((el) => el.simulation_transient_current_graph_id)
   }, [circuitJson])
 
   // Generate SVG from CircuitJSON
@@ -100,7 +107,8 @@ export const AnalogSimulationViewer = ({
       return convertCircuitJsonToSchematicSimulationSvg({
         circuitJson,
         simulation_experiment_id: simulationExperimentId,
-        simulation_transient_voltage_graph_ids: simulationGraphIds,
+        simulation_transient_current_graph_ids: simulationCurrentGraphIds,
+        simulation_transient_voltage_graph_ids: simulationVoltageGraphIds,
         width: effectiveWidth,
         height: effectiveHeight,
         schematicOptions: { colorOverrides },
@@ -115,7 +123,8 @@ export const AnalogSimulationViewer = ({
     effectiveHeight,
     colorOverrides,
     simulationExperimentId,
-    simulationGraphIds,
+    simulationCurrentGraphIds,
+    simulationVoltageGraphIds,
   ])
 
   // Create/revoke object URL whenever the SVG changes


### PR DESCRIPTION
## Summary

`AnalogSimulationViewer` rendered simulation results by collecting only `simulation_transient_voltage_graph` IDs and forwarding them to `convertCircuitJsonToSchematicSimulationSvg`. Any `simulation_transient_current_graph` produced by an `<ammeter />` was silently dropped, so ammeter current waveforms never appeared in the viewer even though the simulation generated them.

<img width="1537" height="786" alt="image" src="https://github.com/user-attachments/assets/fd9c9fbc-6d98-4717-b4f7-c20262d1c721" />


## Changes

- Collect `simulation_transient_current_graph_id`s from the circuit JSON alongside the existing voltage-graph IDs.
- Pass `simulation_transient_current_graph_ids` through to `convertCircuitJsonToSchematicSimulationSvg` so current waveforms are rendered into the schematic simulation SVG.
- Rename `simulationGraphIds` -> `simulationVoltageGraphIds` to make the voltage vs. current distinction explicit, and include both in the `useMemo` dependency arrays so the SVG regenerates when either changes.

## Reproduction

Added `examples/example22-ammeter-current-probe.fixture.tsx`: a voltage source feeding a resistor through an ammeter (`AM1`), with a `VOUT` voltage probe. Before this change the ammeter's current graph was absent from the rendered simulation; after it, both the current and voltage waveforms render.

## Before / After

| | Voltage graphs | Current graphs |
|---|---|---|
| Before | rendered | dropped |
| After | rendered | rendered |
