### PR TITLE
Update Circuit JSON for manually placed vias

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "circuit-json": "^0.0.454",
+        "circuit-json": "^0.0.465",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
         "performance-now": "^2.1.0",
@@ -509,7 +510,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.454", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-e/l/ueZ6y2kyPTWG/M2oqsNc0L7wYsduVpurdaUdtzXVQD65m9jkmMtxKID2gtUrgmalKfuEltT6AFbzbooKcA=="],
+    "circuit-json": ["circuit-json@0.0.465", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-C/H9PzLVuZD2kYb65S9cGqK84Udj42pPr6dWLE/Qkzu5gJFHSqoQbhPpwupKNtXzTwOTBwESKjXOXUcXPgPRJw=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "circuit-json": "^0.0.454",
+    "circuit-json": "^0.0.465",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",
     "performance-now": "^2.1.0",


### PR DESCRIPTION
### Motivation
- Consumers need the current Circuit JSON types used by the latest tscircuit Core.

### Before
- Schematic Viewer required Circuit JSON 0.0.454, creating incompatible duplicate types in consumers using 0.0.465.

### After
- Schematic Viewer uses Circuit JSON 0.0.465 and builds against the current manually placed via schema.