### PR TITLE
Add an analog simulation selector

### DIFF
--- a/examples/example25-multiple-analog-simulations.fixture.tsx
+++ b/examples/example25-multiple-analog-simulations.fixture.tsx
@@ -1,0 +1,57 @@
+import type { CircuitJson } from "circuit-json"
+import { AnalogSimulationViewer } from "lib/components/AnalogSimulationViewer"
+import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+
+const schematicCircuitJson = renderToCircuitJson(
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+    <resistor name="R2" resistance="2k" />
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    <trace from=".R2 > .pin2" to=".V1 > .pin2" />
+  </board>,
+)
+
+const simulationElements = [
+  { name: "Root Fast", color: "#315cff", peak: 5 },
+  { name: "Root Slow", color: "#8a35d7", peak: 3.5 },
+  { name: "Input Group", color: "#e05252", peak: 2.5 },
+  { name: "Output Group", color: "#15803d", peak: 1.5 },
+].flatMap(({ name, color, peak }, index) => {
+  const simulationExperimentId = `simulation_experiment_${index}`
+  return [
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: simulationExperimentId,
+      name,
+      experiment_type: "spice_transient_analysis",
+      time_per_step: 0.25,
+      start_time_ms: 0,
+      end_time_ms: 1,
+    },
+    {
+      type: "simulation_transient_voltage_graph",
+      simulation_transient_voltage_graph_id: `simulation_transient_voltage_graph_${index}`,
+      simulation_experiment_id: simulationExperimentId,
+      voltage_levels: [0, peak * 0.5, peak, peak * 0.75, 0],
+      time_per_step: 0.25,
+      start_time_ms: 0,
+      end_time_ms: 1,
+      name,
+      color,
+    },
+  ]
+})
+
+const circuitJson = [
+  ...schematicCircuitJson,
+  ...simulationElements,
+] as CircuitJson
+
+export default () => (
+  <AnalogSimulationViewer
+    circuitJson={circuitJson}
+    containerStyle={{ width: "100vw", height: "100vh" }}
+  />
+)

--- a/lib/components/AnalogSimulationSelector.tsx
+++ b/lib/components/AnalogSimulationSelector.tsx
@@ -1,0 +1,207 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import type { SimulationExperiment } from "circuit-json"
+import { useState } from "react"
+import { zIndexMap } from "../utils/z-index-map"
+
+interface AnalogSimulationSelectorProps {
+  simulations: SimulationExperiment[]
+  selectedSimulationExperimentId: string | null
+  onSelectSimulation: (simulationExperimentId: string) => void
+}
+
+const FONT_FAMILY =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+
+const contentStyles: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  color: "#111111",
+  borderRadius: 8,
+  boxShadow: "0 6px 24px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
+  border: "1px solid #e5e7eb",
+  padding: 4,
+  minWidth: 220,
+  maxWidth: 360,
+  maxHeight: 320,
+  overflowY: "auto",
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+  outline: "none",
+  zIndex: zIndexMap.viewMenu,
+}
+
+const itemStyles: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "7px 10px 7px 8px",
+  borderRadius: 6,
+  cursor: "pointer",
+  outline: "none",
+  userSelect: "none",
+  color: "#111111",
+  fontSize: 13,
+  fontFamily: FONT_FAMILY,
+}
+
+const iconSlotStyles: React.CSSProperties = {
+  width: 16,
+  height: 16,
+  flexShrink: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#111111",
+}
+
+const ellipsisStyles: React.CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+}
+
+const MENU_CSS = `
+.sv-simulation-item[data-highlighted], .sv-simulation-item:hover { background-color: #f1f3f5; }
+.sv-simulation-chevron { transition: transform 0.2s ease; }
+[data-state="open"] > .sv-simulation-chevron { transform: rotate(180deg); }
+`
+
+const CheckIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
+const ChevronDownIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ opacity: 0.6, flexShrink: 0 }}
+    aria-hidden="true"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+const getSimulationLabels = (simulations: SimulationExperiment[]) => {
+  const nameCounts = new Map<string, number>()
+  return simulations.map((simulation) => {
+    const count = (nameCounts.get(simulation.name) ?? 0) + 1
+    nameCounts.set(simulation.name, count)
+    return {
+      simulation,
+      label: count === 1 ? simulation.name : `${simulation.name} (${count})`,
+    }
+  })
+}
+
+/** A toolbar dropdown for switching between analog simulation experiments. */
+export const AnalogSimulationSelector = ({
+  simulations,
+  selectedSimulationExperimentId,
+  onSelectSimulation,
+}: AnalogSimulationSelectorProps) => {
+  const [open, setOpen] = useState(false)
+
+  if (simulations.length <= 1) return null
+
+  const simulationLabels = getSimulationLabels(simulations)
+  const selectedSimulation = simulationLabels.find(
+    ({ simulation }) =>
+      simulation.simulation_experiment_id === selectedSimulationExperimentId,
+  )
+  const selectedLabel = selectedSimulation?.label ?? "Select simulation"
+
+  return (
+    <>
+      <style>{MENU_CSS}</style>
+      <DropdownMenu.Root open={open} onOpenChange={setOpen} modal={false}>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            title={selectedLabel}
+            onPointerDown={(event) => event.stopPropagation()}
+            style={{
+              position: "absolute",
+              top: "16px",
+              left: "16px",
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              maxWidth: "280px",
+              padding: "8px 12px",
+              backgroundColor: "#ffffff",
+              color: "#000000",
+              border: "none",
+              outline: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+              boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+              fontSize: "13px",
+              fontFamily: FONT_FAMILY,
+              zIndex: zIndexMap.viewMenuIcon,
+            }}
+          >
+            <span style={{ color: "#888888", flexShrink: 0 }}>Simulation:</span>
+            <span style={{ ...ellipsisStyles, minWidth: 0 }}>
+              {selectedLabel}
+            </span>
+            <ChevronDownIcon className="sv-simulation-chevron" />
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            style={contentStyles}
+            side="bottom"
+            align="start"
+            sideOffset={8}
+            collisionPadding={10}
+          >
+            {simulationLabels.map(({ simulation, label }) => {
+              const selected =
+                simulation.simulation_experiment_id ===
+                selectedSimulationExperimentId
+              return (
+                <DropdownMenu.Item
+                  key={simulation.simulation_experiment_id}
+                  className="sv-simulation-item"
+                  style={itemStyles}
+                  title={label}
+                  onSelect={(event) => event.preventDefault()}
+                  onPointerUp={() => {
+                    onSelectSimulation(simulation.simulation_experiment_id)
+                    setOpen(false)
+                  }}
+                >
+                  <span style={iconSlotStyles}>
+                    {selected && <CheckIcon />}
+                  </span>
+                  <span style={{ ...ellipsisStyles, minWidth: 0 }}>
+                    {label}
+                  </span>
+                </DropdownMenu.Item>
+              )
+            })}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </>
+  )
+}

--- a/lib/components/AnalogSimulationViewer.tsx
+++ b/lib/components/AnalogSimulationViewer.tsx
@@ -7,6 +7,7 @@ import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { toString as transformToString } from "transformation-matrix"
 import type { CircuitJson } from "circuit-json"
+import { AnalogSimulationSelector } from "./AnalogSimulationSelector"
 
 const DEFAULT_RENDER_WIDTH = 1200
 const DEFAULT_RENDER_ASPECT_RATIO = 1
@@ -18,6 +19,8 @@ interface Props {
   width?: number
   height?: number
   className?: string
+  /** Called when the active simulation changes. */
+  onSimulationChange?: (simulationExperimentId: string) => void
 }
 
 export const AnalogSimulationViewer = ({
@@ -27,6 +30,7 @@ export const AnalogSimulationViewer = ({
   width,
   height,
   className,
+  onSimulationChange,
 }: Props) => {
   const [circuitJson, setCircuitJson] = useState<CircuitJson | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -69,29 +73,54 @@ export const AnalogSimulationViewer = ({
     setIsLoading(false)
   }, [inputCircuitJson])
 
-  // Find simulation experiment ID from circuit JSON
-  const simulationExperimentId = useMemo(() => {
-    if (!circuitJson) return null
-    const simulationElement = circuitJson.find(
-      (el) => el.type === "simulation_experiment",
+  const simulationExperiments = useMemo(() => {
+    if (!circuitJson) return []
+    return circuitJson.filter(
+      (element) => element.type === "simulation_experiment",
     )
-    return simulationElement?.simulation_experiment_id || null
   }, [circuitJson])
+  const [selectedSimulationExperimentId, setSelectedSimulationExperimentId] =
+    useState<string | null>(null)
+  const simulationExperimentId =
+    (selectedSimulationExperimentId &&
+    simulationExperiments.some(
+      (simulation) =>
+        simulation.simulation_experiment_id === selectedSimulationExperimentId,
+    )
+      ? selectedSimulationExperimentId
+      : simulationExperiments[0]?.simulation_experiment_id) ?? null
+
+  useEffect(() => {
+    if (simulationExperimentId !== selectedSimulationExperimentId) {
+      setSelectedSimulationExperimentId(simulationExperimentId)
+    }
+  }, [simulationExperimentId, selectedSimulationExperimentId])
+
+  const handleSelectSimulation = (nextSimulationExperimentId: string) => {
+    setSelectedSimulationExperimentId(nextSimulationExperimentId)
+    onSimulationChange?.(nextSimulationExperimentId)
+  }
 
   // Find simulation graph IDs from circuit JSON
   const simulationVoltageGraphIds = useMemo(() => {
     if (!circuitJson) return []
-    return circuitJson
-      .filter((el) => el.type === "simulation_transient_voltage_graph")
-      .map((el) => el.simulation_transient_voltage_graph_id)
-  }, [circuitJson])
+    return circuitJson.flatMap((element) =>
+      element.type === "simulation_transient_voltage_graph" &&
+      element.simulation_experiment_id === simulationExperimentId
+        ? [element.simulation_transient_voltage_graph_id]
+        : [],
+    )
+  }, [circuitJson, simulationExperimentId])
 
   const simulationCurrentGraphIds = useMemo(() => {
     if (!circuitJson) return []
-    return circuitJson
-      .filter((el) => el.type === "simulation_transient_current_graph")
-      .map((el) => el.simulation_transient_current_graph_id)
-  }, [circuitJson])
+    return circuitJson.flatMap((element) =>
+      element.type === "simulation_transient_current_graph" &&
+      element.simulation_experiment_id === simulationExperimentId
+        ? [element.simulation_transient_current_graph_id]
+        : [],
+    )
+  }, [circuitJson, simulationExperimentId])
 
   // Generate SVG from CircuitJSON
   const simulationSvg = useMemo(() => {
@@ -284,6 +313,11 @@ export const AnalogSimulationViewer = ({
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}
     >
+      <AnalogSimulationSelector
+        simulations={simulationExperiments}
+        selectedSimulationExperimentId={simulationExperimentId}
+        onSelectSimulation={handleSelectSimulation}
+      />
       {svgObjectUrl ? (
         <img
           ref={imgRef}


### PR DESCRIPTION

<img width="1520" height="1412" alt="image" src="https://github.com/user-attachments/assets/5169201b-4ef6-481e-bfc1-0cd6fa009569" />
<img width="1532" height="1416" alt="image" src="https://github.com/user-attachments/assets/d5558853-bd84-421d-8fe7-1a21cee3e8e9" />

## Summary

- add a compact analog-simulation selector when Circuit JSON contains multiple experiments
- filter voltage and current graphs to the selected `simulation_experiment_id`
- expose `onSimulationChange` for consumers that need to observe selection changes
- add a four-experiment viewer fixture covering root and grouped simulation labels

## Why

The analog simulation viewer previously selected the first experiment unconditionally, so results from additional simulations could not be viewed.

## Impact

The analog simulation tab can switch between experiments in the same circuit using a selector modeled after the schematic sheet selector. Single-experiment behavior remains unchanged.

## Validation

- `bunx tsc --noEmit`
- `bun run build`

