### PR TITLE
Add option to hide schematic in analog simulation viewer

### DIFF
--- a/lib/components/AnalogSimulationViewer.tsx
+++ b/lib/components/AnalogSimulationViewer.tsx
@@ -1,4 +1,5 @@
 import {
+  convertCircuitJsonToSchematicSimulationSvg,
   convertCircuitJsonToSimulationGraphSvg,
   type ColorOverrides,
 } from "circuit-to-svg"
@@ -19,6 +20,8 @@ interface Props {
   width?: number
   height?: number
   className?: string
+  /** Whether to include the schematic alongside the simulation graph. Defaults to true. */
+  showSchematic?: boolean
   /** Called when the active simulation changes. */
   onSimulationChange?: (simulationExperimentId: string) => void
 }
@@ -26,9 +29,11 @@ interface Props {
 export const AnalogSimulationViewer = ({
   circuitJson: inputCircuitJson,
   containerStyle,
+  colorOverrides,
   width,
   height,
   className,
+  showSchematic = true,
   onSimulationChange,
 }: Props) => {
   const [circuitJson, setCircuitJson] = useState<CircuitJson | null>(null)
@@ -121,7 +126,7 @@ export const AnalogSimulationViewer = ({
     )
   }, [circuitJson, simulationExperimentId])
 
-  // Generate the standalone simulation graph SVG from CircuitJSON
+  // Generate the simulation SVG from CircuitJSON
   const simulationSvg = useMemo(() => {
     if (
       !circuitJson ||
@@ -132,22 +137,31 @@ export const AnalogSimulationViewer = ({
       return ""
 
     try {
-      return convertCircuitJsonToSimulationGraphSvg({
+      const simulationOptions = {
         circuitJson,
         simulation_experiment_id: simulationExperimentId,
         simulation_transient_current_graph_ids: simulationCurrentGraphIds,
         simulation_transient_voltage_graph_ids: simulationVoltageGraphIds,
         width: effectiveWidth,
         height: effectiveHeight,
-      })
+      }
+
+      return showSchematic
+        ? convertCircuitJsonToSchematicSimulationSvg({
+            ...simulationOptions,
+            schematicOptions: { colorOverrides },
+          })
+        : convertCircuitJsonToSimulationGraphSvg(simulationOptions)
     } catch (error) {
-      console.error("Failed to generate simulation graph SVG:", error)
+      console.error("Failed to generate simulation SVG:", error)
       return ""
     }
   }, [
     circuitJson,
     effectiveWidth,
     effectiveHeight,
+    colorOverrides,
+    showSchematic,
     simulationExperimentId,
     simulationCurrentGraphIds,
     simulationVoltageGraphIds,

--- a/lib/components/AnalogSimulationViewer.tsx
+++ b/lib/components/AnalogSimulationViewer.tsx
@@ -1,5 +1,5 @@
 import {
-  convertCircuitJsonToSchematicSimulationSvg,
+  convertCircuitJsonToSimulationGraphSvg,
   type ColorOverrides,
 } from "circuit-to-svg"
 import { useEffect, useState, useMemo, useRef } from "react"
@@ -26,7 +26,6 @@ interface Props {
 export const AnalogSimulationViewer = ({
   circuitJson: inputCircuitJson,
   containerStyle,
-  colorOverrides,
   width,
   height,
   className,
@@ -122,7 +121,7 @@ export const AnalogSimulationViewer = ({
     )
   }, [circuitJson, simulationExperimentId])
 
-  // Generate SVG from CircuitJSON
+  // Generate the standalone simulation graph SVG from CircuitJSON
   const simulationSvg = useMemo(() => {
     if (
       !circuitJson ||
@@ -133,24 +132,22 @@ export const AnalogSimulationViewer = ({
       return ""
 
     try {
-      return convertCircuitJsonToSchematicSimulationSvg({
+      return convertCircuitJsonToSimulationGraphSvg({
         circuitJson,
         simulation_experiment_id: simulationExperimentId,
         simulation_transient_current_graph_ids: simulationCurrentGraphIds,
         simulation_transient_voltage_graph_ids: simulationVoltageGraphIds,
         width: effectiveWidth,
         height: effectiveHeight,
-        schematicOptions: { colorOverrides },
       })
-    } catch (fallbackErr) {
-      console.error("Failed to generate fallback schematic SVG:", fallbackErr)
+    } catch (error) {
+      console.error("Failed to generate simulation graph SVG:", error)
       return ""
     }
   }, [
     circuitJson,
     effectiveWidth,
     effectiveHeight,
-    colorOverrides,
     simulationExperimentId,
     simulationCurrentGraphIds,
     simulationVoltageGraphIds,

--- a/lib/components/AnalogSimulationViewer.tsx
+++ b/lib/components/AnalogSimulationViewer.tsx
@@ -20,8 +20,8 @@ interface Props {
   width?: number
   height?: number
   className?: string
-  /** Whether to include the schematic alongside the simulation graph. Defaults to true. */
-  showSchematic?: boolean
+  /** Whether to hide the schematic and render only the simulation graph. Defaults to false. */
+  hideSchematic?: boolean
   /** Called when the active simulation changes. */
   onSimulationChange?: (simulationExperimentId: string) => void
 }
@@ -33,7 +33,7 @@ export const AnalogSimulationViewer = ({
   width,
   height,
   className,
-  showSchematic = true,
+  hideSchematic = false,
   onSimulationChange,
 }: Props) => {
   const [circuitJson, setCircuitJson] = useState<CircuitJson | null>(null)
@@ -146,12 +146,12 @@ export const AnalogSimulationViewer = ({
         height: effectiveHeight,
       }
 
-      return showSchematic
-        ? convertCircuitJsonToSchematicSimulationSvg({
+      return hideSchematic
+        ? convertCircuitJsonToSimulationGraphSvg(simulationOptions)
+        : convertCircuitJsonToSchematicSimulationSvg({
             ...simulationOptions,
             schematicOptions: { colorOverrides },
           })
-        : convertCircuitJsonToSimulationGraphSvg(simulationOptions)
     } catch (error) {
       console.error("Failed to generate simulation SVG:", error)
       return ""
@@ -161,7 +161,7 @@ export const AnalogSimulationViewer = ({
     effectiveWidth,
     effectiveHeight,
     colorOverrides,
-    showSchematic,
+    hideSchematic,
     simulationExperimentId,
     simulationCurrentGraphIds,
     simulationVoltageGraphIds,


### PR DESCRIPTION
## Summary

- add a `hideSchematic` prop to `AnalogSimulationViewer`
- keep the existing combined schematic and simulation graph as the default
- render only the standalone simulation graph when `hideSchematic` is enabled

## Why

Consumers need to choose whether the analog simulation view includes the circuit schematic or focuses only on the simulation traces.

## Impact

Existing callers keep the current combined rendering without any changes. Callers can opt into graph-only rendering with:

```tsx
<AnalogSimulationViewer circuitJson={circuitJson} hideSchematic />
```

Schematic color overrides continue to apply when the schematic is shown.

## Validation

- `bun run format:check`
- `bun run build`
- verified the generated declaration exposes `hideSchematic?: boolean`
- verified the generated bundle selects the standalone graph renderer when the flag is true
