### PR TITLE
Search components by display name

### DIFF
--- a/lib/utils/get-schematic-search-results.ts
+++ b/lib/utils/get-schematic-search-results.ts
@@ -157,7 +157,10 @@ export const getSchematicSearchResults = (
       : undefined
     const primaryLabel =
       sourceComponent?.name ?? sourceComponent?.display_name ?? "Component"
-    const componentScore = getTextMatchScore(primaryLabel, normalizedQuery)
+    const componentScore = Math.min(
+      getTextMatchScore(primaryLabel, normalizedQuery),
+      getTextMatchScore(sourceComponent?.display_name, normalizedQuery),
+    )
 
     if (Number.isFinite(componentScore)) {
       const result: SchematicSearchResult = {

--- a/tests/schematic-search.test.ts
+++ b/tests/schematic-search.test.ts
@@ -36,6 +36,25 @@ test("finds components by reference designator", () => {
   expect(results[0]?.schematicSheetId).toBe("sheet_1")
 })
 
+test("finds components by display name", () => {
+  const circuitWithDisplayName = circuitJson.map((element) => {
+    if (element.type !== "source_component") return element
+    return { ...element, display_name: "USB Connector" }
+  }) as CircuitJson
+
+  const results = getSchematicSearchResults(
+    circuitWithDisplayName,
+    "usb connector",
+  )
+
+  expect(results).toHaveLength(1)
+  expect(results[0]?.label).toBe("U1")
+  expect(results[0]?.target).toEqual({
+    type: "schematic_component",
+    id: "schematic_component_1",
+  })
+})
+
 test("finds net labels case-insensitively", () => {
   const results = getSchematicSearchResults(circuitJson, "gnd")
 


### PR DESCRIPTION
### Motivation
- Component search should find user-facing display names as well as reference designators.

### Before
- Components with a reference designator could not be found by their display name.

### After
- Component search matches both the reference designator and display name case-insensitively.