### PR TITLE
Link supplier part numbers in component details

### DIFF
--- a/examples/example14-schematic-component-click.fixture.tsx
+++ b/examples/example14-schematic-component-click.fixture.tsx
@@ -8,6 +8,7 @@ const circuitJson = renderToCircuitJson(
       name="R1"
       resistance={1000}
       manufacturerPartNumber="RC0603FR-071KL"
+      supplierPartNumbers={{ jlcpcb: ["C2040"], lcsc: ["C2040"] }}
       footprint="0603"
       schX={-2}
       schY={0}

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -5,6 +5,7 @@ import {
   type SourceComponent,
   getFootprintPreviewUrl,
   getSourceComponentInfoEntries,
+  getSupplierPartNumberEntries,
 } from "../utils/component-details"
 import { zIndexMap } from "../utils/z-index-map"
 
@@ -39,6 +40,10 @@ export const SchematicComponentDetailsTooltip = ({
 }: Props) => {
   const infoEntries = useMemo(
     () => getSourceComponentInfoEntries(sourceComponent),
+    [sourceComponent],
+  )
+  const supplierPartNumberEntries = useMemo(
+    () => getSupplierPartNumberEntries(sourceComponent),
     [sourceComponent],
   )
   const footprintPreviewUrl = useMemo(
@@ -109,6 +114,36 @@ export const SchematicComponentDetailsTooltip = ({
               }}
             >
               {entry.value}
+            </dd>
+          </div>
+        ))}
+        {supplierPartNumberEntries.map((entry) => (
+          <div key={entry.key} style={{ display: "contents" }}>
+            <dt style={detailLabelStyle}>{entry.label}</dt>
+            <dd
+              style={{
+                minWidth: 0,
+                margin: 0,
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+                fontSize: "12px",
+                lineHeight: 1.45,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {entry.links.map((link, index) => (
+                <span key={link.href}>
+                  {index > 0 && ", "}
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    style={{ color: "#2563eb", textDecoration: "underline" }}
+                  >
+                    {link.partNumber}
+                  </a>
+                </span>
+              ))}
             </dd>
           </div>
         ))}

--- a/lib/utils/component-details.ts
+++ b/lib/utils/component-details.ts
@@ -33,6 +33,15 @@ export interface ComponentInfoEntry {
   value: string
 }
 
+export interface SupplierPartNumberEntry {
+  key: string
+  label: "jlcpcb" | "lcsc"
+  links: Array<{
+    partNumber: string
+    href: string
+  }>
+}
+
 const hiddenSourceComponentKeys = new Set([
   "type",
   "source_component_id",
@@ -41,6 +50,7 @@ const hiddenSourceComponentKeys = new Set([
   "display_name",
   "ftype",
   "are_pins_interchangeable",
+  "supplier_part_numbers",
 ])
 
 const priorityKeys = [
@@ -55,8 +65,20 @@ const priorityKeys = [
   "max_current_rating",
   "power_rating",
   "manufacturer_part_number",
-  "supplier_part_numbers",
 ]
+
+const supplierPartNumberUrls = {
+  jlcpcb: (partNumber: string) =>
+    `https://jlcpcb.com/partdetail/${encodeURIComponent(partNumber)}`,
+  lcsc: (partNumber: string) =>
+    `https://www.lcsc.com/product-detail/${encodeURIComponent(partNumber)}.html`,
+}
+
+const normalizeLcscPartNumber = (partNumber: string) => {
+  const trimmedPartNumber = partNumber.trim()
+  const numericPartNumber = /^c?(\d+)$/i.exec(trimmedPartNumber)
+  return numericPartNumber ? `C${numericPartNumber[1]}` : trimmedPartNumber
+}
 
 const getKeyPriority = (key: string) => {
   const priority = priorityKeys.indexOf(key)
@@ -104,6 +126,40 @@ export const getSourceComponentInfoEntries = (
       label: key,
       value: formatComponentValue(sourceComponent, key, value),
     }))
+
+export const getSupplierPartNumberEntries = (
+  sourceComponent: SourceComponent,
+): SupplierPartNumberEntry[] => {
+  const supplierPartNumbers = sourceComponent.supplier_part_numbers
+  if (!supplierPartNumbers) return []
+
+  return (["jlcpcb", "lcsc"] as const).flatMap((supplier) => {
+    const partNumbers = supplierPartNumbers[supplier]
+    if (!Array.isArray(partNumbers)) return []
+
+    const normalizedPartNumbers = [
+      ...new Set(
+        partNumbers
+          .filter((partNumber): partNumber is string =>
+            Boolean(typeof partNumber === "string" && partNumber.trim()),
+          )
+          .map(normalizeLcscPartNumber),
+      ),
+    ]
+    if (!normalizedPartNumbers.length) return []
+
+    return [
+      {
+        key: `supplier_part_numbers.${supplier}`,
+        label: supplier,
+        links: normalizedPartNumbers.map((partNumber) => ({
+          partNumber,
+          href: supplierPartNumberUrls[supplier](partNumber),
+        })),
+      },
+    ]
+  })
+}
 
 export const getSchematicComponentDetails = (
   circuitJson: CircuitJson,

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -12,6 +12,7 @@ import {
   getPcbComponentPreview,
   getSchematicComponentDetails,
   getSourceComponentInfoEntries,
+  getSupplierPartNumberEntries,
 } from "../lib/utils/component-details"
 
 const renderedCircuitJson = renderToCircuitJson(
@@ -20,6 +21,11 @@ const renderedCircuitJson = renderToCircuitJson(
       name="R1"
       resistance={1000}
       manufacturerPartNumber="RC0603FR-071KL"
+      supplierPartNumbers={{
+        jlcpcb: ["C2040", "2040"],
+        lcsc: ["C2040"],
+        mouser: ["123-EXAMPLE"],
+      }}
       footprint="0603"
       schX={-2}
       pcbX={-2}
@@ -177,6 +183,31 @@ test("component details include source values and the footprinter string", () =>
   expect(
     resistorInfo.some((entry) => entry.key === "are_pins_interchangeable"),
   ).toBe(false)
+  expect(
+    resistorInfo.some((entry) => entry.key === "supplier_part_numbers"),
+  ).toBe(false)
+  expect(getSupplierPartNumberEntries(details!.sourceComponent)).toEqual([
+    {
+      key: "supplier_part_numbers.jlcpcb",
+      label: "jlcpcb",
+      links: [
+        {
+          partNumber: "C2040",
+          href: "https://jlcpcb.com/partdetail/C2040",
+        },
+      ],
+    },
+    {
+      key: "supplier_part_numbers.lcsc",
+      label: "lcsc",
+      links: [
+        {
+          partNumber: "C2040",
+          href: "https://www.lcsc.com/product-detail/C2040.html",
+        },
+      ],
+    },
+  ])
 
   const capacitor = circuitJson.find(
     (element): element is SourceComponent =>
@@ -307,7 +338,25 @@ test("component details use compact styling and close on zoom or outside click",
     expect(tooltip?.textContent).not.toContain("Resistor")
     expect(tooltip?.textContent).toContain('"1k"')
     expect(tooltip?.textContent).toContain("RC0603FR-071KL")
+    expect(tooltip?.textContent).not.toContain("supplier_part_numbers")
     expect(tooltip?.textContent).toContain("res0603")
+    const supplierLinks = Array.from(tooltip?.querySelectorAll("a") ?? [])
+    expect(supplierLinks).toHaveLength(2)
+    expect(supplierLinks.map((link) => link.textContent)).toEqual([
+      "C2040",
+      "C2040",
+    ])
+    expect(supplierLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "https://jlcpcb.com/partdetail/C2040",
+      "https://www.lcsc.com/product-detail/C2040.html",
+    ])
+    expect(
+      supplierLinks.every(
+        (link) =>
+          link.getAttribute("target") === "_blank" &&
+          link.getAttribute("rel") === "noreferrer noopener",
+      ),
+    ).toBe(true)
     expect(tooltip?.querySelector("img")?.getAttribute("src")).toContain(
       "https://svg.tscircuit.com/",
     )


### PR DESCRIPTION
## Summary
- hide the raw supplier_part_numbers object from component details
- render JLCPCB and LCSC part numbers as external supplier links
- normalize legacy numeric-only part IDs and deduplicate repeated values
- cover parsing and rendered link behavior in the component-details tests

## Validation
- bun test
- bun run build
- bun run format:check