### PR TITLE
Simplify component details tooltip

### DIFF
--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -69,7 +69,7 @@ export const SchematicComponentDetailsTooltip = ({
         overflowY: "auto",
         boxSizing: "border-box",
         border: "1px solid #cbd5e1",
-        borderRadius: "12px",
+        borderRadius: "4px",
         backgroundColor: "rgba(255, 255, 255, 0.98)",
         boxShadow:
           "0 20px 25px -5px rgba(15, 23, 42, 0.18), 0 8px 10px -6px rgba(15, 23, 42, 0.12)",
@@ -88,9 +88,9 @@ export const SchematicComponentDetailsTooltip = ({
         style={{
           display: "grid",
           gridTemplateColumns: "minmax(110px, 0.8fr) minmax(0, 1.2fr)",
-          gap: "10px 18px",
+          gap: "6px 12px",
           margin: 0,
-          padding: "18px",
+          padding: "8px",
         }}
       >
         {infoEntries.map((entry) => (
@@ -134,13 +134,13 @@ export const SchematicComponentDetailsTooltip = ({
       </dl>
 
       {footprinterString && footprintPreviewUrl && (
-        <div style={{ padding: "0 18px 18px" }}>
+        <div style={{ padding: "0 4px 4px" }}>
           <div
             style={{
               height: "210px",
               overflow: "hidden",
               border: "1px solid #e2e8f0",
-              borderRadius: "9px",
+              borderRadius: "2px",
               background: "#f8fafc",
             }}
           >

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -5,7 +5,6 @@ import {
   type SourceComponent,
   getFootprintPreviewUrl,
   getSourceComponentInfoEntries,
-  humanizeComponentField,
 } from "../utils/component-details"
 import { zIndexMap } from "../utils/z-index-map"
 
@@ -18,15 +17,14 @@ interface Props {
   top: number
   width: number
   maxHeight: number
-  onClose: () => void
 }
 
 const detailLabelStyle: React.CSSProperties = {
   color: "#64748b",
-  fontSize: "11px",
-  fontWeight: 700,
-  letterSpacing: "0.04em",
-  textTransform: "uppercase",
+  fontFamily:
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+  fontSize: "12px",
+  lineHeight: 1.45,
 }
 
 export const SchematicComponentDetailsTooltip = ({
@@ -38,7 +36,6 @@ export const SchematicComponentDetailsTooltip = ({
   top,
   width,
   maxHeight,
-  onClose,
 }: Props) => {
   const infoEntries = useMemo(
     () => getSourceComponentInfoEntries(sourceComponent),
@@ -54,10 +51,6 @@ export const SchematicComponentDetailsTooltip = ({
         : undefined,
     [footprintPreviewCircuitJson, footprintPreviewViewBox],
   )
-  const componentType = sourceComponent.ftype
-    ? humanizeComponentField(sourceComponent.ftype)
-    : "Component"
-
   return (
     <dialog
       open
@@ -91,131 +84,79 @@ export const SchematicComponentDetailsTooltip = ({
       onMouseDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
     >
-      <div
+      <dl
         style={{
-          display: "flex",
-          alignItems: "flex-start",
-          justifyContent: "space-between",
-          gap: "16px",
-          padding: "18px 18px 14px",
-          borderBottom: "1px solid #e2e8f0",
+          display: "grid",
+          gridTemplateColumns: "minmax(110px, 0.8fr) minmax(0, 1.2fr)",
+          gap: "10px 18px",
+          margin: 0,
+          padding: "18px",
         }}
       >
-        <div style={{ minWidth: 0 }}>
-          <div
-            style={{
-              fontSize: "20px",
-              fontWeight: 750,
-              lineHeight: 1.2,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {sourceComponent.display_name ?? sourceComponent.name}
-          </div>
-          <div style={{ color: "#64748b", fontSize: "13px", marginTop: 4 }}>
-            {componentType}
-          </div>
-        </div>
-        <button
-          type="button"
-          aria-label="Close component details"
-          onClick={onClose}
-          style={{
-            display: "grid",
-            placeItems: "center",
-            flex: "0 0 auto",
-            width: "30px",
-            height: "30px",
-            padding: 0,
-            border: "1px solid #e2e8f0",
-            borderRadius: "8px",
-            background: "#f8fafc",
-            color: "#475569",
-            cursor: "pointer",
-            fontSize: "20px",
-            lineHeight: 1,
-          }}
-        >
-          ×
-        </button>
-      </div>
-
-      {infoEntries.length > 0 && (
-        <dl
-          style={{
-            display: "grid",
-            gridTemplateColumns: "minmax(110px, 0.8fr) minmax(0, 1.2fr)",
-            gap: "10px 18px",
-            margin: 0,
-            padding: "16px 18px",
-            borderBottom: footprinterString ? "1px solid #e2e8f0" : undefined,
-          }}
-        >
-          {infoEntries.map((entry) => (
-            <div key={entry.key} style={{ display: "contents" }}>
-              <dt style={detailLabelStyle}>{entry.label}</dt>
-              <dd
-                style={{
-                  minWidth: 0,
-                  margin: 0,
-                  color: "#1e293b",
-                  fontFamily:
-                    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
-                  fontSize: "12px",
-                  lineHeight: 1.45,
-                  overflowWrap: "anywhere",
-                }}
-              >
-                {entry.value}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-
-      {footprinterString && (
-        <div style={{ padding: "16px 18px 18px" }}>
-          <div style={{ ...detailLabelStyle, marginBottom: 7 }}>Footprint</div>
-          <code
-            style={{
-              display: "block",
-              marginBottom: "12px",
-              padding: "8px 10px",
-              borderRadius: "7px",
-              background: "#f1f5f9",
-              color: "#334155",
-              fontSize: "12px",
-              lineHeight: 1.4,
-              overflowWrap: "anywhere",
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {footprinterString}
-          </code>
-          {footprintPreviewUrl && (
-            <div
+        {infoEntries.map((entry) => (
+          <div key={entry.key} style={{ display: "contents" }}>
+            <dt style={detailLabelStyle}>{entry.label}</dt>
+            <dd
               style={{
-                height: "210px",
-                overflow: "hidden",
-                border: "1px solid #e2e8f0",
-                borderRadius: "9px",
-                background: "#f8fafc",
+                minWidth: 0,
+                margin: 0,
+                color: "#1e293b",
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+                fontSize: "12px",
+                lineHeight: 1.45,
+                overflowWrap: "anywhere",
               }}
             >
-              <img
-                src={footprintPreviewUrl}
-                alt={`${sourceComponent.name} ${footprinterString} PCB footprint`}
-                loading="lazy"
-                referrerPolicy="no-referrer"
-                style={{
-                  display: "block",
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "contain",
-                }}
-              />
-            </div>
-          )}
+              {entry.value}
+            </dd>
+          </div>
+        ))}
+        {footprinterString && (
+          <div style={{ display: "contents" }}>
+            <dt style={detailLabelStyle}>footprint</dt>
+            <dd
+              style={{
+                minWidth: 0,
+                margin: 0,
+                color: "#1e293b",
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+                fontSize: "12px",
+                lineHeight: 1.45,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {JSON.stringify(footprinterString)}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      {footprinterString && footprintPreviewUrl && (
+        <div style={{ padding: "0 18px 18px" }}>
+          <div
+            style={{
+              height: "210px",
+              overflow: "hidden",
+              border: "1px solid #e2e8f0",
+              borderRadius: "9px",
+              background: "#f8fafc",
+            }}
+          >
+            <img
+              src={footprintPreviewUrl}
+              alt={`${sourceComponent.name} ${footprinterString} PCB footprint`}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              style={{
+                display: "block",
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+              }}
+            />
+          </div>
         </div>
       )}
     </dialog>

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -201,6 +201,7 @@ export const SchematicViewer = ({
 
   const svgDivRef = useRef<HTMLDivElement>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const zoomScaleRef = useRef({ x: 1, y: 1 })
 
   const schematicComponentIds = useMemo(() => {
     try {
@@ -279,6 +280,13 @@ export const SchematicViewer = ({
 
   const { ref: containerRef } = useMouseMatrixTransform({
     onSetTransform(transform) {
+      const zoomChanged =
+        transform.a !== zoomScaleRef.current.x ||
+        transform.d !== zoomScaleRef.current.y
+      zoomScaleRef.current = { x: transform.a, y: transform.d }
+      if (zoomChanged) {
+        setSelectedSchematicComponent(null)
+      }
       if (!svgDivRef.current) return
       svgDivRef.current.style.transform = transformToString(transform)
     },

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -613,7 +613,6 @@ export const SchematicViewer = ({
               selectedComponentDetails.footprintPreviewViewBox
             }
             {...componentTooltipLayout}
-            onClose={() => setSelectedSchematicComponent(null)}
           />
         )}
         {showSchematicPortsInternal &&

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -38,13 +38,13 @@ const hiddenSourceComponentKeys = new Set([
   "source_component_id",
   "source_group_id",
   "subcircuit_id",
-  "name",
   "display_name",
   "ftype",
   "are_pins_interchangeable",
 ])
 
 const priorityKeys = [
+  "name",
   "resistance",
   "capacitance",
   "inductance",
@@ -63,39 +63,22 @@ const getKeyPriority = (key: string) => {
   return priority === -1 ? priorityKeys.length : priority
 }
 
-export const humanizeComponentField = (field: string) =>
-  field
-    .replace(/^simple_/, "")
-    .replaceAll("_", " ")
-    .replace(/\b\w/g, (character) => character.toUpperCase())
-
-const formatObjectValue = (value: Record<string, unknown>) =>
-  Object.entries(value)
-    .map(([key, nestedValue]) => {
-      const formattedNestedValue = Array.isArray(nestedValue)
-        ? nestedValue.join(", ")
-        : String(nestedValue)
-      return `${humanizeComponentField(key)}: ${formattedNestedValue}`
-    })
-    .join(" · ")
-
 const formatComponentValue = (
   sourceComponent: SourceComponent,
   key: string,
   value: unknown,
 ) => {
+  if (key === "name") return String(value)
+
   const displayValue = (sourceComponent as Record<string, unknown>)[
     `display_${key}`
   ]
   if (typeof displayValue === "string" && displayValue.trim()) {
-    return displayValue
+    const propValue =
+      key === "resistance" ? displayValue.replace(/Ω$/, "") : displayValue
+    return JSON.stringify(propValue)
   }
-  if (typeof value === "boolean") return value ? "Yes" : "No"
-  if (Array.isArray(value)) return value.join(", ")
-  if (value && typeof value === "object") {
-    return formatObjectValue(value as Record<string, unknown>)
-  }
-  return String(value)
+  return JSON.stringify(value) ?? String(value)
 }
 
 export const getSourceComponentInfoEntries = (
@@ -118,7 +101,7 @@ export const getSourceComponentInfoEntries = (
     })
     .map(([key, value]) => ({
       key,
-      label: humanizeComponentField(key),
+      label: key,
       value: formatComponentValue(sourceComponent, key, value),
     }))
 

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -251,7 +251,7 @@ test("footprint previews use the selected component's actual PCB elements", () =
   )
 })
 
-test("clicking a component opens its details without requiring a callback", async () => {
+test("component details use compact styling and close on zoom or outside click", async () => {
   const { dom, restore } = installDom()
   const reactRoot = createRoot(document.getElementById("root")!)
 
@@ -294,6 +294,10 @@ test("clicking a component opens its details without requiring a callback", asyn
       "[data-schematic-component-details-tooltip]",
     )
     expect(tooltip).not.toBeNull()
+    expect((tooltip as HTMLElement).style.borderRadius).toBe("4px")
+    expect((tooltip?.firstElementChild as HTMLElement).style.padding).toBe(
+      "8px",
+    )
     const nameLabel = Array.from(tooltip?.querySelectorAll("dt") ?? []).find(
       (element) => element.textContent === "name",
     )
@@ -310,6 +314,38 @@ test("clicking a component opens its details without requiring a callback", asyn
     expect(tooltip?.querySelector("img")?.getAttribute("alt")).toBe(
       "R1 res0603 PCB footprint",
     )
+    expect(
+      (tooltip?.querySelector("img")?.parentElement as HTMLElement).style
+        .borderRadius,
+    ).toBe("2px")
+
+    const viewerContainer = tooltip?.parentElement
+    await act(async () => {
+      viewerContainer?.dispatchEvent(
+        new dom.window.WheelEvent("wheel", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+          deltaY: -100,
+        }),
+      )
+    })
+    expect(
+      document.querySelector("[data-schematic-component-details-tooltip]"),
+    ).toBeNull()
+
+    await act(async () => {
+      component.dispatchEvent(
+        new dom.window.MouseEvent("click", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+        }),
+      )
+    })
+    expect(
+      document.querySelector("[data-schematic-component-details-tooltip]"),
+    ).not.toBeNull()
 
     await act(async () => {
       document.body.dispatchEvent(

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -159,15 +159,20 @@ test("component details include source values and the footprinter string", () =>
   expect(details?.sourceComponent.name).toBe("R1")
   expect(details?.footprinterString).toBe("res0603")
   const resistorInfo = getSourceComponentInfoEntries(details!.sourceComponent)
+  expect(resistorInfo[0]).toEqual({
+    key: "name",
+    label: "name",
+    value: "R1",
+  })
   expect(resistorInfo).toContainEqual({
     key: "resistance",
-    label: "Resistance",
-    value: "1kΩ",
+    label: "resistance",
+    value: '"1k"',
   })
   expect(resistorInfo).toContainEqual({
     key: "manufacturer_part_number",
-    label: "Manufacturer Part Number",
-    value: "RC0603FR-071KL",
+    label: "manufacturer_part_number",
+    value: '"RC0603FR-071KL"',
   })
   expect(
     resistorInfo.some((entry) => entry.key === "are_pins_interchangeable"),
@@ -181,8 +186,8 @@ test("component details include source values and the footprinter string", () =>
   )!
   expect(getSourceComponentInfoEntries(capacitor)).toContainEqual({
     key: "capacitance",
-    label: "Capacitance",
-    value: "1uF",
+    label: "capacitance",
+    value: '"1uF"',
   })
 })
 
@@ -289,8 +294,14 @@ test("clicking a component opens its details without requiring a callback", asyn
       "[data-schematic-component-details-tooltip]",
     )
     expect(tooltip).not.toBeNull()
-    expect(tooltip?.textContent).toContain("R1")
-    expect(tooltip?.textContent).toContain("1kΩ")
+    const nameLabel = Array.from(tooltip?.querySelectorAll("dt") ?? []).find(
+      (element) => element.textContent === "name",
+    )
+    expect(nameLabel?.nextElementSibling?.textContent).toBe("R1")
+    expect(tooltip?.firstElementChild?.tagName).toBe("DL")
+    expect(tooltip?.querySelector("button")).toBeNull()
+    expect(tooltip?.textContent).not.toContain("Resistor")
+    expect(tooltip?.textContent).toContain('"1k"')
     expect(tooltip?.textContent).toContain("RC0603FR-071KL")
     expect(tooltip?.textContent).toContain("res0603")
     expect(tooltip?.querySelector("img")?.getAttribute("src")).toContain(


### PR DESCRIPTION
## Summary

- remove the tooltip's visible title, component-type subtitle, close button, and title/content divider
- render component details as one compact Circuit JSON-style property grid beginning with `name`
- preserve source property keys such as `resistance`, `capacitance`, and `manufacturer_part_number`
- format display values like prop values (`name C1`, `resistance "1k"`, `capacitance "1uF"`)
- include the footprinter string as the `footprint` row above the existing PCB preview
- reduce the property and preview padding and use 4 px/2 px corner radii
- close the tooltip when wheel or pinch zoom changes the schematic scale
- retain outside-click and Escape dismissal

## Why

The previous header repeated information already available in the component properties and added unnecessary visual hierarchy. The simplified layout is denser and more closely resembles the underlying tscircuit data.

## Validation

- `bunx tsc --noEmit`
- `bun test` — 10 tests passing
- `bun run build`
- `bun run build:site`
- `bun run format:check`
- `git diff --check`
