### PR TITLE
Search components by manufacturer part number

### DIFF
--- a/lib/utils/get-schematic-search-results.ts
+++ b/lib/utils/get-schematic-search-results.ts
@@ -160,6 +160,10 @@ export const getSchematicSearchResults = (
     const componentScore = Math.min(
       getTextMatchScore(primaryLabel, normalizedQuery),
       getTextMatchScore(sourceComponent?.display_name, normalizedQuery),
+      getTextMatchScore(
+        sourceComponent?.manufacturer_part_number,
+        normalizedQuery,
+      ),
     )
 
     if (Number.isFinite(componentScore)) {

--- a/tests/schematic-search.test.ts
+++ b/tests/schematic-search.test.ts
@@ -55,6 +55,25 @@ test("finds components by display name", () => {
   })
 })
 
+test("finds components by manufacturer part number", () => {
+  const circuitWithManufacturerPartNumber = circuitJson.map((element) => {
+    if (element.type !== "source_component") return element
+    return { ...element, manufacturer_part_number: "STM32F103C8T6" }
+  }) as CircuitJson
+
+  const results = getSchematicSearchResults(
+    circuitWithManufacturerPartNumber,
+    "stm32f103",
+  )
+
+  expect(results).toHaveLength(1)
+  expect(results[0]?.label).toBe("U1")
+  expect(results[0]?.target).toEqual({
+    type: "schematic_component",
+    id: "schematic_component_1",
+  })
+})
+
 test("finds net labels case-insensitively", () => {
   const results = getSchematicSearchResults(circuitJson, "gnd")
 


### PR DESCRIPTION
### Motivation
- Component search should find manufacturer part numbers as well as component labels.

### Before
- Components could not be found by their manufacturer part number.

### After
- Component search matches manufacturer part numbers case-insensitively, including partial matches.