### PR TITLE
Show component details and footprint preview on click

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#ded28270ad82f19a65fa353cf758e7945c030169",
+        "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
         "circuit-json": "^0.0.465",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
@@ -352,7 +352,7 @@
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#ded2827", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-ded2827"],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#7c7b63a", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-7c7b63a"],
 
     "@tscircuit/cli": ["@tscircuit/cli@0.1.1698", "", { "peerDependencies": { "circuit-json": "^0.0.446", "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-VrvC6WkjrNO67jbHBymL4u3aySpTYSEXGcPtJHQFMMkmaUQClRlhdfT7hrabhlnbnXJOd22wTdlSNZi0b0bX/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
         "circuit-json": "^0.0.465",
+        "circuit-json-util-preview": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
         "fflate": "^0.8.3",
@@ -352,7 +352,7 @@
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#7c7b63a", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-7c7b63a"],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 
     "@tscircuit/cli": ["@tscircuit/cli@0.1.1698", "", { "peerDependencies": { "circuit-json": "^0.0.446", "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-VrvC6WkjrNO67jbHBymL4u3aySpTYSEXGcPtJHQFMMkmaUQClRlhdfT7hrabhlnbnXJOd22wTdlSNZi0b0bX/Q=="],
 
@@ -543,6 +543,8 @@
     "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.9", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-thpCtDb9LpAQfGO+Z0hae19sxVAmJAMYM/It9UTMCtyXC3zoUHwRcp/oqtMO/ZIW+JDBhiR8AHmmtKScL2kW7Q=="],
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.43", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-lYXOplosjiYhpWe8IUJ8s9E9G0OH4c+Ygn60lnpco1TEjwD+byUTp3dCk6qDw5VNG5QUdGUD1pe95HoFMzL/TA=="],
+
+    "circuit-json-util-preview": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#7c7b63a", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-7c7b63a"],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.393", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-wyPi94yex6lYMbXpNHyaTzrZM8qqH0nNUJDCl1bzQlpc9Q6P92aU6SwAHEkuxRAmhs3Yk1kS1DZLT9ci3KafDA=="],
 
@@ -1323,8 +1325,6 @@
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
-
-    "tscircuit/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 
     "tscircuit/circuit-json": ["circuit-json@0.0.450", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ctPtiiEdNNeLNyifzJ8x0Nwzoy/N6Iago82Oa7lsOxuzGLo+RX0VaHQAFeWfQ/8TjXRT8mFcw/krbZtPE3DyCg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@tscircuit/circuit-json-util": "^0.0.108",
         "circuit-json": "^0.0.465",
-        "circuit-json-util-preview": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
         "fflate": "^0.8.3",
@@ -352,7 +352,7 @@
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.108", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-6faP8DiOk+ShNUVBuVeThXYTTLTEMc3z+DJAxGTLnPl0ybwV9MKYSL6xwsRlVImZEEl+FMRN164e6sm11EXxMA=="],
 
     "@tscircuit/cli": ["@tscircuit/cli@0.1.1698", "", { "peerDependencies": { "circuit-json": "^0.0.446", "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-VrvC6WkjrNO67jbHBymL4u3aySpTYSEXGcPtJHQFMMkmaUQClRlhdfT7hrabhlnbnXJOd22wTdlSNZi0b0bX/Q=="],
 
@@ -543,8 +543,6 @@
     "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.9", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-thpCtDb9LpAQfGO+Z0hae19sxVAmJAMYM/It9UTMCtyXC3zoUHwRcp/oqtMO/ZIW+JDBhiR8AHmmtKScL2kW7Q=="],
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.43", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-lYXOplosjiYhpWe8IUJ8s9E9G0OH4c+Ygn60lnpco1TEjwD+byUTp3dCk6qDw5VNG5QUdGUD1pe95HoFMzL/TA=="],
-
-    "circuit-json-util-preview": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#7c7b63a", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-7c7b63a"],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.393", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-wyPi94yex6lYMbXpNHyaTzrZM8qqH0nNUJDCl1bzQlpc9Q6P92aU6SwAHEkuxRAmhs3Yk1kS1DZLT9ci3KafDA=="],
 
@@ -1325,6 +1323,8 @@
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "tscircuit/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 
     "tscircuit/circuit-json": ["circuit-json@0.0.450", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ctPtiiEdNNeLNyifzJ8x0Nwzoy/N6Iago82Oa7lsOxuzGLo+RX0VaHQAFeWfQ/8TjXRT8mFcw/krbZtPE3DyCg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,11 @@
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@tscircuit/create-snippet-url": "^0.0.15",
+        "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#ded28270ad82f19a65fa353cf758e7945c030169",
         "circuit-json": "^0.0.465",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
+        "fflate": "^0.8.3",
         "performance-now": "^2.1.0",
         "use-mouse-matrix-transform": "^1.2.2",
       },
@@ -351,15 +352,13 @@
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@github:tscircuit/circuit-json-util#ded2827", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "tscircuit-circuit-json-util-ded2827"],
 
     "@tscircuit/cli": ["@tscircuit/cli@0.1.1698", "", { "peerDependencies": { "circuit-json": "^0.0.446", "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-VrvC6WkjrNO67jbHBymL4u3aySpTYSEXGcPtJHQFMMkmaUQClRlhdfT7hrabhlnbnXJOd22wTdlSNZi0b0bX/Q=="],
 
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.39", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Z8+3UrK919QbwJkGyHsb8DGuHqE66iCylpbF/v132PuvrRbHo+phmOfP9nEQjI63ldh976EsT26qw535H15M1g=="],
 
     "@tscircuit/core": ["@tscircuit/core@0.0.1468", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.13", "calculate-packing": "^0.0.78", "css-select": "5.1.0", "format-si-unit": "^0.0.7", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "schematic-symbols": "*", "typescript": "^5.0.0" } }, "sha512-ZtWuH+0EMwmgnR2VfHNUGztQEPpYSgG5xR+B0yX9vr6I5+WQCTud3m99cTsW8l/xReTlkAmbwBduTtdYmpPHDQ=="],
-
-    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.15", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-ei7096EYmi/LuwaSGiuSA205Z2ZE+O9ha0GVJN09IiKFUYqRaFN8wtHeNOqQ3CUf/JDBRpMc47g0V9npkTynfA=="],
 
     "@tscircuit/eval": ["@tscircuit/eval@0.0.1024", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-s23AEzd/zS5bY1APYJS3uBHLK1VFBWwO9BzjzOtqTxUu9Zo7UhuUo8NYiXtNS449jk0r64DK41ZkD904VvAFpQ=="],
 
@@ -1324,6 +1323,8 @@
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "tscircuit/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 
     "tscircuit/circuit-json": ["circuit-json@0.0.450", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ctPtiiEdNNeLNyifzJ8x0Nwzoy/N6Iago82Oa7lsOxuzGLo+RX0VaHQAFeWfQ/8TjXRT8mFcw/krbZtPE3DyCg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@tscircuit/schematic-viewer",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@tscircuit/create-snippet-url": "^0.0.15",
         "circuit-json": "^0.0.465",
         "circuit-to-svg": "^0.0.393",
         "debug": "^4.4.0",
@@ -357,6 +358,8 @@
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.39", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Z8+3UrK919QbwJkGyHsb8DGuHqE66iCylpbF/v132PuvrRbHo+phmOfP9nEQjI63ldh976EsT26qw535H15M1g=="],
 
     "@tscircuit/core": ["@tscircuit/core@0.0.1468", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.13", "calculate-packing": "^0.0.78", "css-select": "5.1.0", "format-si-unit": "^0.0.7", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "schematic-symbols": "*", "typescript": "^5.0.0" } }, "sha512-ZtWuH+0EMwmgnR2VfHNUGztQEPpYSgG5xR+B0yX9vr6I5+WQCTud3m99cTsW8l/xReTlkAmbwBduTtdYmpPHDQ=="],
+
+    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.15", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-ei7096EYmi/LuwaSGiuSA205Z2ZE+O9ha0GVJN09IiKFUYqRaFN8wtHeNOqQ3CUf/JDBRpMc47g0V9npkTynfA=="],
 
     "@tscircuit/eval": ["@tscircuit/eval@0.0.1024", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-s23AEzd/zS5bY1APYJS3uBHLK1VFBWwO9BzjzOtqTxUu9Zo7UhuUo8NYiXtNS449jk0r64DK41ZkD904VvAFpQ=="],
 

--- a/examples/example14-schematic-component-click.fixture.tsx
+++ b/examples/example14-schematic-component-click.fixture.tsx
@@ -4,7 +4,14 @@ import { useState } from "react"
 
 const circuitJson = renderToCircuitJson(
   <board width="12mm" height="12mm">
-    <resistor name="R1" resistance={1000} footprint="0603" schX={-2} schY={0} />
+    <resistor
+      name="R1"
+      resistance={1000}
+      manufacturerPartNumber="RC0603FR-071KL"
+      footprint="0603"
+      schX={-2}
+      schY={0}
+    />
     <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} schY={0} />
     <trace from=".R1 .pin2" to=".C1 .pin1" />
     <trace from=".R1 .pin1" to=".C1 .pin2" />

--- a/examples/example14-schematic-component-click.fixture.tsx
+++ b/examples/example14-schematic-component-click.fixture.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react"
 import { SchematicViewer } from "lib/components/SchematicViewer"
 import { renderToCircuitJson } from "lib/dev/render-to-circuit-json"
+import { useState } from "react"
 
 const circuitJson = renderToCircuitJson(
   <board width="12mm" height="12mm">
-    <resistor name="R1" resistance={1000} schX={-2} schY={0} />
-    <capacitor name="C1" capacitance="1uF" schX={2} schY={0} />
+    <resistor name="R1" resistance={1000} footprint="0603" schX={-2} schY={0} />
+    <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} schY={0} />
     <trace from=".R1 .pin2" to=".C1 .pin1" />
     <trace from=".R1 .pin1" to=".C1 .pin2" />
   </board>,
@@ -30,7 +30,7 @@ export default function Example() {
       <div style={{ fontFamily: "sans-serif" }}>
         {clickedComponentId
           ? `Last clicked component: ${clickedComponentId}`
-          : "Click a component to highlight it"}
+          : "Click a component to inspect it"}
       </div>
       <div style={{ flex: 1, minHeight: 320 }}>
         <SchematicViewer

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -1,6 +1,7 @@
-import type { AnySourceComponent } from "circuit-json"
+import type { CircuitJson } from "circuit-json"
 import { useMemo } from "react"
 import {
+  type SourceComponent,
   getFootprintPreviewUrl,
   getSourceComponentInfoEntries,
   humanizeComponentField,
@@ -8,8 +9,9 @@ import {
 import { zIndexMap } from "../utils/z-index-map"
 
 interface Props {
-  sourceComponent: AnySourceComponent
+  sourceComponent: SourceComponent
   footprinterString?: string
+  footprintPreviewCircuitJson?: CircuitJson
   left: number
   top: number
   width: number
@@ -28,6 +30,7 @@ const detailLabelStyle: React.CSSProperties = {
 export const SchematicComponentDetailsTooltip = ({
   sourceComponent,
   footprinterString,
+  footprintPreviewCircuitJson,
   left,
   top,
   width,
@@ -40,8 +43,10 @@ export const SchematicComponentDetailsTooltip = ({
   )
   const footprintPreviewUrl = useMemo(
     () =>
-      footprinterString ? getFootprintPreviewUrl(footprinterString) : undefined,
-    [footprinterString],
+      footprintPreviewCircuitJson?.length
+        ? getFootprintPreviewUrl(footprintPreviewCircuitJson)
+        : undefined,
+    [footprintPreviewCircuitJson],
   )
   const componentType = sourceComponent.ftype
     ? humanizeComponentField(sourceComponent.ftype)
@@ -162,7 +167,7 @@ export const SchematicComponentDetailsTooltip = ({
         </dl>
       )}
 
-      {footprinterString && footprintPreviewUrl && (
+      {footprinterString && (
         <div style={{ padding: "16px 18px 18px" }}>
           <div style={{ ...detailLabelStyle, marginBottom: 7 }}>Footprint</div>
           <code
@@ -181,28 +186,30 @@ export const SchematicComponentDetailsTooltip = ({
           >
             {footprinterString}
           </code>
-          <div
-            style={{
-              height: "210px",
-              overflow: "hidden",
-              border: "1px solid #e2e8f0",
-              borderRadius: "9px",
-              background: "#f8fafc",
-            }}
-          >
-            <img
-              src={footprintPreviewUrl}
-              alt={`${footprinterString} PCB footprint`}
-              loading="lazy"
-              referrerPolicy="no-referrer"
+          {footprintPreviewUrl && (
+            <div
               style={{
-                display: "block",
-                width: "100%",
-                height: "100%",
-                objectFit: "contain",
+                height: "210px",
+                overflow: "hidden",
+                border: "1px solid #e2e8f0",
+                borderRadius: "9px",
+                background: "#f8fafc",
               }}
-            />
-          </div>
+            >
+              <img
+                src={footprintPreviewUrl}
+                alt={`${sourceComponent.name} ${footprinterString} PCB footprint`}
+                loading="lazy"
+                referrerPolicy="no-referrer"
+                style={{
+                  display: "block",
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "contain",
+                }}
+              />
+            </div>
+          )}
         </div>
       )}
     </dialog>

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -1,6 +1,7 @@
 import type { CircuitJson } from "circuit-json"
 import { useMemo } from "react"
 import {
+  type PcbBounds,
   type SourceComponent,
   getFootprintPreviewUrl,
   getSourceComponentInfoEntries,
@@ -12,6 +13,7 @@ interface Props {
   sourceComponent: SourceComponent
   footprinterString?: string
   footprintPreviewCircuitJson?: CircuitJson
+  footprintPreviewViewBox?: PcbBounds
   left: number
   top: number
   width: number
@@ -31,6 +33,7 @@ export const SchematicComponentDetailsTooltip = ({
   sourceComponent,
   footprinterString,
   footprintPreviewCircuitJson,
+  footprintPreviewViewBox,
   left,
   top,
   width,
@@ -43,10 +46,13 @@ export const SchematicComponentDetailsTooltip = ({
   )
   const footprintPreviewUrl = useMemo(
     () =>
-      footprintPreviewCircuitJson?.length
-        ? getFootprintPreviewUrl(footprintPreviewCircuitJson)
+      footprintPreviewCircuitJson?.length && footprintPreviewViewBox
+        ? getFootprintPreviewUrl(
+            footprintPreviewCircuitJson,
+            footprintPreviewViewBox,
+          )
         : undefined,
-    [footprintPreviewCircuitJson],
+    [footprintPreviewCircuitJson, footprintPreviewViewBox],
   )
   const componentType = sourceComponent.ftype
     ? humanizeComponentField(sourceComponent.ftype)

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -1,0 +1,210 @@
+import type { AnySourceComponent } from "circuit-json"
+import { useMemo } from "react"
+import {
+  getFootprintPreviewUrl,
+  getSourceComponentInfoEntries,
+  humanizeComponentField,
+} from "../utils/component-details"
+import { zIndexMap } from "../utils/z-index-map"
+
+interface Props {
+  sourceComponent: AnySourceComponent
+  footprinterString?: string
+  left: number
+  top: number
+  width: number
+  maxHeight: number
+  onClose: () => void
+}
+
+const detailLabelStyle: React.CSSProperties = {
+  color: "#64748b",
+  fontSize: "11px",
+  fontWeight: 700,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+}
+
+export const SchematicComponentDetailsTooltip = ({
+  sourceComponent,
+  footprinterString,
+  left,
+  top,
+  width,
+  maxHeight,
+  onClose,
+}: Props) => {
+  const infoEntries = useMemo(
+    () => getSourceComponentInfoEntries(sourceComponent),
+    [sourceComponent],
+  )
+  const footprintPreviewUrl = useMemo(
+    () =>
+      footprinterString ? getFootprintPreviewUrl(footprinterString) : undefined,
+    [footprinterString],
+  )
+  const componentType = sourceComponent.ftype
+    ? humanizeComponentField(sourceComponent.ftype)
+    : "Component"
+
+  return (
+    <dialog
+      open
+      aria-label={`${sourceComponent.name} component details`}
+      data-schematic-component-details-tooltip
+      style={{
+        position: "absolute",
+        left,
+        right: "auto",
+        top,
+        bottom: "auto",
+        width,
+        maxHeight,
+        margin: 0,
+        padding: 0,
+        overflowY: "auto",
+        boxSizing: "border-box",
+        border: "1px solid #cbd5e1",
+        borderRadius: "12px",
+        backgroundColor: "rgba(255, 255, 255, 0.98)",
+        boxShadow:
+          "0 20px 25px -5px rgba(15, 23, 42, 0.18), 0 8px 10px -6px rgba(15, 23, 42, 0.12)",
+        color: "#0f172a",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        pointerEvents: "auto",
+        userSelect: "text",
+        WebkitUserSelect: "text",
+        zIndex: zIndexMap.schematicComponentDetailsTooltip,
+      }}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: "16px",
+          padding: "18px 18px 14px",
+          borderBottom: "1px solid #e2e8f0",
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: "20px",
+              fontWeight: 750,
+              lineHeight: 1.2,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {sourceComponent.display_name ?? sourceComponent.name}
+          </div>
+          <div style={{ color: "#64748b", fontSize: "13px", marginTop: 4 }}>
+            {componentType}
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Close component details"
+          onClick={onClose}
+          style={{
+            display: "grid",
+            placeItems: "center",
+            flex: "0 0 auto",
+            width: "30px",
+            height: "30px",
+            padding: 0,
+            border: "1px solid #e2e8f0",
+            borderRadius: "8px",
+            background: "#f8fafc",
+            color: "#475569",
+            cursor: "pointer",
+            fontSize: "20px",
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {infoEntries.length > 0 && (
+        <dl
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(110px, 0.8fr) minmax(0, 1.2fr)",
+            gap: "10px 18px",
+            margin: 0,
+            padding: "16px 18px",
+            borderBottom: footprinterString ? "1px solid #e2e8f0" : undefined,
+          }}
+        >
+          {infoEntries.map((entry) => (
+            <div key={entry.key} style={{ display: "contents" }}>
+              <dt style={detailLabelStyle}>{entry.label}</dt>
+              <dd
+                style={{
+                  minWidth: 0,
+                  margin: 0,
+                  color: "#1e293b",
+                  fontFamily:
+                    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+                  fontSize: "12px",
+                  lineHeight: 1.45,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {entry.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {footprinterString && footprintPreviewUrl && (
+        <div style={{ padding: "16px 18px 18px" }}>
+          <div style={{ ...detailLabelStyle, marginBottom: 7 }}>Footprint</div>
+          <code
+            style={{
+              display: "block",
+              marginBottom: "12px",
+              padding: "8px 10px",
+              borderRadius: "7px",
+              background: "#f1f5f9",
+              color: "#334155",
+              fontSize: "12px",
+              lineHeight: 1.4,
+              overflowWrap: "anywhere",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {footprinterString}
+          </code>
+          <div
+            style={{
+              height: "210px",
+              overflow: "hidden",
+              border: "1px solid #e2e8f0",
+              borderRadius: "9px",
+              background: "#f8fafc",
+            }}
+          >
+            <img
+              src={footprintPreviewUrl}
+              alt={`${footprinterString} PCB footprint`}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              style={{
+                display: "block",
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </dialog>
+  )
+}

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -19,8 +19,10 @@ import { toString as transformToString } from "transformation-matrix"
 import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useContextMenu } from "../hooks/useContextMenu"
+import { getSchematicComponentDetails } from "../utils/component-details"
 import { zIndexMap } from "../utils/z-index-map"
 import { MouseTracker } from "./MouseTracker"
+import { SchematicComponentDetailsTooltip } from "./SchematicComponentDetailsTooltip"
 import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
 import { SchematicSheetSelector } from "./SchematicSheetSelector"
@@ -49,6 +51,12 @@ interface Props {
   }) => void
   /** Called when the active schematic sheet changes (multi-sheet circuits). */
   onSchematicSheetChange?: (schematicSheetId: string) => void
+}
+
+interface SelectedSchematicComponent {
+  schematicComponentId: string
+  anchorX: number
+  anchorY: number
 }
 
 export const SchematicViewer = ({
@@ -161,6 +169,8 @@ export const SchematicViewer = ({
   const [isHoveringClickableComponent, setIsHoveringClickableComponent] =
     useState(false)
   const hoveringComponentsRef = useRef<Set<string>>(new Set())
+  const [selectedSchematicComponent, setSelectedSchematicComponent] =
+    useState<SelectedSchematicComponent | null>(null)
 
   const handleComponentHoverChange = useCallback(
     (componentId: string, isHovering: boolean) => {
@@ -286,6 +296,101 @@ export const SchematicViewer = ({
   } = useContextMenu({ containerRef })
 
   const { containerWidth, containerHeight } = useResizeHandling(containerRef)
+  const selectedComponentDetails = useMemo(
+    () =>
+      selectedSchematicComponent
+        ? getSchematicComponentDetails(
+            circuitJson,
+            selectedSchematicComponent.schematicComponentId,
+          )
+        : null,
+    [circuitJsonKey, circuitJson, selectedSchematicComponent],
+  )
+
+  const componentTooltipLayout = useMemo(() => {
+    if (!selectedSchematicComponent || !containerWidth || !containerHeight) {
+      return null
+    }
+
+    const margin = 12
+    const gap = 14
+    const width = Math.min(420, containerWidth - margin * 2)
+    const maxHeight = Math.min(520, containerHeight - margin * 2)
+    const { anchorX, anchorY } = selectedSchematicComponent
+
+    const rightOfAnchor = anchorX + gap
+    const leftOfAnchor = anchorX - width - gap
+    const left =
+      rightOfAnchor + width <= containerWidth - margin
+        ? rightOfAnchor
+        : leftOfAnchor >= margin
+          ? leftOfAnchor
+          : Math.max(
+              margin,
+              Math.min(anchorX - width / 2, containerWidth - width - margin),
+            )
+    const top = Math.max(
+      margin,
+      Math.min(anchorY - 24, containerHeight - maxHeight - margin),
+    )
+
+    return { left, top, width, maxHeight }
+  }, [selectedSchematicComponent, containerWidth, containerHeight])
+
+  const handleSchematicComponentClick = useCallback(
+    (schematicComponentId: string, event: MouseEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-schematic-component-details-tooltip]")
+      ) {
+        return
+      }
+
+      const containerRect = containerRef.current?.getBoundingClientRect()
+      if (!containerRect) return
+
+      setSelectedSchematicComponent({
+        schematicComponentId,
+        anchorX: event.clientX - containerRect.left,
+        anchorY: event.clientY - containerRect.top,
+      })
+      onSchematicComponentClicked?.({
+        schematicComponentId,
+        event,
+      })
+    },
+    [containerRef, onSchematicComponentClicked],
+  )
+
+  useEffect(() => {
+    setSelectedSchematicComponent(null)
+  }, [circuitJsonKey, activeSheetId])
+
+  useEffect(() => {
+    if (!selectedSchematicComponent) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedSchematicComponent(null)
+      }
+    }
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-schematic-component-details-tooltip]")
+      ) {
+        return
+      }
+      setSelectedSchematicComponent(null)
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    document.addEventListener("mousedown", handleDocumentMouseDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+      document.removeEventListener("mousedown", handleDocumentMouseDown)
+    }
+  }, [selectedSchematicComponent])
+
   const svgString = useMemo(() => {
     if (!containerWidth || !containerHeight) return ""
 
@@ -350,11 +455,7 @@ export const SchematicViewer = ({
             : "auto",
           transformOrigin: "0 0",
         }}
-        className={
-          onSchematicComponentClicked
-            ? "schematic-component-clickable"
-            : undefined
-        }
+        className="schematic-component-clickable"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
         dangerouslySetInnerHTML={{ __html: svgString }}
       />
@@ -370,13 +471,11 @@ export const SchematicViewer = ({
             svg :is(g.trace, g.trace-overlays, g[data-schematic-component-id], [data-schematic-net-label-id]) { transition: opacity 0.12s ease-in-out; }`}
         </style>
       )}
-      {onSchematicComponentClicked && (
-        <style>
-          {
-            ".schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }"
-          }
-        </style>
-      )}
+      <style>
+        {
+          ".schematic-component-clickable [data-schematic-component-id]:hover { cursor: pointer !important; }"
+        }
+      </style>
       {onSchematicPortClicked && (
         <style>
           {"[data-schematic-port-id]:hover { cursor: pointer !important; }"}
@@ -391,7 +490,7 @@ export const SchematicViewer = ({
           cursor:
             clickToInteractEnabled && !isInteractionEnabled
               ? "pointer"
-              : isHoveringClickableComponent && onSchematicComponentClicked
+              : isHoveringClickableComponent
                 ? "pointer"
                 : isHoveringClickablePort && onSchematicPortClicked
                   ? "pointer"
@@ -490,25 +589,27 @@ export const SchematicViewer = ({
           selectedSheetId={activeSheetId}
           onSelectSheet={handleSelectSheet}
         />
-        {onSchematicComponentClicked &&
-          schematicComponentIds.map((componentId) => (
-            <SchematicComponentMouseTarget
-              key={componentId}
-              componentId={componentId}
-              svgDivRef={svgDivRef}
-              containerRef={containerRef}
-              showOutline={true}
-              circuitJsonKey={circuitJsonKey}
-              onHoverChange={handleComponentHoverChange}
-              onComponentClick={(id, event) => {
-                onSchematicComponentClicked?.({
-                  schematicComponentId: id,
-                  event,
-                })
-              }}
-            />
-          ))}
+        {schematicComponentIds.map((componentId) => (
+          <SchematicComponentMouseTarget
+            key={componentId}
+            componentId={componentId}
+            svgDivRef={svgDivRef}
+            containerRef={containerRef}
+            showOutline={true}
+            circuitJsonKey={circuitJsonKey}
+            onHoverChange={handleComponentHoverChange}
+            onComponentClick={handleSchematicComponentClick}
+          />
+        ))}
         {svgDiv}
+        {selectedComponentDetails && componentTooltipLayout && (
+          <SchematicComponentDetailsTooltip
+            sourceComponent={selectedComponentDetails.sourceComponent}
+            footprinterString={selectedComponentDetails.footprinterString}
+            {...componentTooltipLayout}
+            onClose={() => setSelectedSchematicComponent(null)}
+          />
+        )}
         {showSchematicPortsInternal &&
           schematicPortsInfo.map(({ portId, label }) => (
             <SchematicPortMouseTarget

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -606,6 +606,9 @@ export const SchematicViewer = ({
           <SchematicComponentDetailsTooltip
             sourceComponent={selectedComponentDetails.sourceComponent}
             footprinterString={selectedComponentDetails.footprinterString}
+            footprintPreviewCircuitJson={
+              selectedComponentDetails.footprintPreviewCircuitJson
+            }
             {...componentTooltipLayout}
             onClose={() => setSelectedSchematicComponent(null)}
           />

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -609,6 +609,9 @@ export const SchematicViewer = ({
             footprintPreviewCircuitJson={
               selectedComponentDetails.footprintPreviewCircuitJson
             }
+            footprintPreviewViewBox={
+              selectedComponentDetails.footprintPreviewViewBox
+            }
             {...componentTooltipLayout}
             onClose={() => setSelectedSchematicComponent(null)}
           />

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -1,10 +1,17 @@
-import { createSvgUrl } from "@tscircuit/create-snippet-url"
+import {
+  type PcbBounds,
+  getPcbElementBounds,
+  getPcbElementsWithinBounds,
+} from "@tscircuit/circuit-json-util"
 import type {
   CadComponent,
   CircuitJson,
   PcbComponent,
   SchematicComponent,
 } from "circuit-json"
+import { gzipSync, strToU8 } from "fflate"
+
+export type { PcbBounds } from "@tscircuit/circuit-json-util"
 
 export type SourceComponent = Extract<
   CircuitJson[number],
@@ -17,6 +24,7 @@ export interface SchematicComponentDetails {
   pcbComponent?: PcbComponent
   footprinterString?: string
   footprintPreviewCircuitJson?: CircuitJson
+  footprintPreviewViewBox?: PcbBounds
 }
 
 export interface ComponentInfoEntry {
@@ -154,64 +162,82 @@ export const getSchematicComponentDetails = (
         | undefined
     )?.footprinter_string ?? cadComponent?.footprinter_string
 
+  const footprintPreview = pcbComponent
+    ? getPcbComponentPreview(circuitJson, pcbComponent.pcb_component_id)
+    : null
+
   return {
     schematicComponent,
     sourceComponent,
     pcbComponent,
     footprinterString,
-    footprintPreviewCircuitJson: pcbComponent
-      ? getPcbComponentPreviewCircuitJson(
-          circuitJson,
-          pcbComponent.pcb_component_id,
-        )
-      : undefined,
+    footprintPreviewCircuitJson: footprintPreview?.circuitJson,
+    footprintPreviewViewBox: footprintPreview?.viewBox,
   }
 }
 
-const hasPcbComponentId = (
-  element: CircuitJson[number],
-): element is CircuitJson[number] & { pcb_component_id: string } =>
-  "pcb_component_id" in element && typeof element.pcb_component_id === "string"
+const PCB_PREVIEW_PADDING_MM = 2
+
+interface PcbComponentPreview {
+  circuitJson: CircuitJson
+  viewBox: PcbBounds
+}
 
 /**
- * Keep the component and every PCB primitive generated for its footprint.
- * In particular, this preserves the real reference-designator silkscreen text
- * instead of regenerating the footprint under a generic component name.
+ * Select the real PCB context around a component. Elements only need to
+ * intersect the view box, so long traces and the board remain available for
+ * rendering while svg.tscircuit.com clips the parts outside the preview.
  */
-export const getPcbComponentPreviewCircuitJson = (
+export const getPcbComponentPreview = (
   circuitJson: CircuitJson,
   pcbComponentId: string,
-): CircuitJson => {
+): PcbComponentPreview | null => {
   const pcbComponent = circuitJson.find(
     (element): element is PcbComponent =>
       element.type === "pcb_component" &&
       element.pcb_component_id === pcbComponentId,
   )
-  if (!pcbComponent) return []
+  if (!pcbComponent) return null
 
-  return circuitJson.filter(
-    (element) =>
-      (element.type === "source_component" &&
-        element.source_component_id === pcbComponent.source_component_id) ||
-      (element.type === "pcb_component" &&
-        element.pcb_component_id === pcbComponentId) ||
-      (hasPcbComponentId(element) &&
-        element.pcb_component_id === pcbComponentId),
-  )
+  const componentBounds = getPcbElementBounds(pcbComponent)
+  if (!componentBounds) return null
+
+  const viewBox = {
+    minX: componentBounds.minX - PCB_PREVIEW_PADDING_MM,
+    minY: componentBounds.minY - PCB_PREVIEW_PADDING_MM,
+    maxX: componentBounds.maxX + PCB_PREVIEW_PADDING_MM,
+    maxY: componentBounds.maxY + PCB_PREVIEW_PADDING_MM,
+  }
+
+  return {
+    circuitJson: getPcbElementsWithinBounds(circuitJson, viewBox),
+    viewBox,
+  }
+}
+
+const bytesToBase64 = (bytes: Uint8Array) => {
+  let binary = ""
+  const chunkSize = 8192
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize))
+  }
+  return btoa(binary)
 }
 
 export const getFootprintPreviewUrl = (
   footprintPreviewCircuitJson: CircuitJson,
+  viewBox: PcbBounds,
 ) => {
-  const code = `
-const circuitJson = ${JSON.stringify(footprintPreviewCircuitJson)}
-
-export default () => (
-  <board circuitJson={circuitJson} />
-)
-`
-
-  const url = new URL(createSvgUrl(code, "pcb"))
+  const encodedCircuitJson = bytesToBase64(
+    gzipSync(strToU8(JSON.stringify(footprintPreviewCircuitJson))),
+  )
+  const url = new URL("https://svg.tscircuit.com/")
+  url.searchParams.set("svg_type", "pcb")
+  url.searchParams.set("circuit_json", encodedCircuitJson)
+  url.searchParams.set(
+    "viewbox",
+    [viewBox.minX, viewBox.minY, viewBox.maxX, viewBox.maxY].join(","),
+  )
   url.searchParams.set("background_color", "#f8fafc")
   return url.toString()
 }

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -1,0 +1,171 @@
+import { createSvgUrl } from "@tscircuit/create-snippet-url"
+import type {
+  AnySourceComponent,
+  CadComponent,
+  CircuitJson,
+  PcbComponent,
+  SchematicComponent,
+} from "circuit-json"
+
+export interface SchematicComponentDetails {
+  schematicComponent: SchematicComponent
+  sourceComponent: AnySourceComponent
+  pcbComponent?: PcbComponent
+  footprinterString?: string
+}
+
+export interface ComponentInfoEntry {
+  key: string
+  label: string
+  value: string
+}
+
+const hiddenSourceComponentKeys = new Set([
+  "type",
+  "source_component_id",
+  "source_group_id",
+  "subcircuit_id",
+  "name",
+  "display_name",
+  "ftype",
+])
+
+const priorityKeys = [
+  "resistance",
+  "capacitance",
+  "inductance",
+  "frequency",
+  "voltage",
+  "current",
+  "max_voltage_rating",
+  "max_current_rating",
+  "power_rating",
+  "manufacturer_part_number",
+  "supplier_part_numbers",
+]
+
+const getKeyPriority = (key: string) => {
+  const priority = priorityKeys.indexOf(key)
+  return priority === -1 ? priorityKeys.length : priority
+}
+
+export const humanizeComponentField = (field: string) =>
+  field
+    .replace(/^simple_/, "")
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+
+const formatObjectValue = (value: Record<string, unknown>) =>
+  Object.entries(value)
+    .map(([key, nestedValue]) => {
+      const formattedNestedValue = Array.isArray(nestedValue)
+        ? nestedValue.join(", ")
+        : String(nestedValue)
+      return `${humanizeComponentField(key)}: ${formattedNestedValue}`
+    })
+    .join(" · ")
+
+const formatComponentValue = (
+  sourceComponent: AnySourceComponent,
+  key: string,
+  value: unknown,
+) => {
+  const displayValue = (sourceComponent as Record<string, unknown>)[
+    `display_${key}`
+  ]
+  if (typeof displayValue === "string" && displayValue.trim()) {
+    return displayValue
+  }
+  if (typeof value === "boolean") return value ? "Yes" : "No"
+  if (Array.isArray(value)) return value.join(", ")
+  if (value && typeof value === "object") {
+    return formatObjectValue(value as Record<string, unknown>)
+  }
+  return String(value)
+}
+
+export const getSourceComponentInfoEntries = (
+  sourceComponent: AnySourceComponent,
+): ComponentInfoEntry[] =>
+  Object.entries(sourceComponent as Record<string, unknown>)
+    .filter(([key, value]) => {
+      if (hiddenSourceComponentKeys.has(key)) return false
+      if (
+        key.startsWith("display_") &&
+        key.slice("display_".length) in sourceComponent
+      ) {
+        return false
+      }
+      return value !== undefined && value !== null && value !== ""
+    })
+    .sort(([keyA], [keyB]) => {
+      const priorityDifference = getKeyPriority(keyA) - getKeyPriority(keyB)
+      return priorityDifference || keyA.localeCompare(keyB)
+    })
+    .map(([key, value]) => ({
+      key,
+      label: humanizeComponentField(key),
+      value: formatComponentValue(sourceComponent, key, value),
+    }))
+
+export const getSchematicComponentDetails = (
+  circuitJson: CircuitJson,
+  schematicComponentId: string,
+): SchematicComponentDetails | null => {
+  const schematicComponent = circuitJson.find(
+    (element): element is SchematicComponent =>
+      element.type === "schematic_component" &&
+      element.schematic_component_id === schematicComponentId,
+  )
+  if (!schematicComponent) return null
+
+  const sourceComponent = circuitJson.find(
+    (element): element is AnySourceComponent =>
+      element.type === "source_component" &&
+      element.source_component_id === schematicComponent.source_component_id,
+  )
+  if (!sourceComponent) return null
+
+  const pcbComponent = circuitJson.find(
+    (element): element is PcbComponent =>
+      element.type === "pcb_component" &&
+      element.source_component_id === sourceComponent.source_component_id,
+  )
+  const cadComponent = circuitJson.find(
+    (element): element is CadComponent =>
+      element.type === "cad_component" &&
+      element.source_component_id === sourceComponent.source_component_id &&
+      (!pcbComponent ||
+        element.pcb_component_id === pcbComponent.pcb_component_id),
+  )
+
+  // Newer Circuit JSON producers may put this directly on pcb_component;
+  // current producers retain it on the associated cad_component.
+  const footprinterString =
+    (
+      pcbComponent as
+        | (PcbComponent & { footprinter_string?: string })
+        | undefined
+    )?.footprinter_string ?? cadComponent?.footprinter_string
+
+  return {
+    schematicComponent,
+    sourceComponent,
+    pcbComponent,
+    footprinterString,
+  }
+}
+
+export const getFootprintPreviewUrl = (footprinterString: string) => {
+  const code = `
+export default () => (
+  <board>
+    <chip name="U1" footprint={${JSON.stringify(footprinterString)}} />
+  </board>
+)
+`
+
+  const url = new URL(createSvgUrl(code, "pcb"))
+  url.searchParams.set("background_color", "#f8fafc")
+  return url.toString()
+}

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -2,7 +2,7 @@ import {
   type PcbBounds,
   getPcbElementBounds,
   getPcbElementsWithinBounds,
-} from "@tscircuit/circuit-json-util"
+} from "circuit-json-util-preview/lib/get-bounds-of-pcb-elements"
 import type {
   CadComponent,
   CircuitJson,
@@ -11,7 +11,7 @@ import type {
 } from "circuit-json"
 import { gzipSync, strToU8 } from "fflate"
 
-export type { PcbBounds } from "@tscircuit/circuit-json-util"
+export type { PcbBounds } from "circuit-json-util-preview/lib/get-bounds-of-pcb-elements"
 
 export type SourceComponent = Extract<
   CircuitJson[number],

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -28,6 +28,7 @@ const hiddenSourceComponentKeys = new Set([
   "name",
   "display_name",
   "ftype",
+  "are_pins_interchangeable",
 ])
 
 const priorityKeys = [

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -1,17 +1,22 @@
 import { createSvgUrl } from "@tscircuit/create-snippet-url"
 import type {
-  AnySourceComponent,
   CadComponent,
   CircuitJson,
   PcbComponent,
   SchematicComponent,
 } from "circuit-json"
 
+export type SourceComponent = Extract<
+  CircuitJson[number],
+  { type: "source_component" }
+>
+
 export interface SchematicComponentDetails {
   schematicComponent: SchematicComponent
-  sourceComponent: AnySourceComponent
+  sourceComponent: SourceComponent
   pcbComponent?: PcbComponent
   footprinterString?: string
+  footprintPreviewCircuitJson?: CircuitJson
 }
 
 export interface ComponentInfoEntry {
@@ -67,7 +72,7 @@ const formatObjectValue = (value: Record<string, unknown>) =>
     .join(" · ")
 
 const formatComponentValue = (
-  sourceComponent: AnySourceComponent,
+  sourceComponent: SourceComponent,
   key: string,
   value: unknown,
 ) => {
@@ -86,7 +91,7 @@ const formatComponentValue = (
 }
 
 export const getSourceComponentInfoEntries = (
-  sourceComponent: AnySourceComponent,
+  sourceComponent: SourceComponent,
 ): ComponentInfoEntry[] =>
   Object.entries(sourceComponent as Record<string, unknown>)
     .filter(([key, value]) => {
@@ -121,7 +126,7 @@ export const getSchematicComponentDetails = (
   if (!schematicComponent) return null
 
   const sourceComponent = circuitJson.find(
-    (element): element is AnySourceComponent =>
+    (element): element is SourceComponent =>
       element.type === "source_component" &&
       element.source_component_id === schematicComponent.source_component_id,
   )
@@ -154,15 +159,55 @@ export const getSchematicComponentDetails = (
     sourceComponent,
     pcbComponent,
     footprinterString,
+    footprintPreviewCircuitJson: pcbComponent
+      ? getPcbComponentPreviewCircuitJson(
+          circuitJson,
+          pcbComponent.pcb_component_id,
+        )
+      : undefined,
   }
 }
 
-export const getFootprintPreviewUrl = (footprinterString: string) => {
+const hasPcbComponentId = (
+  element: CircuitJson[number],
+): element is CircuitJson[number] & { pcb_component_id: string } =>
+  "pcb_component_id" in element && typeof element.pcb_component_id === "string"
+
+/**
+ * Keep the component and every PCB primitive generated for its footprint.
+ * In particular, this preserves the real reference-designator silkscreen text
+ * instead of regenerating the footprint under a generic component name.
+ */
+export const getPcbComponentPreviewCircuitJson = (
+  circuitJson: CircuitJson,
+  pcbComponentId: string,
+): CircuitJson => {
+  const pcbComponent = circuitJson.find(
+    (element): element is PcbComponent =>
+      element.type === "pcb_component" &&
+      element.pcb_component_id === pcbComponentId,
+  )
+  if (!pcbComponent) return []
+
+  return circuitJson.filter(
+    (element) =>
+      (element.type === "source_component" &&
+        element.source_component_id === pcbComponent.source_component_id) ||
+      (element.type === "pcb_component" &&
+        element.pcb_component_id === pcbComponentId) ||
+      (hasPcbComponentId(element) &&
+        element.pcb_component_id === pcbComponentId),
+  )
+}
+
+export const getFootprintPreviewUrl = (
+  footprintPreviewCircuitJson: CircuitJson,
+) => {
   const code = `
+const circuitJson = ${JSON.stringify(footprintPreviewCircuitJson)}
+
 export default () => (
-  <board>
-    <chip name="U1" footprint={${JSON.stringify(footprinterString)}} />
-  </board>
+  <board circuitJson={circuitJson} />
 )
 `
 

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -2,7 +2,7 @@ import {
   type PcbBounds,
   getPcbElementBounds,
   getPcbElementsWithinBounds,
-} from "circuit-json-util-preview/lib/get-bounds-of-pcb-elements"
+} from "@tscircuit/circuit-json-util"
 import type {
   CadComponent,
   CircuitJson,
@@ -11,7 +11,7 @@ import type {
 } from "circuit-json"
 import { gzipSync, strToU8 } from "fflate"
 
-export type { PcbBounds } from "circuit-json-util-preview/lib/get-bounds-of-pcb-elements"
+export type { PcbBounds } from "@tscircuit/circuit-json-util"
 
 export type SourceComponent = Extract<
   CircuitJson[number],

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -3,6 +3,7 @@ export const zIndexMap = {
   viewMenu: 55,
   viewMenuIcon: 48,
   clickToInteractOverlay: 100,
+  schematicComponentDetailsTooltip: 105,
   schematicComponentHoverOutline: 47,
   schematicPortHoverOutline: 48,
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@tscircuit/create-snippet-url": "^0.0.15",
     "circuit-json": "^0.0.465",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@tscircuit/circuit-json-util": "^0.0.108",
     "circuit-json": "^0.0.465",
-    "circuit-json-util-preview": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",
     "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#ded28270ad82f19a65fa353cf758e7945c030169",
+    "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
     "circuit-json": "^0.0.465",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
     "circuit-json": "^0.0.465",
+    "circuit-json-util-preview": "github:tscircuit/circuit-json-util#7c7b63a3019048d8dfbe37e53d19224c8e2c5df4",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",
     "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@tscircuit/create-snippet-url": "^0.0.15",
+    "@tscircuit/circuit-json-util": "github:tscircuit/circuit-json-util#ded28270ad82f19a65fa353cf758e7945c030169",
     "circuit-json": "^0.0.465",
     "circuit-to-svg": "^0.0.393",
     "debug": "^4.4.0",
+    "fflate": "^0.8.3",
     "performance-now": "^2.1.0",
     "use-mouse-matrix-transform": "^1.2.2"
   }

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -6,7 +6,9 @@ import { createRoot } from "react-dom/client"
 import { SchematicViewer } from "../lib/components/SchematicViewer"
 import { renderToCircuitJson } from "../lib/dev/render-to-circuit-json"
 import {
+  type SourceComponent,
   getFootprintPreviewUrl,
+  getPcbComponentPreviewCircuitJson,
   getSchematicComponentDetails,
   getSourceComponentInfoEntries,
 } from "../lib/utils/component-details"
@@ -158,7 +160,10 @@ test("component details include source values and the footprinter string", () =>
   ).toBe(false)
 
   const capacitor = circuitJson.find(
-    (element) => element.type === "source_component" && element.name === "C1",
+    (element): element is SourceComponent =>
+      element.type === "source_component" &&
+      element.ftype === "simple_capacitor" &&
+      element.name === "C1",
   )!
   expect(getSourceComponentInfoEntries(capacitor)).toContainEqual({
     key: "capacitance",
@@ -167,9 +172,16 @@ test("component details include source values and the footprinter string", () =>
   })
 })
 
-test("footprint preview URLs safely encode the footprinter string", () => {
-  const footprinterString = 'kicad:Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"test'
-  const previewUrl = new URL(getFootprintPreviewUrl(footprinterString))
+test("footprint previews use the selected component's actual PCB elements", () => {
+  const details = getSchematicComponentDetails(
+    circuitJson,
+    "schematic_component_0",
+  )!
+  const previewCircuitJson = getPcbComponentPreviewCircuitJson(
+    circuitJson,
+    details.pcbComponent!.pcb_component_id,
+  )
+  const previewUrl = new URL(getFootprintPreviewUrl(previewCircuitJson))
   const generatedCode = getUncompressedSnippetString(
     previewUrl.searchParams.get("code")!,
   )
@@ -177,9 +189,21 @@ test("footprint preview URLs safely encode the footprinter string", () => {
   expect(previewUrl.origin).toBe("https://svg.tscircuit.com")
   expect(previewUrl.searchParams.get("svg_type")).toBe("pcb")
   expect(previewUrl.searchParams.get("background_color")).toBe("#f8fafc")
-  expect(generatedCode).toContain(
-    `footprint={${JSON.stringify(footprinterString)}}`,
+  expect(generatedCode).toContain("<board circuitJson={circuitJson} />")
+  expect(generatedCode).not.toContain('name="U1"')
+  expect(previewCircuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_silkscreen_text",
+      pcb_component_id: details.pcbComponent!.pcb_component_id,
+      text: "R1",
+    }),
   )
+  expect(
+    previewCircuitJson.some(
+      (element) =>
+        element.type === "pcb_silkscreen_text" && element.text === "C1",
+    ),
+  ).toBe(false)
 })
 
 test("clicking a component opens its details without requiring a callback", async () => {
@@ -231,6 +255,9 @@ test("clicking a component opens its details without requiring a callback", asyn
     expect(tooltip?.textContent).toContain("res0603")
     expect(tooltip?.querySelector("img")?.getAttribute("src")).toContain(
       "https://svg.tscircuit.com/",
+    )
+    expect(tooltip?.querySelector("img")?.getAttribute("alt")).toBe(
+      "R1 res0603 PCB footprint",
     )
 
     await act(async () => {

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -1,0 +1,235 @@
+import { expect, test } from "bun:test"
+import { getUncompressedSnippetString } from "@tscircuit/create-snippet-url"
+import { JSDOM } from "jsdom"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { SchematicViewer } from "../lib/components/SchematicViewer"
+import { renderToCircuitJson } from "../lib/dev/render-to-circuit-json"
+import {
+  getFootprintPreviewUrl,
+  getSchematicComponentDetails,
+  getSourceComponentInfoEntries,
+} from "../lib/utils/component-details"
+
+const circuitJson = renderToCircuitJson(
+  <board width="12mm" height="12mm">
+    <resistor name="R1" resistance={1000} footprint="0603" schX={-2} />
+    <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} />
+  </board>,
+)
+
+const installDom = () => {
+  const dom = new JSDOM('<div id="root"></div>', {
+    url: "http://localhost",
+  })
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    Element: globalThis.Element,
+    Event: globalThis.Event,
+    HTMLElement: globalThis.HTMLElement,
+    MouseEvent: globalThis.MouseEvent,
+    MutationObserver: globalThis.MutationObserver,
+    Node: globalThis.Node,
+    ResizeObserver: globalThis.ResizeObserver,
+    getComputedStyle: globalThis.getComputedStyle,
+  }
+
+  class TestResizeObserver {
+    constructor(private callback: ResizeObserverCallback) {}
+
+    observe() {
+      this.callback([], this as unknown as ResizeObserver)
+    }
+
+    disconnect() {}
+  }
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    Element: dom.window.Element,
+    Event: dom.window.Event,
+    HTMLElement: dom.window.HTMLElement,
+    MouseEvent: dom.window.MouseEvent,
+    MutationObserver: dom.window.MutationObserver,
+    Node: dom.window.Node,
+    ResizeObserver: TestResizeObserver,
+    getComputedStyle: dom.window.getComputedStyle,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })
+
+  Object.assign(dom.window, {
+    ResizeObserver: TestResizeObserver,
+    requestAnimationFrame: (callback: FrameRequestCallback) =>
+      dom.window.setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: (frameId: number) => dom.window.clearTimeout(frameId),
+  })
+
+  const originalGetBoundingClientRect =
+    dom.window.Element.prototype.getBoundingClientRect
+  dom.window.Element.prototype.getBoundingClientRect = function () {
+    const schematicComponentId = this.getAttribute(
+      "data-schematic-component-id",
+    )
+    if (schematicComponentId === "schematic_component_0") {
+      return {
+        x: 280,
+        y: 240,
+        left: 280,
+        top: 240,
+        right: 360,
+        bottom: 300,
+        width: 80,
+        height: 60,
+        toJSON: () => {},
+      } as DOMRect
+    }
+    if (schematicComponentId) {
+      return {
+        x: 480,
+        y: 240,
+        left: 480,
+        top: 240,
+        right: 560,
+        bottom: 300,
+        width: 80,
+        height: 60,
+        toJSON: () => {},
+      } as DOMRect
+    }
+    return {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 600,
+      width: 800,
+      height: 600,
+      toJSON: () => {},
+    } as DOMRect
+  }
+
+  return {
+    dom,
+    restore: () => {
+      dom.window.Element.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect
+      Object.assign(globalThis, {
+        ...previousGlobals,
+        IS_REACT_ACT_ENVIRONMENT: false,
+      })
+      dom.window.close()
+    },
+  }
+}
+
+test("component details include source values and the footprinter string", () => {
+  const schematicComponent = circuitJson.find(
+    (element) => element.type === "schematic_component",
+  )!
+  const details = getSchematicComponentDetails(
+    circuitJson,
+    schematicComponent.schematic_component_id,
+  )
+
+  expect(details?.sourceComponent.name).toBe("R1")
+  expect(details?.footprinterString).toBe("res0603")
+  expect(
+    getSourceComponentInfoEntries(details!.sourceComponent),
+  ).toContainEqual({
+    key: "resistance",
+    label: "Resistance",
+    value: "1kΩ",
+  })
+
+  const capacitor = circuitJson.find(
+    (element) => element.type === "source_component" && element.name === "C1",
+  )!
+  expect(getSourceComponentInfoEntries(capacitor)).toContainEqual({
+    key: "capacitance",
+    label: "Capacitance",
+    value: "1uF",
+  })
+})
+
+test("footprint preview URLs safely encode the footprinter string", () => {
+  const footprinterString = 'kicad:Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"test'
+  const previewUrl = new URL(getFootprintPreviewUrl(footprinterString))
+  const generatedCode = getUncompressedSnippetString(
+    previewUrl.searchParams.get("code")!,
+  )
+
+  expect(previewUrl.origin).toBe("https://svg.tscircuit.com")
+  expect(previewUrl.searchParams.get("svg_type")).toBe("pcb")
+  expect(previewUrl.searchParams.get("background_color")).toBe("#f8fafc")
+  expect(generatedCode).toContain(
+    `footprint={${JSON.stringify(footprinterString)}}`,
+  )
+})
+
+test("clicking a component opens its details without requiring a callback", async () => {
+  const { dom, restore } = installDom()
+  const reactRoot = createRoot(document.getElementById("root")!)
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <SchematicViewer
+          circuitJson={circuitJson}
+          containerStyle={{ width: 800, height: 600 }}
+        />,
+      )
+    })
+    await act(
+      () => new Promise<void>((resolve) => dom.window.setTimeout(resolve, 10)),
+    )
+
+    const component = document.querySelector(
+      '[data-schematic-component-id="schematic_component_0"]',
+    )!
+    expect(component).not.toBeNull()
+
+    await act(async () => {
+      component.dispatchEvent(
+        new dom.window.MouseEvent("mousedown", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+        }),
+      )
+      component.dispatchEvent(
+        new dom.window.MouseEvent("click", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+        }),
+      )
+    })
+
+    const tooltip = document.querySelector(
+      "[data-schematic-component-details-tooltip]",
+    )
+    expect(tooltip).not.toBeNull()
+    expect(tooltip?.textContent).toContain("R1")
+    expect(tooltip?.textContent).toContain("1kΩ")
+    expect(tooltip?.textContent).toContain("res0603")
+    expect(tooltip?.querySelector("img")?.getAttribute("src")).toContain(
+      "https://svg.tscircuit.com/",
+    )
+
+    await act(async () => {
+      document.body.dispatchEvent(
+        new dom.window.MouseEvent("mousedown", { bubbles: true }),
+      )
+    })
+    expect(
+      document.querySelector("[data-schematic-component-details-tooltip]"),
+    ).toBeNull()
+  } finally {
+    await act(async () => reactRoot.unmount())
+    await new Promise<void>((resolve) => dom.window.setTimeout(resolve, 0))
+    restore()
+  }
+})

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
-import { getUncompressedSnippetString } from "@tscircuit/create-snippet-url"
+import type { CircuitJson } from "circuit-json"
+import { gunzipSync, strFromU8 } from "fflate"
 import { JSDOM } from "jsdom"
 import { act } from "react"
 import { createRoot } from "react-dom/client"
@@ -8,12 +9,12 @@ import { renderToCircuitJson } from "../lib/dev/render-to-circuit-json"
 import {
   type SourceComponent,
   getFootprintPreviewUrl,
-  getPcbComponentPreviewCircuitJson,
+  getPcbComponentPreview,
   getSchematicComponentDetails,
   getSourceComponentInfoEntries,
 } from "../lib/utils/component-details"
 
-const circuitJson = renderToCircuitJson(
+const renderedCircuitJson = renderToCircuitJson(
   <board width="12mm" height="12mm">
     <resistor
       name="R1"
@@ -21,10 +22,23 @@ const circuitJson = renderToCircuitJson(
       manufacturerPartNumber="RC0603FR-071KL"
       footprint="0603"
       schX={-2}
+      pcbX={-2}
     />
-    <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} />
+    <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} pcbX={2} />
   </board>,
 )
+
+const circuitJson: CircuitJson = [
+  ...renderedCircuitJson,
+  {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_preview_context",
+    route: [
+      { route_type: "wire", x: -6, y: 0, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 6, y: 0, width: 0.15, layer: "top" },
+    ],
+  },
+]
 
 const installDom = () => {
   const dom = new JSDOM('<div id="root"></div>', {
@@ -177,33 +191,59 @@ test("footprint previews use the selected component's actual PCB elements", () =
     circuitJson,
     "schematic_component_0",
   )!
-  const previewCircuitJson = getPcbComponentPreviewCircuitJson(
+  const preview = getPcbComponentPreview(
     circuitJson,
     details.pcbComponent!.pcb_component_id,
+  )!
+  const previewUrl = new URL(
+    getFootprintPreviewUrl(preview.circuitJson, preview.viewBox),
   )
-  const previewUrl = new URL(getFootprintPreviewUrl(previewCircuitJson))
-  const generatedCode = getUncompressedSnippetString(
-    previewUrl.searchParams.get("code")!,
+  const compressedCircuitJson = Uint8Array.from(
+    atob(previewUrl.searchParams.get("circuit_json")!),
+    (character) => character.charCodeAt(0),
+  )
+  const decodedCircuitJson = JSON.parse(
+    strFromU8(gunzipSync(compressedCircuitJson)),
   )
 
   expect(previewUrl.origin).toBe("https://svg.tscircuit.com")
   expect(previewUrl.searchParams.get("svg_type")).toBe("pcb")
   expect(previewUrl.searchParams.get("background_color")).toBe("#f8fafc")
-  expect(generatedCode).toContain("<board circuitJson={circuitJson} />")
-  expect(generatedCode).not.toContain('name="U1"')
-  expect(previewCircuitJson).toContainEqual(
+  expect(previewUrl.searchParams.get("viewbox")).toBe(
+    [
+      preview.viewBox.minX,
+      preview.viewBox.minY,
+      preview.viewBox.maxX,
+      preview.viewBox.maxY,
+    ].join(","),
+  )
+  expect(decodedCircuitJson).toEqual(preview.circuitJson)
+  expect(preview.circuitJson).toContainEqual(
     expect.objectContaining({
       type: "pcb_silkscreen_text",
       pcb_component_id: details.pcbComponent!.pcb_component_id,
       text: "R1",
     }),
   )
-  expect(
-    previewCircuitJson.some(
-      (element) =>
-        element.type === "pcb_silkscreen_text" && element.text === "C1",
-    ),
-  ).toBe(false)
+  expect(preview.circuitJson).toContainEqual(
+    expect.objectContaining({ type: "pcb_board" }),
+  )
+  expect(preview.circuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_preview_context",
+    }),
+  )
+  const capacitor = circuitJson.find(
+    (element): element is SourceComponent =>
+      element.type === "source_component" && element.name === "C1",
+  )!
+  expect(preview.circuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_component",
+      source_component_id: capacitor.source_component_id,
+    }),
+  )
 })
 
 test("clicking a component opens its details without requiring a callback", async () => {

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -13,7 +13,13 @@ import {
 
 const circuitJson = renderToCircuitJson(
   <board width="12mm" height="12mm">
-    <resistor name="R1" resistance={1000} footprint="0603" schX={-2} />
+    <resistor
+      name="R1"
+      resistance={1000}
+      manufacturerPartNumber="RC0603FR-071KL"
+      footprint="0603"
+      schX={-2}
+    />
     <capacitor name="C1" capacitance="1uF" footprint="0603" schX={2} />
   </board>,
 )
@@ -142,6 +148,11 @@ test("component details include source values and the footprinter string", () =>
     label: "Resistance",
     value: "1kΩ",
   })
+  expect(resistorInfo).toContainEqual({
+    key: "manufacturer_part_number",
+    label: "Manufacturer Part Number",
+    value: "RC0603FR-071KL",
+  })
   expect(
     resistorInfo.some((entry) => entry.key === "are_pins_interchangeable"),
   ).toBe(false)
@@ -216,6 +227,7 @@ test("clicking a component opens its details without requiring a callback", asyn
     expect(tooltip).not.toBeNull()
     expect(tooltip?.textContent).toContain("R1")
     expect(tooltip?.textContent).toContain("1kΩ")
+    expect(tooltip?.textContent).toContain("RC0603FR-071KL")
     expect(tooltip?.textContent).toContain("res0603")
     expect(tooltip?.querySelector("img")?.getAttribute("src")).toContain(
       "https://svg.tscircuit.com/",

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -136,13 +136,15 @@ test("component details include source values and the footprinter string", () =>
 
   expect(details?.sourceComponent.name).toBe("R1")
   expect(details?.footprinterString).toBe("res0603")
-  expect(
-    getSourceComponentInfoEntries(details!.sourceComponent),
-  ).toContainEqual({
+  const resistorInfo = getSourceComponentInfoEntries(details!.sourceComponent)
+  expect(resistorInfo).toContainEqual({
     key: "resistance",
     label: "Resistance",
     value: "1kΩ",
   })
+  expect(
+    resistorInfo.some((entry) => entry.key === "are_pins_interchangeable"),
+  ).toBe(false)
 
   const capacitor = circuitJson.find(
     (element) => element.type === "source_component" && element.name === "C1",


### PR DESCRIPTION
## Summary

- make schematic components clickable without requiring a consumer callback
- show a large, viewport-bounded tooltip with source-component metadata, including resistance, capacitance, and manufacturer part number
- omit internal fields such as `are_pins_interchangeable`
- display the component's footprinter string and render the actual Circuit JSON around its PCB component
- select PCB geometry intersecting a 2 mm padded component viewbox, preserving the correct reference designator plus nearby components, board edges, and crossing traces
- gzip the Circuit JSON into the `svg.tscircuit.com` image URL and pass the viewbox so distant geometry cannot expand the preview
- preserve the existing callback and add close-button, outside-click, and Escape dismissal

## Dependencies

- uses released `@tscircuit/circuit-json-util@^0.0.108` from https://github.com/tscircuit/circuit-json-util/pull/117
- uses the deployed viewbox and compressed Circuit JSON support from https://github.com/tscircuit/svg.tscircuit.com/pull/2076

## Validation

- `bunx tsc --noEmit`
- `bun test` — 10 tests passing
- `bun run build`
- `bun run build:site`
- `bun run format:check`
- `git diff --check`
