### PR TITLE
fix: export ControlledSchematicViewer from the package entry point

### DIFF
--- a/examples/example1-resistor-and-capacitor.fixture.tsx
+++ b/examples/example1-resistor-and-capacitor.fixture.tsx
@@ -1,4 +1,4 @@
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { ControlledSchematicViewer } from "lib/index"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 
 export default () => (

--- a/examples/example14-schematic-component-click.fixture.tsx
+++ b/examples/example14-schematic-component-click.fixture.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { ControlledSchematicViewer } from "lib/index"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 
 const circuitJson = renderToCircuitJson(

--- a/examples/example2-small-circuit.fixture.tsx
+++ b/examples/example2-small-circuit.fixture.tsx
@@ -1,4 +1,4 @@
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { ControlledSchematicViewer } from "lib/index"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 
 const circuitJson = renderToCircuitJson(

--- a/examples/example3-small-circuit-without-debug-grid.fixture.tsx
+++ b/examples/example3-small-circuit-without-debug-grid.fixture.tsx
@@ -1,4 +1,4 @@
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { ControlledSchematicViewer } from "lib/index"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 
 export default () => (

--- a/examples/example4-reset-edit-events.fixture.tsx
+++ b/examples/example4-reset-edit-events.fixture.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react"
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 import type { ManualEditEvent } from "lib/types/edit-events"
-import { SchematicViewer } from "lib/index"
+import { ControlledSchematicViewer, SchematicViewer } from "lib/index"
 
 export default () => {
   const [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])

--- a/examples/example5-circuit-json-rerender.fixture.tsx
+++ b/examples/example5-circuit-json-rerender.fixture.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 import type { ManualEditEvent } from "lib/types/edit-events"
-import { SchematicViewer } from "lib/index"
+import { ControlledSchematicViewer, SchematicViewer } from "lib/index"
 import type { CircuitJson } from "circuit-json"
 
 export default () => {

--- a/examples/example6-click-to-interact.fixture.tsx
+++ b/examples/example6-click-to-interact.fixture.tsx
@@ -1,4 +1,4 @@
-import { ControlledSchematicViewer } from "lib/components/ControlledSchematicViewer"
+import { ControlledSchematicViewer } from "lib/index"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
 
 export default () => (

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export { SchematicViewer } from "./components/SchematicViewer"
+export { ControlledSchematicViewer } from "./components/ControlledSchematicViewer"
 export { MouseTracker } from "./components/MouseTracker"
 export { useMouseEventsOverBoundingBox } from "./hooks/useMouseEventsOverBoundingBox"
 export { AnalogSimulationViewer } from "./components/AnalogSimulationViewer"

--- a/tests/lib-index-exports.test.ts
+++ b/tests/lib-index-exports.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import * as packageExports from "../lib/index"
+
+test("exports ControlledSchematicViewer from the package entry point", () => {
+  expect(packageExports.ControlledSchematicViewer).toBeDefined()
+  expect(typeof packageExports.ControlledSchematicViewer).toBe("function")
+})
+
+test("exports the full expected public API surface", () => {
+  expect(Object.keys(packageExports).sort()).toEqual(
+    [
+      "AnalogSimulationViewer",
+      "ControlledSchematicViewer",
+      "MouseTracker",
+      "SchematicViewer",
+      "useMouseEventsOverBoundingBox",
+    ].sort(),
+  )
+})


### PR DESCRIPTION


### Summary

- `ControlledSchematicViewer` wraps `SchematicViewer` and manages `editEvents`/`onEditEvent` for you — it's the pattern 7 of the example fixtures use for drag-to-edit, and it's referenced in `docs/dragndrop-spec.md`.
- Added `export { ControlledSchematicViewer } from "./components/ControlledSchematicViewer"` to `lib/index.ts`.
- Updated the 7 fixtures that previously deep-imported it from `lib/components/ControlledSchematicViewer` to import from `lib/index` instead, so the examples now demonstrate the actual public API.
- Added `tests/lib-index-exports.test.ts` to lock in the package's export surface so this can't silently regress again.

### Why

`ControlledSchematicViewer` was never added to `lib/index.ts`, so consumers of the published `@tscircuit/schematic-viewer` package had no way to import it  only Cosmos's `lib/*` path alias made the examples work, and that alias doesn't exist in `dist/`.

### Impact

Consumers of `@tscircuit/schematic-viewer` can now import `ControlledSchematicViewer` directly, matching the pattern every relevant example and the drag-and-drop docs already show as the intended usage.

### Validation

- `bun run format:check`
- `bunx tsc --noEmit`
- `bun test` (6 pass, 0 fail)
- Verified visually in Cosmos: ran `bun run start`, drove `example1`, `example4`, `example5`, and `example14` with Playwright after switching their imports to `lib/index` — all render correctly, zero page errors.
