### PR TITLE
Fix MouseTracker hook order

### DIFF
--- a/lib/components/MouseTracker.tsx
+++ b/lib/components/MouseTracker.tsx
@@ -57,6 +57,10 @@ export const MouseTracker = ({ children }: { children: ReactNode }) => {
     return <>{children}</>
   }
 
+  return <MouseTrackerProvider>{children}</MouseTrackerProvider>
+}
+
+const MouseTrackerProvider = ({ children }: { children: ReactNode }) => {
   const storeRef = useRef({
     pointer: null as { x: number; y: number } | null,
     boundingBoxes: new Map<string, BoundingBoxRegistration>(),


### PR DESCRIPTION
## Summary

- keep the ancestor `MouseTrackerContext` check in `MouseTracker`
- move the local tracker state and effects into a dedicated `MouseTrackerProvider` child
- preserve the existing behavior of reusing an ancestor tracker instead of nesting another provider

## Root cause

`MouseTracker` called `useContext` and returned early when an ancestor tracker was present. When no ancestor context was present, the same component continued into `useRef`, multiple `useCallback` calls, `useEffect`, and `useMemo`. If the context availability changed for a mounted instance, React could report fewer or more hooks than the previous render.

Separating the provider implementation gives each component a stable hook sequence: `MouseTracker` always calls one hook, while `MouseTrackerProvider` always calls the full provider hook set.

## Impact

Nested schematic viewers and provider-tree changes can no longer trigger a hook-order failure from `MouseTracker`.

## Validation

- full first-party hook-order audit: no findings
- `bun test` (4 passed)
- `bun run build`
- `git diff --check`

No lint configuration or dependency changes were added.