### PR TITLE
feat: add schematic sheet selector to switch between sheets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "chart.js": "^4.5.0",
         "debug": "^4.4.0",
         "performance-now": "^2.1.0",
@@ -24,7 +26,7 @@
         "react-dom": "^19.1.0",
         "react-reconciler": "^0.31.0",
         "semver": "^7.7.2",
-        "tscircuit": "^0.0.1938",
+        "tscircuit": "^0.0.1972",
         "tsup": "^8.3.5",
         "vite": "^6.0.3",
       },
@@ -152,6 +154,14 @@
 
     "@flatten-js/interval-tree": ["@flatten-js/interval-tree@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-Lv3eaITqU20WD+5W8L7JeJdjDXC9hfTUEzY0cRLx/sXj1+P3XdK6Fig4UdxvsekakTK8XeOwnpAKEpTI728U4g=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@gltf-transform/core": ["@gltf-transform/core@4.4.0", "", { "dependencies": { "property-graph": "^4.1.0" } }, "sha512-cOPxOhHFFz5hwmix+li1+Nnq5qMV/QD3fTCsVlApxxFACtFdjkt2R/juseD4gvZ7D2c/yl6OilKH0pvI735YyQ=="],
 
     "@gltf-transform/extensions": ["@gltf-transform/extensions@4.4.0", "", { "dependencies": { "@gltf-transform/core": "^4.4.0", "ktx-parse": "^1.1.0" } }, "sha512-ZwEgFkkqnUR7d4m6roK9BycxxdoqJNtVyo7w5ShJ9syKBoQiXw2QrTSLwXaUAImSrEIl9Jh/wZTtvSVyviQuXg=="],
@@ -231,6 +241,58 @@
     "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.10", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-escape-keydown": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg=="],
+
+    "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.18", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-menu": "2.1.18", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.18", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.13", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.10", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-popper": "1.3.1", "@radix-ui/react-portal": "1.1.12", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-roving-focus": "1.1.13", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-callback-ref": "1.1.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.3.1", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-rect": "1.1.2", "@radix-ui/react-use-size": "1.1.2", "@radix-ui/rect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.12", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
+
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.2", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.2", "", { "dependencies": { "@radix-ui/rect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.2", "", {}, "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="],
 
     "@react-hook/latest": ["@react-hook/latest@1.0.3", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="],
 
@@ -342,17 +404,17 @@
 
     "@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.583", "", { "dependencies": { "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0" } }, "sha512-uSbZct2KuSz5PsS4gcYozhqPlyVx6FhvCZpGX8nBC/b0Xcej+RwZ3O7z6gIpVaj4MO4/iC/3E5TkhKAe3Upwrg=="],
 
-    "@tscircuit/checks": ["@tscircuit/checks@0.0.138", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-NN84PSdV5Tem9+NpNrereoXHwDg8FHssdY8x1l7Bz8lO5gkYc8HzgUrEpjIhwBqgpe4oELMnwnQ6r3ebXTAs0Q=="],
+    "@tscircuit/checks": ["@tscircuit/checks@0.0.140", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-2E4NU0SCbuwlSxrWOXwycUJLJtGORQaCSc4nyNlqaKZkoFESS+SrK6icpOb57P6efDSpetyUNeDNf26cV39rIg=="],
 
     "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.96", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-/D5lEPuW77xYESswlufGmJkxh0V4d6aYHA4E1k5ta/erYBZyXGr6Fw8f/cl1lcO1GYo/TWwy6aB8LiNkAVZQTw=="],
 
-    "@tscircuit/cli": ["@tscircuit/cli@0.1.1550", "", { "peerDependencies": { "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-fck64oVV8cEplOemeYfpuZ3zLwAHGVsfCmVt9++I+50kFfBzBiaHwKzDU2DPKLFYM2cgeJpYFd2MqJ2D80uKkA=="],
+    "@tscircuit/cli": ["@tscircuit/cli@0.1.1575", "", { "peerDependencies": { "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-lQiOKEPjzwUOb8xj7gxdygpgla5BBNJ7Y4/AQlhX2GGl27oNSuXczCTNPRqhcaSM9bBjpfS3L48JzzN8IRVEBg=="],
 
-    "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.29", "", { "dependencies": { "manifold-3d": "^3.4.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-hFg69kJu/dBMLzCdaKYAShxvn6e3Wf92sUmTzhnz2oT62YS/0uPL8uqDe5agYblYV/fnADBaV28UvzTFbl8UwA=="],
+    "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.35", "", { "dependencies": { "manifold-3d": "^3.4.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-HASJmL7Uj20ZlAcXoH2c+aJkwhUnxZmHNXYJfPQSBWB3qSzWR7jIYfFyfRtyGPe2xpnmuiF/j0d4mwE/0vK2rg=="],
 
-    "@tscircuit/core": ["@tscircuit/core@0.0.1352", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.13", "calculate-packing": "0.0.75", "css-select": "5.1.0", "format-si-unit": "^0.0.7", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "schematic-symbols": "*", "typescript": "^5.0.0" } }, "sha512-Qc1VePBaD2h/cRM4kVgjaANrSywnFRlpz8ku5Mio39nQaxVdiiYj9DvpllLE2IiiLQWcxjhawizTh/lsp3KEWA=="],
+    "@tscircuit/core": ["@tscircuit/core@0.0.1369", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.13", "calculate-packing": "0.0.75", "css-select": "5.1.0", "format-si-unit": "^0.0.7", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "schematic-symbols": "*", "typescript": "^5.0.0" } }, "sha512-MFE6/acCDORiurvFC4eofyFm3gdtGPabeNR1bGZwqhMbl8RtTlOyd3iy3237YV788qE0H+m/OL+x/mX4AMzsrg=="],
 
-    "@tscircuit/eval": ["@tscircuit/eval@0.0.948", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-4RQZA10dNB1H3oY5CWok/2ftnhHZbTGswsosu9ZCH3wRSUurfIk6TXPwIx5uw2Kp2fYFuQIEAhz0+b0R7XwQ0A=="],
+    "@tscircuit/eval": ["@tscircuit/eval@0.0.960", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-39t6hSDtRIuXpiyyDMnqHM194PXvW278lhy/J4UeL3zMz/bnn1aikK6K1JManu2ct/78XmpIDhdL9C98jQk0gg=="],
 
     "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.357", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-N4QjwY+GkRm1DvPDWQbTq+sRJU59v+ahMxiAIGemBJsoPVFjodVOnu50oN8q41ps4mCXQMS8/16blbLWkZlBkw=="],
 
@@ -366,7 +428,7 @@
 
     "@tscircuit/krt-wasm": ["@tscircuit/krt-wasm@0.1.6", "", { "peerDependencies": { "tscircuit": "*" } }, "sha512-XRj8SIgWro1t56TieLhkOtRVsptq3cwzBtdbDEkRB2YiyX4V/r0zneii+c5I8F3D8rJUz4+GswGpPeO4eV8x8w=="],
 
-    "@tscircuit/matchpack": ["@tscircuit/matchpack@0.0.24", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-wRrk83y1NPPkUBmMNxXNQyaQ4Oau8HoIgD0Y/oRKFzbnG0ZD1ZnKUoXJ88Uix2tkoNrroV7ZbsQAvqQ/6GxUNg=="],
+    "@tscircuit/matchpack": ["@tscircuit/matchpack@0.0.29", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-CxKD3G7ZlW7AUuUIbc6iwHs0mM6JGt6UYukWe0r/66mdfYvwWil3UPHyhNR4PC8rlrgm1jN8nk78A0gJz+7KwA=="],
 
     "@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.36", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HwHS3do6CLQFnLGd0f3+kQzGfENFllpt5ZFWF9gfw2k5Rc5VSxSJi8/MLfHEgaMgrnMCZ5Hqh3DlUD6U3pMXyg=="],
 
@@ -376,9 +438,9 @@
 
     "@tscircuit/ngspice-spice-engine": ["@tscircuit/ngspice-spice-engine@0.0.18", "", { "peerDependencies": { "@tscircuit/props": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-2Yb5nDlZvcBtjAhQuW2VkZmz+tmIDRyxR7cxH7ucioU+hyq7DkihFUp6rITQEY+2+5qKuoXgjVFOv7LxiTgreA=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.553", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-ZzOgY7z2CmoTGLWrITaDH44tFlW1sMcXLQ1/v41LgoZNnqrsYwutn+F0bg6LqE7um1glhmVQhvnzh9hKf+Eb4w=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.565", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-J5FJAe82CpOYUCTkDrRsxweUoZAZDPGrPXmgCQFAfOHTW5zfmTq8W+2bhIzSTNJDOdjgMewOtJp9LORc8hOTfQ=="],
 
-    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.2114", "", { "dependencies": { "@tscircuit/eval": "^0.0.948", "@tscircuit/solver-utils": "^0.0.7" } }, "sha512-0nHOBqpoPW6zF6zcFBJem7HCdEPf6dnzWxkrEACfFg/fIOhUCE87dAxzXAfelV0587eKKhGeWmEdxCTN2K4Erg=="],
+    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.2134", "", { "dependencies": { "@tscircuit/eval": "^0.0.960", "@tscircuit/solver-utils": "^0.0.7" } }, "sha512-aojslHepIr8zcdSSy8GdaJXLwz/sj7vtvXkv87cysLOFWaYq5/e/g8Vun7o2RAyaXRYmvWyQIFFMBVU6eURk+Q=="],
 
     "@tscircuit/schematic-corpus": ["@tscircuit/schematic-corpus@0.0.114", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-jDQX+XDXP6PklB39X8AwUSuiqGRdn78esy1wD/qG8U3cCXkT5rtE3ousDVaKRxclCeED8FxJlD+ZvRtAe8mw8w=="],
 
@@ -466,6 +528,8 @@
 
     "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
@@ -540,7 +604,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.438", "", {}, "sha512-aZiroCeGymKFRZcKzSGA6Ojzjz252NJXBNaRnLn2FjWNmsRm38Kyb3rJWnHt5ALyAobsXCzE51Fn5Hy04WrFaQ=="],
+    "circuit-json": ["circuit-json@0.0.443", "", {}, "sha512-DEZHyM9aTKd7Kew3wXROIK6xIXPDE4NMUISF6BRlGwsY6/xlJSX0qkIpdbMvGbD2uMX3G4/psfaeCG2M9CsCGA=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 
@@ -552,7 +616,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.39", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-fRbVa7Xmqf4Gd6LQbIaceFYif04aDd92IKmOtj4JRIzoHf29Kk9ta95MebWWULOjg+igboKrhtBBvalE24nvQg=="],
 
-    "circuit-to-svg": ["circuit-to-svg@0.0.360", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-IkCttIdppzqkh8D53uRxjaxaE9TjpUYFTSzxvj7SIMb7UMABOFQ4xAMzfz8NqzObTiMwi9KPsbkn/aki2PFaRQ=="],
+    "circuit-to-svg": ["circuit-to-svg@0.0.367", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-0d5WLeztsE01ZxBagtQ+9TvNx9FjL3d1Uegug/E6KAtpN2xV1zO3AVu93qMSytJGUhc2gOrsSpyBQfA6MsKeCg=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -647,6 +711,8 @@
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -757,6 +823,8 @@
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
@@ -1060,9 +1128,15 @@
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-router": ["react-router@6.30.4", "", { "dependencies": { "@remix-run/router": "1.23.3" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA=="],
 
     "react-router-dom": ["react-router-dom@6.30.4", "", { "dependencies": { "@remix-run/router": "1.23.3", "react-router": "6.30.4" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-supergrid": ["react-supergrid@1.0.10", "", { "peerDependencies": { "react": "*", "react-dom": "*", "transformation-matrix": "*" } }, "sha512-dJd9wkH6BJkdfkv62EcRAIBn59e2wj58bJFVXiW/ZHQzxz20qIql63fTU2qFMOujXnBIDaMG0uTod67/mjEGeA=="],
 
@@ -1202,7 +1276,7 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "tscircuit": ["tscircuit@0.0.1938", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "@resvg/resvg-js": "^2.6.2", "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.3", "@rollup/plugin-typescript": "^12.3.0", "@tscircuit/alphabet": "0.0.25", "@tscircuit/capacity-autorouter": "^0.0.583", "@tscircuit/checks": "0.0.138", "@tscircuit/circuit-json-util": "^0.0.96", "@tscircuit/cli": "^0.1.1547", "@tscircuit/copper-pour-solver": "^0.0.29", "@tscircuit/core": "^0.0.1352", "@tscircuit/eval": "^0.0.948", "@tscircuit/footprinter": "^0.0.357", "@tscircuit/image-utils": "^0.0.8", "@tscircuit/infer-cable-insertion-point": "^0.0.2", "@tscircuit/infgrid-ijump-astar": "^0.0.35", "@tscircuit/internal-dynamic-import": "^0.0.2", "@tscircuit/krt-wasm": "^0.1.1", "@tscircuit/matchpack": "", "@tscircuit/math-utils": "^0.0.36", "@tscircuit/miniflex": "^0.0.4", "@tscircuit/ngspice-spice-engine": "^0.0.18", "@tscircuit/props": "^0.0.553", "@tscircuit/runframe": "^0.0.2114", "@tscircuit/schematic-match-adapt": "^0.0.18", "@tscircuit/schematic-trace-solver": "^0.0.72", "@tscircuit/simple-3d-svg": "^0.0.41", "@tscircuit/solver-utils": "^0.0.16", "@tscircuit/soup-util": "^0.0.41", "bpc-graph": "^0.0.57", "calculate-cell-boundaries": "^0.0.13", "calculate-elbow": "^0.0.12", "calculate-packing": "0.0.75", "circuit-json": "^0.0.438", "circuit-json-to-bpc": "^0.0.13", "circuit-json-to-connectivity-map": "^0.0.23", "circuit-json-to-gltf": "^0.0.105", "circuit-json-to-simple-3d": "^0.0.9", "circuit-json-to-spice": "^0.0.39", "circuit-to-svg": "^0.0.360", "comlink": "^4.4.2", "connectivity-map": "^1.0.0", "css-select": "5.1.0", "debug": "^4.3.6", "flatbush": "^4.5.0", "format-si-unit": "^0.0.7", "graphics-debug": "^0.0.95", "jscad-planner": "^0.0.13", "kicad-component-converter": "^0.1.40", "kicad-to-circuit-json": "^0.0.97", "kicadts": "^0.0.47", "manifold-3d": "^3.4.1", "minicssgrid": "^0.0.9", "performance-now": "^2.1.0", "poppygl": "^0.0.24", "react": "^19.1.0", "react-dom": "^19.1.0", "rollup": "^4.53.2", "rollup-plugin-dts": "^6.2.3", "s-expression": "^3.1.1", "schematic-symbols": "^0.0.226", "spicets": "^0.0.2", "spicey": "^0.0.14", "sucrase": "^3.35.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "tslib": "^2.8.1", "zod": "^3.25.67" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "tsci": "cli.mjs", "tscircuit": "cli.mjs" } }, "sha512-oFyvuJIwzhLV78yLSE3r5rPeuxafDQpEYaXCsIomhOckWRuGOiiKrIFyfRN2Ro1puU352l3IU56li0QAYNtD9g=="],
+    "tscircuit": ["tscircuit@0.0.1972", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "@resvg/resvg-js": "^2.6.2", "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.3", "@rollup/plugin-typescript": "^12.3.0", "@tscircuit/alphabet": "0.0.25", "@tscircuit/capacity-autorouter": "^0.0.583", "@tscircuit/checks": "0.0.140", "@tscircuit/circuit-json-util": "^0.0.96", "@tscircuit/cli": "^0.1.1575", "@tscircuit/copper-pour-solver": "0.0.35", "@tscircuit/core": "^0.0.1369", "@tscircuit/eval": "^0.0.960", "@tscircuit/footprinter": "^0.0.357", "@tscircuit/image-utils": "^0.0.8", "@tscircuit/infer-cable-insertion-point": "^0.0.2", "@tscircuit/infgrid-ijump-astar": "^0.0.35", "@tscircuit/internal-dynamic-import": "^0.0.2", "@tscircuit/krt-wasm": "^0.1.1", "@tscircuit/matchpack": "^0.0.29", "@tscircuit/math-utils": "^0.0.36", "@tscircuit/miniflex": "^0.0.4", "@tscircuit/ngspice-spice-engine": "^0.0.18", "@tscircuit/props": "^0.0.565", "@tscircuit/runframe": "^0.0.2134", "@tscircuit/schematic-match-adapt": "^0.0.18", "@tscircuit/schematic-trace-solver": "^0.0.72", "@tscircuit/simple-3d-svg": "^0.0.41", "@tscircuit/solver-utils": "^0.0.16", "@tscircuit/soup-util": "^0.0.41", "bpc-graph": "^0.0.57", "calculate-cell-boundaries": "^0.0.13", "calculate-elbow": "^0.0.12", "calculate-packing": "0.0.75", "circuit-json": "^0.0.443", "circuit-json-to-bpc": "^0.0.13", "circuit-json-to-connectivity-map": "^0.0.23", "circuit-json-to-gltf": "^0.0.105", "circuit-json-to-simple-3d": "^0.0.9", "circuit-json-to-spice": "^0.0.40", "circuit-to-svg": "^0.0.367", "comlink": "^4.4.2", "connectivity-map": "^1.0.0", "css-select": "5.1.0", "debug": "^4.3.6", "flatbush": "^4.5.0", "format-si-unit": "^0.0.7", "graphics-debug": "^0.0.95", "jscad-planner": "^0.0.13", "kicad-component-converter": "^0.1.40", "kicad-to-circuit-json": "^0.0.97", "kicadts": "^0.0.47", "manifold-3d": "^3.4.1", "minicssgrid": "^0.0.9", "performance-now": "^2.1.0", "poppygl": "^0.0.24", "react": "^19.1.0", "react-dom": "^19.1.0", "rollup": "^4.53.2", "rollup-plugin-dts": "^6.2.3", "s-expression": "^3.1.1", "schematic-symbols": "^0.0.226", "spicets": "^0.0.2", "spicey": "^0.0.14", "sucrase": "^3.35.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "tslib": "^2.8.1", "zod": "^3.25.67" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "tsci": "cli.mjs", "tscircuit": "cli.mjs" } }, "sha512-m+aPXJWkfp0YfBFM7BH9JIArGv9vh8Ejzejf/gwDgz1n4AApIVrbLgrDbPVnzqSClHKexZpU+IsP9kEiJiKEcw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1226,7 +1300,11 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
     "use-mouse-matrix-transform": ["use-mouse-matrix-transform@1.3.5", "", { "dependencies": { "transformation-matrix": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-Ng938MFw/1kmxqQYORBIzC50KAekVLLtY3aepGbrzHehoNvbE75afOo3APxGk+kR3cVKKc3H8fW6vjbNY5J5tw=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
@@ -1316,6 +1394,8 @@
 
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "jscad-electronics/circuit-json": ["circuit-json@0.0.438", "", {}, "sha512-aZiroCeGymKFRZcKzSGA6Ojzjz252NJXBNaRnLn2FjWNmsRm38Kyb3rJWnHt5ALyAobsXCzE51Fn5Hy04WrFaQ=="],
+
     "kicad-to-circuit-json/schematic-symbols": ["schematic-symbols@0.0.202", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-zMdY7VaEg2Sc25T0h9LkWttEoyxGamgBfFDQKUXtYRoLSChrNDOKbNLaxU/GH2L2GbsasV8OLiHyHGb5u7NUpg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -1339,6 +1419,8 @@
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "tscircuit/circuit-json-to-spice": ["circuit-json-to-spice@0.0.40", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-rER9mfZezQ6fh93An9TNCpALoLVbnrQezk6X2Lj0hAe1SPHbpthbVGHTpoxHlfq2hfdHSbaF7kO5jl/spdVtmQ=="],
 
     "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -1395,6 +1477,8 @@
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "tscircuit/circuit-json-to-spice/circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
 
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -1455,6 +1539,8 @@
     "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "tscircuit/circuit-json-to-spice/circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
 
     "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/examples/example23-multiple-schematic-sheets.fixture.tsx
+++ b/examples/example23-multiple-schematic-sheets.fixture.tsx
@@ -71,11 +71,11 @@ const RcFilter = (props: SubcircuitProps) => (
 
 const circuitJson = renderToCircuitJson(
   <board routingDisabled>
-    <schematicsheet name="Sheet 1" displayName="LED Driver" sheetIndex={0} />
-    <schematicsheet name="Sheet 2" displayName="RC Filter" sheetIndex={1} />
+    <schematicsheet name="LED Driver" displayName="LED Driver" sheetIndex={0} />
+    <schematicsheet name="RC Filter" displayName="RC Filter" sheetIndex={1} />
 
-    <LedDriver name="DRV" schSheetName="Sheet 1" />
-    <RcFilter name="FLT" schSheetName="Sheet 2" />
+    <LedDriver name="DRV" schSheetName="LED Driver" />
+    <RcFilter name="FLT" schSheetName="RC Filter" />
   </board>,
 )
 

--- a/examples/example23-multiple-schematic-sheets.fixture.tsx
+++ b/examples/example23-multiple-schematic-sheets.fixture.tsx
@@ -1,0 +1,96 @@
+import type { SubcircuitProps } from "@tscircuit/props"
+import { SchematicViewer } from "lib/components/SchematicViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+/**
+ * A generic LED driver block placed on its own schematic sheet.
+ */
+const LedDriver = (props: SubcircuitProps) => (
+  <subcircuit {...props}>
+    <chip
+      name="U1"
+      footprint="soic4"
+      pinLabels={{ pin1: "VCC", pin2: "GND", pin3: "IN", pin4: "OUT" }}
+      schPinArrangement={{
+        leftSide: { direction: "top-to-bottom", pins: ["VCC", "IN", "GND"] },
+        rightSide: { direction: "top-to-bottom", pins: ["OUT"] },
+      }}
+      connections={{ VCC: "net.VCC", GND: "net.GND" }}
+    />
+    <capacitor
+      name="C_DEC"
+      capacitance="100nF"
+      footprint="0402"
+      connections={{ pin1: "U1.VCC", pin2: "net.GND" }}
+    />
+    <resistor
+      name="R_LED"
+      resistance="330"
+      footprint="0402"
+      connections={{ pin1: "U1.OUT", pin2: "D1.anode" }}
+    />
+    <led name="D1" footprint="0603" connections={{ cathode: "net.GND" }} />
+  </subcircuit>
+)
+
+/**
+ * A generic buffered RC filter block placed on its own schematic sheet.
+ */
+const RcFilter = (props: SubcircuitProps) => (
+  <subcircuit {...props}>
+    <chip
+      name="U1"
+      footprint="soic4"
+      pinLabels={{ pin1: "VCC", pin2: "GND", pin3: "IN", pin4: "OUT" }}
+      schPinArrangement={{
+        leftSide: { direction: "top-to-bottom", pins: ["IN", "VCC", "GND"] },
+        rightSide: { direction: "top-to-bottom", pins: ["OUT"] },
+      }}
+      connections={{ VCC: "net.VCC", GND: "net.GND" }}
+    />
+    <resistor
+      name="R_F"
+      resistance="1k"
+      footprint="0402"
+      connections={{ pin1: "net.SIG_IN", pin2: "U1.IN" }}
+    />
+    <capacitor
+      name="C_F"
+      capacitance="10nF"
+      footprint="0402"
+      connections={{ pin1: "U1.IN", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_OUT"
+      capacitance="1uF"
+      footprint="0402"
+      connections={{ pin1: "U1.OUT", pin2: "net.GND" }}
+    />
+  </subcircuit>
+)
+
+const circuitJson = renderToCircuitJson(
+  <board routingDisabled>
+    <schematicsheet name="Sheet 1" displayName="LED Driver" sheetIndex={0} />
+    <schematicsheet name="Sheet 2" displayName="RC Filter" sheetIndex={1} />
+
+    <LedDriver name="DRV" schSheetName="Sheet 1" />
+    <RcFilter name="FLT" schSheetName="Sheet 2" />
+  </board>,
+)
+
+export default () => {
+  return (
+    <div style={{ position: "relative", height: "100%" }}>
+      <SchematicViewer
+        circuitJson={circuitJson}
+        containerStyle={{
+          width: "100vw",
+          height: "100vh",
+          backgroundColor: "#f8f9fa",
+        }}
+        editingEnabled
+      />
+    </div>
+  )
+}

--- a/lib/components/SchematicSheetSelector.tsx
+++ b/lib/components/SchematicSheetSelector.tsx
@@ -1,12 +1,10 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import type { SchematicSheet } from "circuit-json"
 import { zIndexMap } from "../utils/z-index-map"
-import {
-  getSchematicSheetLabel,
-  type SchematicSheetInfo,
-} from "../utils/schematic-sheet"
+import { getSchematicSheetLabel } from "../utils/schematic-sheet"
 
 interface SchematicSheetSelectorProps {
-  sheets: SchematicSheetInfo[]
+  sheets: SchematicSheet[]
   selectedSheetId: string | undefined
   onSelectSheet: (schematicSheetId: string) => void
 }

--- a/lib/components/SchematicSheetSelector.tsx
+++ b/lib/components/SchematicSheetSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import type { SchematicSheet } from "circuit-json"
 import { zIndexMap } from "../utils/z-index-map"
@@ -107,6 +108,8 @@ export const SchematicSheetSelector = ({
   selectedSheetId,
   onSelectSheet,
 }: SchematicSheetSelectorProps) => {
+  const [open, setOpen] = useState(false)
+
   if (sheets.length <= 1) return null
 
   const selectedSheet = sheets.find(
@@ -117,7 +120,7 @@ export const SchematicSheetSelector = ({
   return (
     <>
       <style>{MENU_CSS}</style>
-      <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Root open={open} onOpenChange={setOpen} modal={false}>
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
@@ -168,7 +171,13 @@ export const SchematicSheetSelector = ({
                   className="sv-sheet-item"
                   style={itemStyles}
                   title={sheet.name}
-                  onSelect={() => onSelectSheet(sheet.schematic_sheet_id)}
+                  // Select on pointerup (fires reliably on touch); Radix's own
+                  // onSelect fires on `click`, which is unreliable on mobile.
+                  onSelect={(e) => e.preventDefault()}
+                  onPointerUp={() => {
+                    onSelectSheet(sheet.schematic_sheet_id)
+                    setOpen(false)
+                  }}
                 >
                   <span style={iconSlotStyles}>
                     {selected && <CheckIcon />}

--- a/lib/components/SchematicSheetSelector.tsx
+++ b/lib/components/SchematicSheetSelector.tsx
@@ -1,7 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import type { SchematicSheet } from "circuit-json"
 import { zIndexMap } from "../utils/z-index-map"
-import { getSchematicSheetLabel } from "../utils/schematic-sheet"
 
 interface SchematicSheetSelectorProps {
   sheets: SchematicSheet[]
@@ -110,13 +109,10 @@ export const SchematicSheetSelector = ({
 }: SchematicSheetSelectorProps) => {
   if (sheets.length <= 1) return null
 
-  const selectedIndex = sheets.findIndex(
+  const selectedSheet = sheets.find(
     (s) => s.schematic_sheet_id === selectedSheetId,
   )
-  const selectedLabel =
-    selectedIndex >= 0
-      ? getSchematicSheetLabel(sheets[selectedIndex], selectedIndex)
-      : "Select sheet"
+  const selectedLabel = selectedSheet?.name ?? "Select sheet"
 
   return (
     <>
@@ -164,22 +160,21 @@ export const SchematicSheetSelector = ({
             sideOffset={8}
             collisionPadding={10}
           >
-            {sheets.map((sheet, index) => {
+            {sheets.map((sheet) => {
               const selected = sheet.schematic_sheet_id === selectedSheetId
-              const label = getSchematicSheetLabel(sheet, index)
               return (
                 <DropdownMenu.Item
                   key={sheet.schematic_sheet_id}
                   className="sv-sheet-item"
                   style={itemStyles}
-                  title={label}
+                  title={sheet.name}
                   onSelect={() => onSelectSheet(sheet.schematic_sheet_id)}
                 >
                   <span style={iconSlotStyles}>
                     {selected && <CheckIcon />}
                   </span>
                   <span style={{ ...ellipsisStyles, minWidth: 0 }}>
-                    {label}
+                    {sheet.name}
                   </span>
                 </DropdownMenu.Item>
               )

--- a/lib/components/SchematicSheetSelector.tsx
+++ b/lib/components/SchematicSheetSelector.tsx
@@ -1,0 +1,194 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { zIndexMap } from "../utils/z-index-map"
+import {
+  getSchematicSheetLabel,
+  type SchematicSheetInfo,
+} from "../utils/schematic-sheet"
+
+interface SchematicSheetSelectorProps {
+  sheets: SchematicSheetInfo[]
+  selectedSheetId: string | undefined
+  onSelectSheet: (schematicSheetId: string) => void
+}
+
+const FONT_FAMILY =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+
+const contentStyles: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  color: "#111111",
+  borderRadius: 8,
+  boxShadow: "0 6px 24px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
+  border: "1px solid #e5e7eb",
+  padding: 4,
+  minWidth: 200,
+  maxWidth: 320,
+  maxHeight: 320,
+  overflowY: "auto",
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+  outline: "none",
+  zIndex: zIndexMap.viewMenu,
+}
+
+const itemStyles: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "7px 10px 7px 8px",
+  borderRadius: 6,
+  cursor: "pointer",
+  outline: "none",
+  userSelect: "none",
+  color: "#111111",
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+}
+
+const iconSlotStyles: React.CSSProperties = {
+  width: 16,
+  height: 16,
+  flexShrink: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#111111",
+}
+
+const ellipsisStyles: React.CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+}
+
+const MENU_CSS = `
+.sv-sheet-item[data-highlighted], .sv-sheet-item:hover { background-color: #f1f3f5; }
+.sv-sheet-chevron { transition: transform 0.2s ease; }
+[data-state="open"] > .sv-sheet-chevron { transform: rotate(180deg); }
+`
+
+const CheckIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
+const ChevronDownIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ opacity: 0.6, flexShrink: 0 }}
+    aria-hidden="true"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+/**
+ * A standalone toolbar dropdown for switching the active schematic sheet.
+ * Rendered only when the circuit has more than one sheet.
+ */
+export const SchematicSheetSelector = ({
+  sheets,
+  selectedSheetId,
+  onSelectSheet,
+}: SchematicSheetSelectorProps) => {
+  if (sheets.length <= 1) return null
+
+  const selectedIndex = sheets.findIndex(
+    (s) => s.schematic_sheet_id === selectedSheetId,
+  )
+  const selectedLabel =
+    selectedIndex >= 0
+      ? getSchematicSheetLabel(sheets[selectedIndex], selectedIndex)
+      : "Select sheet"
+
+  return (
+    <>
+      <style>{MENU_CSS}</style>
+      <DropdownMenu.Root modal={false}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            title={selectedLabel}
+            onPointerDown={(e) => e.stopPropagation()}
+            style={{
+              position: "absolute",
+              top: "16px",
+              left: "16px",
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              maxWidth: "220px",
+              padding: "8px 12px",
+              backgroundColor: "#ffffff",
+              color: "#000000",
+              border: "none",
+              outline: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+              boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+              fontSize: "13px",
+              fontFamily: FONT_FAMILY,
+              zIndex: zIndexMap.viewMenuIcon,
+            }}
+          >
+            <span style={{ color: "#888888", flexShrink: 0 }}>Sheet:</span>
+            <span style={{ ...ellipsisStyles, minWidth: 0 }}>
+              {selectedLabel}
+            </span>
+            <ChevronDownIcon className="sv-sheet-chevron" />
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            style={contentStyles}
+            side="bottom"
+            align="start"
+            sideOffset={8}
+            collisionPadding={10}
+          >
+            {sheets.map((sheet, index) => {
+              const selected = sheet.schematic_sheet_id === selectedSheetId
+              const label = getSchematicSheetLabel(sheet, index)
+              return (
+                <DropdownMenu.Item
+                  key={sheet.schematic_sheet_id}
+                  className="sv-sheet-item"
+                  style={itemStyles}
+                  title={label}
+                  onSelect={() => onSelectSheet(sheet.schematic_sheet_id)}
+                >
+                  <span style={iconSlotStyles}>
+                    {selected && <CheckIcon />}
+                  </span>
+                  <span style={{ ...ellipsisStyles, minWidth: 0 }}>
+                    {label}
+                  </span>
+                </DropdownMenu.Item>
+              )
+            })}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </>
+  )
+}

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -19,7 +19,6 @@ import { useComponentDragging } from "../hooks/useComponentDragging"
 import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
-import { ViewMenuIcon } from "./ViewMenuIcon"
 import { ViewMenu } from "./ViewMenu"
 import type { CircuitJson } from "circuit-json"
 import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
@@ -27,10 +26,18 @@ import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
 import { zIndexMap } from "../utils/z-index-map"
 import { useSpiceSimulation } from "../hooks/useSpiceSimulation"
 import { getSpiceFromCircuitJson } from "../utils/spice-utils"
-import { getStoredBoolean, setStoredBoolean } from "lib/hooks/useLocalStorage"
+import {
+  getStoredBoolean,
+  setStoredBoolean,
+  getStoredString,
+  setStoredString,
+  STORAGE_KEYS,
+} from "lib/hooks/useLocalStorage"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
+import { SchematicSheetSelector } from "./SchematicSheetSelector"
+import type { SchematicSheetInfo } from "../utils/schematic-sheet"
 
 interface Props {
   circuitJson: CircuitJson
@@ -56,6 +63,8 @@ interface Props {
     schematicPortId: string
     event: MouseEvent
   }) => void
+  /** Called when the active schematic sheet changes (multi-sheet circuits). */
+  onSchematicSheetChange?: (schematicSheetId: string) => void
 }
 
 export const SchematicViewer = ({
@@ -74,6 +83,7 @@ export const SchematicViewer = ({
   onSchematicComponentClicked,
   showSchematicPorts = false,
   onSchematicPortClicked,
+  onSchematicSheetChange,
   css,
   className,
 }: Props) => {
@@ -95,6 +105,64 @@ export const SchematicViewer = ({
   const circuitJsonKey = useMemo(
     () => getCircuitHash(circuitJson),
     [circuitJson],
+  )
+
+  // Schematic sheets present in the circuit, sorted by sheet_index. A circuit
+  // may have zero (single implicit sheet), one, or many sheets.
+  const schematicSheets = useMemo<SchematicSheetInfo[]>(() => {
+    try {
+      return (circuitJson as any[])
+        .filter((elm) => elm?.type === "schematic_sheet")
+        .slice()
+        .sort((a, b) => (a.sheet_index ?? 0) - (b.sheet_index ?? 0))
+    } catch (err) {
+      console.error("Failed to derive schematic sheets", err)
+      return []
+    }
+  }, [circuitJsonKey])
+
+  const hasMultipleSheets = schematicSheets.length > 1
+  const defaultSheetId = schematicSheets[0]?.schematic_sheet_id
+
+  const [selectedSheetId, setSelectedSheetId] = useState<string | undefined>(
+    () => {
+      // Restore the last-viewed sheet from localStorage so it survives reloads.
+      const stored = getStoredString(STORAGE_KEYS.SELECTED_SCHEMATIC_SHEET)
+      if (
+        stored &&
+        schematicSheets.some((s) => s.schematic_sheet_id === stored)
+      ) {
+        return stored
+      }
+      return defaultSheetId
+    },
+  )
+
+  // Keep the selection valid as the circuit changes: fall back to the default
+  // sheet if the previously-selected sheet no longer exists.
+  useEffect(() => {
+    const stillExists =
+      selectedSheetId !== undefined &&
+      schematicSheets.some((s) => s.schematic_sheet_id === selectedSheetId)
+    if (!stillExists) {
+      setSelectedSheetId(defaultSheetId)
+    }
+  }, [circuitJsonKey])
+
+  // The sheet that should actually be rendered. When there is a single sheet
+  // (or none) we leave this undefined so circuit-to-svg uses its default and
+  // behavior is unchanged for single-sheet circuits.
+  const activeSheetId = hasMultipleSheets
+    ? (selectedSheetId ?? defaultSheetId)
+    : undefined
+
+  const handleSelectSheet = useCallback(
+    (sheetId: string) => {
+      setSelectedSheetId(sheetId)
+      setStoredString(STORAGE_KEYS.SELECTED_SCHEMATIC_SHEET, sheetId)
+      onSchematicSheetChange?.(sheetId)
+    },
+    [onSchematicSheetChange],
   )
 
   const spiceString = useMemo(() => {
@@ -173,21 +241,25 @@ export const SchematicViewer = ({
 
   const schematicComponentIds = useMemo(() => {
     try {
-      return (
-        su(circuitJson)
-          .schematic_component?.list()
-          ?.map((component) => component.schematic_component_id as string) ?? []
-      )
+      const components = su(circuitJson).schematic_component?.list() ?? []
+      return components
+        .filter(
+          (component) =>
+            !activeSheetId || component.schematic_sheet_id === activeSheetId,
+        )
+        .map((component) => component.schematic_component_id as string)
     } catch (err) {
       console.error("Failed to derive schematic component ids", err)
       return []
     }
-  }, [circuitJsonKey, circuitJson])
+  }, [circuitJsonKey, circuitJson, activeSheetId])
 
   const schematicPortsInfo = useMemo(() => {
     if (!showSchematicPorts) return []
     try {
-      const ports = su(circuitJson).schematic_port?.list() ?? []
+      const ports = (su(circuitJson).schematic_port?.list() ?? []).filter(
+        (port) => !activeSheetId || port.schematic_sheet_id === activeSheetId,
+      )
       return ports.map((port) => {
         const sourcePort = su(circuitJson).source_port.get(port.source_port_id)
         const sourceComponent = sourcePort?.source_component_id
@@ -208,7 +280,7 @@ export const SchematicViewer = ({
       console.error("Failed to derive schematic port info", err)
       return []
     }
-  }, [circuitJsonKey, circuitJson, showSchematicPorts])
+  }, [circuitJsonKey, circuitJson, showSchematicPorts, activeSheetId])
 
   const handleTouchStart = (e: React.TouchEvent) => {
     const touch = e.touches[0]
@@ -270,6 +342,7 @@ export const SchematicViewer = ({
       width: containerWidth,
       height: containerHeight || 720,
       drawPorts: showSchematicPorts,
+      schematicSheetId: activeSheetId,
       grid: !showGrid
         ? undefined
         : {
@@ -286,6 +359,7 @@ export const SchematicViewer = ({
     containerHeight,
     showGrid,
     showSchematicPorts,
+    activeSheetId,
   ])
 
   const containerBackgroundColor = useMemo(() => {
@@ -351,11 +425,12 @@ export const SchematicViewer = ({
     editEvents: editEventsWithUnappliedEditEvents,
   })
 
-  // Add group overlays when enabled
+  // Add group overlays when enabled. The key includes the active sheet so
+  // overlays are recomputed against the freshly-rendered sheet's SVG.
   useSchematicGroupsOverlay({
     svgDivRef,
     circuitJson,
-    circuitJsonKey,
+    circuitJsonKey: `${circuitJsonKey}_${activeSheetId ?? ""}`,
     showGroups: showSchematicGroups && !disableGroups,
   })
 
@@ -498,10 +573,6 @@ export const SchematicViewer = ({
             </div>
           </div>
         )}
-        <ViewMenuIcon
-          active={showViewMenu}
-          onClick={() => setShowViewMenu(!showViewMenu)}
-        />
         {editingEnabled && (
           <EditIcon
             active={editModeEnabled}
@@ -517,8 +588,8 @@ export const SchematicViewer = ({
         <ViewMenu
           circuitJson={circuitJson}
           circuitJsonKey={circuitJsonKey}
-          isVisible={showViewMenu}
-          onClose={() => setShowViewMenu(false)}
+          open={showViewMenu}
+          onOpenChange={setShowViewMenu}
           showGroups={showSchematicGroups}
           onToggleGroups={(value) => {
             if (!disableGroups) {
@@ -528,6 +599,11 @@ export const SchematicViewer = ({
           }}
           showGrid={showGrid}
           onToggleGrid={setShowGridInternal}
+        />
+        <SchematicSheetSelector
+          sheets={schematicSheets}
+          selectedSheetId={activeSheetId}
+          onSelectSheet={handleSelectSheet}
         />
         {spiceSimulationEnabled && (
           <SpiceSimulationIcon onClick={() => setShowSpiceOverlay(true)} />

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -20,7 +20,7 @@ import type { ManualEditEvent } from "../types/edit-events"
 import { EditIcon } from "./EditIcon"
 import { GridIcon } from "./GridIcon"
 import { ViewMenu } from "./ViewMenu"
-import type { CircuitJson } from "circuit-json"
+import type { CircuitJson, SchematicSheet } from "circuit-json"
 import { SpiceSimulationIcon } from "./SpiceSimulationIcon"
 import { SpiceSimulationOverlay } from "./SpiceSimulationOverlay"
 import { zIndexMap } from "../utils/z-index-map"
@@ -37,7 +37,6 @@ import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
 import { SchematicSheetSelector } from "./SchematicSheetSelector"
-import type { SchematicSheetInfo } from "../utils/schematic-sheet"
 
 interface Props {
   circuitJson: CircuitJson
@@ -109,7 +108,7 @@ export const SchematicViewer = ({
 
   // Schematic sheets present in the circuit, sorted by sheet_index. A circuit
   // may have zero (single implicit sheet), one, or many sheets.
-  const schematicSheets = useMemo<SchematicSheetInfo[]>(() => {
+  const schematicSheets = useMemo<SchematicSheet[]>(() => {
     try {
       return (circuitJson as any[])
         .filter((elm) => elm?.type === "schematic_sheet")

--- a/lib/components/ViewMenu.tsx
+++ b/lib/components/ViewMenu.tsx
@@ -149,8 +149,10 @@ export const ViewMenu = ({
             style={itemStyles}
             disabled={!hasGroups}
             title={hasGroups ? undefined : "No groups found in this schematic"}
-            onSelect={(e) => {
-              e.preventDefault()
+            // Toggle on pointerup (reliable on touch); keep the menu open by
+            // preventing Radix's click-based onSelect (which also closes it).
+            onSelect={(e) => e.preventDefault()}
+            onPointerUp={() => {
               if (hasGroups) onToggleGroups(!showGroups)
             }}
           >
@@ -161,10 +163,8 @@ export const ViewMenu = ({
           <DropdownMenu.Item
             className="sv-vm-item"
             style={itemStyles}
-            onSelect={(e) => {
-              e.preventDefault()
-              onToggleGrid(!showGrid)
-            }}
+            onSelect={(e) => e.preventDefault()}
+            onPointerUp={() => onToggleGrid(!showGrid)}
           >
             <span style={iconSlotStyles}>{showGrid && <CheckIcon />}</span>
             <span>Show Grid</span>

--- a/lib/components/ViewMenu.tsx
+++ b/lib/components/ViewMenu.tsx
@@ -1,25 +1,96 @@
 import { useMemo } from "react"
 import { su } from "@tscircuit/soup-util"
 import type { CircuitJson } from "circuit-json"
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import { zIndexMap } from "../utils/z-index-map"
 import packageJson from "../../package.json"
+import { ViewMenuIcon } from "./ViewMenuIcon"
 
 interface ViewMenuProps {
   circuitJson: CircuitJson
   circuitJsonKey: string
-  isVisible: boolean
-  onClose: () => void
+  open: boolean
+  onOpenChange: (open: boolean) => void
   showGroups: boolean
   onToggleGroups: (show: boolean) => void
   showGrid: boolean
   onToggleGrid: (show: boolean) => void
 }
 
+const FONT_FAMILY =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+
+const contentStyles: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  color: "#111111",
+  borderRadius: 8,
+  boxShadow: "0 6px 24px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
+  border: "1px solid #e5e7eb",
+  padding: 4,
+  minWidth: 224,
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+  outline: "none",
+  zIndex: zIndexMap.viewMenu,
+}
+
+const itemStyles: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "7px 10px 7px 8px",
+  borderRadius: 6,
+  cursor: "pointer",
+  outline: "none",
+  userSelect: "none",
+  color: "#111111",
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+}
+
+const iconSlotStyles: React.CSSProperties = {
+  width: 16,
+  height: 16,
+  flexShrink: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#111111",
+}
+
+const separatorStyles: React.CSSProperties = {
+  height: 1,
+  backgroundColor: "#ececec",
+  margin: "4px 0",
+}
+
+const HIGHLIGHT_CSS = `
+.sv-vm-item[data-highlighted]:not([data-disabled]),
+.sv-vm-item:hover:not([data-disabled]) { background-color: #f1f3f5; }
+.sv-vm-item[data-disabled] { opacity: 0.45; cursor: not-allowed; }
+`
+
+const CheckIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
 export const ViewMenu = ({
   circuitJson,
   circuitJsonKey,
-  isVisible,
-  onClose,
+  open,
+  onOpenChange,
   showGroups,
   onToggleGroups,
   showGrid,
@@ -56,163 +127,65 @@ export const ViewMenu = ({
     }
   }, [circuitJsonKey])
 
-  if (!isVisible) return null
-
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        onClick={onClose}
-        onTouchEnd={(e) => {
-          e.preventDefault()
-          onClose()
-        }}
-        style={{
-          position: "absolute",
-          inset: 0,
-          backgroundColor: "transparent",
-          zIndex: zIndexMap.viewMenuBackdrop,
-        }}
-      />
+    <DropdownMenu.Root open={open} onOpenChange={onOpenChange} modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <ViewMenuIcon active={open} />
+      </DropdownMenu.Trigger>
 
-      {/* Menu */}
-      <div
-        style={{
-          position: "absolute",
-          top: "56px",
-          right: "16px",
-          backgroundColor: "#ffffff",
-          color: "#000000",
-          border: "1px solid #ccc",
-          borderRadius: "4px",
-          boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-          minWidth: "200px",
-          zIndex: zIndexMap.viewMenu,
-        }}
-      >
-        {/* Groups Toggle Option */}
-        <div
-          onClick={() => {
-            if (hasGroups) {
-              onToggleGroups(!showGroups)
-            }
-          }}
-          onTouchEnd={(e) => {
-            e.preventDefault()
-            if (hasGroups) {
-              onToggleGroups(!showGroups)
-            }
-          }}
-          style={{
-            padding: "8px 12px",
-            cursor: hasGroups ? "pointer" : "not-allowed",
-            opacity: hasGroups ? 1 : 0.5,
-            fontSize: "13px",
-            color: "#000000",
-            fontFamily: "sans-serif",
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-          }}
-          onMouseEnter={(e) => {
-            if (hasGroups) {
-              e.currentTarget.style.backgroundColor = "#f0f0f0"
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (hasGroups) {
-              e.currentTarget.style.backgroundColor = "transparent"
-            }
-          }}
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          style={contentStyles}
+          side="bottom"
+          align="end"
+          sideOffset={8}
+          collisionPadding={10}
         >
-          <div
-            style={{
-              width: "16px",
-              height: "16px",
-              border: "2px solid #000",
-              borderRadius: "2px",
-              backgroundColor: "transparent",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: "10px",
-              fontWeight: "bold",
+          <style>{HIGHLIGHT_CSS}</style>
+
+          {/* View toggles */}
+          <DropdownMenu.Item
+            className="sv-vm-item"
+            style={itemStyles}
+            disabled={!hasGroups}
+            title={hasGroups ? undefined : "No groups found in this schematic"}
+            onSelect={(e) => {
+              e.preventDefault()
+              if (hasGroups) onToggleGroups(!showGroups)
             }}
           >
-            {showGroups && "✓"}
-          </div>
-          View Schematic Groups
-        </div>
+            <span style={iconSlotStyles}>{showGroups && <CheckIcon />}</span>
+            <span>View Schematic Groups</span>
+          </DropdownMenu.Item>
 
-        {!hasGroups && (
-          <div
-            style={{
-              padding: "8px 12px",
-              fontSize: "11px",
-              color: "#666",
-              fontStyle: "italic",
+          <DropdownMenu.Item
+            className="sv-vm-item"
+            style={itemStyles}
+            onSelect={(e) => {
+              e.preventDefault()
+              onToggleGrid(!showGrid)
             }}
           >
-            No groups found in this schematic
-          </div>
-        )}
+            <span style={iconSlotStyles}>{showGrid && <CheckIcon />}</span>
+            <span>Show Grid</span>
+          </DropdownMenu.Item>
 
-        {/* Grid Toggle Option */}
-        <div
-          onClick={() => onToggleGrid(!showGrid)}
-          onTouchEnd={(e) => {
-            e.preventDefault()
-            onToggleGrid(!showGrid)
-          }}
-          style={{
-            padding: "8px 12px",
-            cursor: "pointer",
-            fontSize: "13px",
-            color: "#000000",
-            fontFamily: "sans-serif",
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = "#f0f0f0"
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = "transparent"
-          }}
-        >
+          <DropdownMenu.Separator style={separatorStyles} />
+
+          {/* Version */}
           <div
             style={{
-              width: "16px",
-              height: "16px",
-              border: "2px solid #000",
-              borderRadius: "2px",
-              backgroundColor: "transparent",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: "10px",
-              fontWeight: "bold",
+              padding: "4px 8px",
+              fontSize: 12,
+              color: "#9ca3af",
+              textAlign: "center",
+              fontFamily: FONT_FAMILY,
             }}
           >
-            {showGrid && "✓"}
+            v{String(packageJson?.version)}
           </div>
-          Show Grid
-        </div>
-
-        {/* Version Info */}
-        <div
-          style={{
-            padding: "4px 8px",
-            fontSize: "12px",
-            color: "#999",
-            borderTop: "1px solid #eee",
-            textAlign: "center",
-          }}
-        >
-          v{String(packageJson?.version)}
-        </div>
-      </div>
-    </>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   )
 }

--- a/lib/components/ViewMenuIcon.tsx
+++ b/lib/components/ViewMenuIcon.tsx
@@ -1,19 +1,18 @@
 import { zIndexMap } from "../utils/z-index-map"
 
-export const ViewMenuIcon = ({
-  onClick,
-  active,
-}: { onClick: () => void; active: boolean }) => {
-  const handleInteraction = (e: React.MouseEvent | React.TouchEvent) => {
-    e.preventDefault()
-    onClick()
-  }
+interface ViewMenuIconProps extends React.ComponentPropsWithRef<"button"> {
+  active?: boolean
+}
 
+export const ViewMenuIcon = ({
+  active = false,
+  ...props
+}: ViewMenuIconProps) => {
   return (
-    <div
-      onClick={handleInteraction}
-      onTouchEnd={handleInteraction}
+    <button
+      type="button"
       title={active ? "Hide view menu" : "Show view menu"}
+      {...props}
       style={{
         position: "absolute",
         top: "16px",
@@ -21,8 +20,10 @@ export const ViewMenuIcon = ({
         backgroundColor: active ? "#4CAF50" : "#fff",
         color: active ? "#fff" : "#000",
         padding: "8px",
+        border: "none",
         borderRadius: "4px",
         cursor: "pointer",
+        outline: "none",
         boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
         display: "flex",
         alignItems: "center",
@@ -42,6 +43,6 @@ export const ViewMenuIcon = ({
         <circle cx="12" cy="5" r="1" />
         <circle cx="12" cy="19" r="1" />
       </svg>
-    </div>
+    </button>
   )
 }

--- a/lib/hooks/useLocalStorage.ts
+++ b/lib/hooks/useLocalStorage.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react"
 
 export const STORAGE_KEYS = {
   IS_SHOWING_SCHEMATIC_GROUPS: "schematic_viewer_show_groups",
+  SELECTED_SCHEMATIC_SHEET: "schematic_viewer_selected_sheet",
 } as const
 
 export const getStoredBoolean = (
@@ -21,6 +22,22 @@ export const setStoredBoolean = (key: string, value: boolean): void => {
   if (typeof window === "undefined") return
   try {
     localStorage.setItem(key, JSON.stringify(value))
+  } catch {}
+}
+
+export const getStoredString = (key: string): string | null => {
+  if (typeof window === "undefined") return null
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export const setStoredString = (key: string, value: string): void => {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(key, value)
   } catch {}
 }
 

--- a/lib/utils/schematic-sheet.ts
+++ b/lib/utils/schematic-sheet.ts
@@ -1,6 +1,0 @@
-import type { SchematicSheet } from "circuit-json"
-
-export const getSchematicSheetLabel = (
-  sheet: SchematicSheet,
-  fallbackIndex: number,
-) => sheet.name ?? `Sheet ${sheet.sheet_index ?? fallbackIndex + 1}`

--- a/lib/utils/schematic-sheet.ts
+++ b/lib/utils/schematic-sheet.ts
@@ -1,0 +1,14 @@
+export interface SchematicSheetInfo {
+  schematic_sheet_id: string
+  name?: string
+  display_name?: string
+  sheet_index?: number
+}
+
+export const getSchematicSheetLabel = (
+  sheet: SchematicSheetInfo,
+  fallbackIndex: number,
+) =>
+  sheet.display_name ??
+  sheet.name ??
+  `Sheet ${sheet.sheet_index ?? fallbackIndex + 1}`

--- a/lib/utils/schematic-sheet.ts
+++ b/lib/utils/schematic-sheet.ts
@@ -1,14 +1,6 @@
-export interface SchematicSheetInfo {
-  schematic_sheet_id: string
-  name?: string
-  display_name?: string
-  sheet_index?: number
-}
+import type { SchematicSheet } from "circuit-json"
 
 export const getSchematicSheetLabel = (
-  sheet: SchematicSheetInfo,
+  sheet: SchematicSheet,
   fallbackIndex: number,
-) =>
-  sheet.display_name ??
-  sheet.name ??
-  `Sheet ${sheet.sheet_index ?? fallbackIndex + 1}`
+) => sheet.name ?? `Sheet ${sheet.sheet_index ?? fallbackIndex + 1}`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "^19.1.0",
     "react-reconciler": "^0.31.0",
     "semver": "^7.7.2",
-    "tscircuit": "^0.0.1938",
+    "tscircuit": "^0.0.1972",
     "tsup": "^8.3.5",
     "vite": "^6.0.3"
   },
@@ -40,6 +40,7 @@
     "circuit-json-to-spice": "*"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "chart.js": "^4.5.0",
     "debug": "^4.4.0",
     "performance-now": "^2.1.0",


### PR DESCRIPTION
Adds the ability to view independent schematic sheets in the schematic viewer. Multi-sheet circuits (using `<schematicsheet />`) previously rendered all sheets merged together with no way to switch between them.

A **"Sheet:" dropdown** now appears in the top-left toolbar whenever a circuit has more than one schematic sheet. Selecting a sheet renders only that sheet, using `circuit-to-svg`'s built-in `schematicSheetId` option (no manual DOM filtering).

## Changes

- **`SchematicSheetSelector`** (new) — a standalone Radix `DropdownMenu` (`@radix-ui/react-dropdown-menu`, same lib as the 3d-viewer) showing the active sheet with a check on the selection and an animated chevron. Only renders when there are 2+ sheets; width fits the longest name (with ellipsis + tooltip for very long names).
- **`SchematicViewer`** — derives the sheet list from the circuit JSON, tracks the active sheet, passes `schematicSheetId` to `convertCircuitJsonToSchematicSvg`, and filters the clickable component/port overlays to the active sheet so they line up with what's drawn. Single/no-sheet circuits are unchanged. New optional `onSchematicSheetChange` callback.
- **Sheet persistence** — the selected sheet is saved to `localStorage` and restored on reload (falls back to the first sheet if it no longer exists). Adds `getStoredString`/`setStoredString` helpers.
- **`ViewMenu`** — migrated the 3-dots menu to Radix `DropdownMenu` for proper dismiss/keyboard/positioning; `ViewMenuIcon` is now the Radix trigger (`<button>`, ref-as-prop, no `forwardRef`).
- **`schematic-sheet.ts`** (new) — shared `SchematicSheetInfo` type + `getSchematicSheetLabel` helper (`display_name ?? name ?? "Sheet N"`).
- **`example23-multiple-schematic-sheets.fixture.tsx`** (new) — LED driver on Sheet 1, RC filter on Sheet 2.