### PR TITLE
Add schematic-to-PCB component navigation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ export default () => (
   />
 )
 ```
+
+Pass `onNavigateToPcbComponent` to add a **Go to PCB View** action to
+component-detail popups when the selected schematic component has a matching
+PCB component. The host callback receives the schematic, source, and PCB
+component IDs so it can switch views without coupling this package to a PCB
+viewer.

--- a/lib/components/SchematicComponentDetailsTooltip.tsx
+++ b/lib/components/SchematicComponentDetailsTooltip.tsx
@@ -1,5 +1,6 @@
 import type { CircuitJson } from "circuit-json"
 import { useMemo } from "react"
+import type { NavigateToPcbComponentOptions } from "../types/schematic-component-navigation"
 import {
   type PcbBounds,
   type SourceComponent,
@@ -11,6 +12,10 @@ import { zIndexMap } from "../utils/z-index-map"
 
 interface Props {
   sourceComponent: SourceComponent
+  schematicComponentId: string
+  sourceComponentId: string
+  pcbComponentId?: string
+  onNavigateToPcbComponent?: (options: NavigateToPcbComponentOptions) => void
   footprinterString?: string
   footprintPreviewCircuitJson?: CircuitJson
   footprintPreviewViewBox?: PcbBounds
@@ -30,6 +35,10 @@ const detailLabelStyle: React.CSSProperties = {
 
 export const SchematicComponentDetailsTooltip = ({
   sourceComponent,
+  schematicComponentId,
+  sourceComponentId,
+  pcbComponentId,
+  onNavigateToPcbComponent,
   footprinterString,
   footprintPreviewCircuitJson,
   footprintPreviewViewBox,
@@ -192,6 +201,45 @@ export const SchematicComponentDetailsTooltip = ({
               }}
             />
           </div>
+        </div>
+      )}
+      {onNavigateToPcbComponent && pcbComponentId && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            padding: "4px 8px 8px",
+          }}
+        >
+          <button
+            type="button"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation()
+              onNavigateToPcbComponent({
+                schematicComponentId,
+                sourceComponentId,
+                pcbComponentId,
+              })
+            }}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "1px solid #cbd5e1",
+              borderRadius: "3px",
+              backgroundColor: "#f8fafc",
+              color: "#334155",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              fontSize: "12px",
+              fontWeight: 500,
+              lineHeight: 1.25,
+              padding: "4px 8px",
+            }}
+          >
+            Go to PCB View
+          </button>
         </div>
       )}
     </dialog>

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -21,6 +21,7 @@ import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
 import { useResizeHandling } from "../hooks/use-resize-handling"
 import { useContextMenu } from "../hooks/useContextMenu"
 import { getSchematicComponentDetails } from "../utils/component-details"
+import type { NavigateToPcbComponentOptions } from "../types/schematic-component-navigation"
 import { zIndexMap } from "../utils/z-index-map"
 import { MouseTracker } from "./MouseTracker"
 import { SchematicComponentDetailsTooltip } from "./SchematicComponentDetailsTooltip"
@@ -30,7 +31,7 @@ import { SchematicSearch } from "./SchematicSearch"
 import { SchematicSheetSelector } from "./SchematicSheetSelector"
 import { ViewMenu } from "./ViewMenu"
 
-interface Props {
+export interface SchematicViewerProps {
   circuitJson: CircuitJson
   containerStyle?: React.CSSProperties
   debugGrid?: boolean
@@ -46,6 +47,8 @@ interface Props {
     schematicComponentId: string
     event: MouseEvent
   }) => void
+  /** Request that the host open and focus the matching PCB component. */
+  onNavigateToPcbComponent?: (options: NavigateToPcbComponentOptions) => void
   showSchematicPorts?: boolean
   onSchematicPortClicked?: (options: {
     schematicPortId: string
@@ -73,13 +76,14 @@ export const SchematicViewer = ({
   disableGroups = false,
   netHoverHighlightEnabled = true,
   onSchematicComponentClicked,
+  onNavigateToPcbComponent,
   showSchematicPorts,
   onSchematicPortClicked,
   onSchematicSheetChange,
   searchEnabled = true,
   css,
   className,
-}: Props) => {
+}: SchematicViewerProps) => {
   if (debug) {
     enableDebug()
   }
@@ -691,6 +695,16 @@ export const SchematicViewer = ({
         {selectedComponentDetails && componentTooltipLayout && (
           <SchematicComponentDetailsTooltip
             sourceComponent={selectedComponentDetails.sourceComponent}
+            schematicComponentId={
+              selectedComponentDetails.schematicComponent.schematic_component_id
+            }
+            sourceComponentId={
+              selectedComponentDetails.sourceComponent.source_component_id
+            }
+            pcbComponentId={
+              selectedComponentDetails.pcbComponent?.pcb_component_id
+            }
+            onNavigateToPcbComponent={onNavigateToPcbComponent}
             footprinterString={selectedComponentDetails.footprinterString}
             footprintPreviewCircuitJson={
               selectedComponentDetails.footprintPreviewCircuitJson

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,8 @@
-export { SchematicViewer } from "./components/SchematicViewer"
+export {
+  SchematicViewer,
+  type SchematicViewerProps,
+} from "./components/SchematicViewer"
+export type { NavigateToPcbComponentOptions } from "./types/schematic-component-navigation"
 export { MouseTracker } from "./components/MouseTracker"
 export { useMouseEventsOverBoundingBox } from "./hooks/useMouseEventsOverBoundingBox"
 export { AnalogSimulationViewer } from "./components/AnalogSimulationViewer"

--- a/lib/types/schematic-component-navigation.ts
+++ b/lib/types/schematic-component-navigation.ts
@@ -1,0 +1,5 @@
+export interface NavigateToPcbComponentOptions {
+  schematicComponentId: string
+  sourceComponentId: string
+  pcbComponentId: string
+}

--- a/tests/schematic-component-details.test.tsx
+++ b/tests/schematic-component-details.test.tsx
@@ -410,3 +410,129 @@ test("component details use compact styling and close on zoom or outside click",
     restore()
   }
 })
+
+test("PCB navigation is offered for represented components and emits resolved IDs", async () => {
+  const { dom, restore } = installDom()
+  const reactRoot = createRoot(document.getElementById("root")!)
+  const navigationEvents: Array<{
+    schematicComponentId: string
+    sourceComponentId: string
+    pcbComponentId: string
+  }> = []
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <SchematicViewer
+          circuitJson={circuitJson}
+          containerStyle={{ width: 800, height: 600 }}
+          onNavigateToPcbComponent={(options) => navigationEvents.push(options)}
+        />,
+      )
+    })
+    await act(
+      () => new Promise<void>((resolve) => dom.window.setTimeout(resolve, 10)),
+    )
+
+    const component = document.querySelector(
+      '[data-schematic-component-id="schematic_component_0"]',
+    )!
+    await act(async () => {
+      component.dispatchEvent(
+        new dom.window.MouseEvent("click", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+        }),
+      )
+    })
+
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (element) => element.textContent === "Go to PCB View",
+    )
+    expect(button).not.toBeNull()
+    expect(button?.style.fontSize).toBe("12px")
+    expect(button?.style.padding).toBe("4px 8px")
+    expect(button?.style.backgroundColor).toBe("rgb(248, 250, 252)")
+    expect(button?.parentElement?.style.justifyContent).toBe("flex-end")
+
+    await act(async () => {
+      button?.dispatchEvent(
+        new dom.window.MouseEvent("mousedown", { bubbles: true }),
+      )
+      button?.dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true }),
+      )
+    })
+
+    const details = getSchematicComponentDetails(
+      circuitJson,
+      "schematic_component_0",
+    )!
+    expect(navigationEvents).toEqual([
+      {
+        schematicComponentId: details.schematicComponent.schematic_component_id,
+        sourceComponentId: details.sourceComponent.source_component_id,
+        pcbComponentId: details.pcbComponent!.pcb_component_id,
+      },
+    ])
+  } finally {
+    await act(async () => reactRoot.unmount())
+    await new Promise<void>((resolve) => dom.window.setTimeout(resolve, 0))
+    restore()
+  }
+})
+
+test("PCB navigation is hidden when a component has no PCB representation", async () => {
+  const { dom, restore } = installDom()
+  const reactRoot = createRoot(document.getElementById("root")!)
+  const details = getSchematicComponentDetails(
+    circuitJson,
+    "schematic_component_0",
+  )!
+  const circuitWithoutPcbComponent = circuitJson.filter(
+    (element) =>
+      !(
+        element.type === "pcb_component" &&
+        element.pcb_component_id === details.pcbComponent!.pcb_component_id
+      ),
+  )
+
+  try {
+    await act(async () => {
+      reactRoot.render(
+        <SchematicViewer
+          circuitJson={circuitWithoutPcbComponent}
+          containerStyle={{ width: 800, height: 600 }}
+          onNavigateToPcbComponent={() => {}}
+        />,
+      )
+    })
+    await act(
+      () => new Promise<void>((resolve) => dom.window.setTimeout(resolve, 10)),
+    )
+
+    const component = document.querySelector(
+      '[data-schematic-component-id="schematic_component_0"]',
+    )!
+    await act(async () => {
+      component.dispatchEvent(
+        new dom.window.MouseEvent("click", {
+          bubbles: true,
+          clientX: 320,
+          clientY: 270,
+        }),
+      )
+    })
+
+    expect(
+      Array.from(document.querySelectorAll("button")).some(
+        (element) => element.textContent === "Go to PCB View",
+      ),
+    ).toBe(false)
+  } finally {
+    await act(async () => reactRoot.unmount())
+    await new Promise<void>((resolve) => dom.window.setTimeout(resolve, 0))
+    restore()
+  }
+})


### PR DESCRIPTION
## Summary

Adds the producer-side API for navigating from a schematic component to its matching PCB component without coupling schematic-viewer to tabs or pcb-viewer.

- adds the optional `onNavigateToPcbComponent` callback
- resolves and emits schematic, source, and PCB component IDs
- shows a compact, theme-matched **Go to PCB View** action only when a PCB representation exists
- preserves existing component-click and popup behavior
- exports the new callback options and viewer prop types

## PR chain

**Part 1 of 3 — merge first.**

1. **This PR:** schematic-viewer navigation callback
2. [tscircuit/pcb-viewer#963](https://github.com/tscircuit/pcb-viewer/pull/963) — controlled component focus
3. [tscircuit/runframe#4668](https://github.com/tscircuit/runframe/pull/4668) — tab and focus integration

The downstream runframe integration requires releases containing parts 1 and 2 before its dependency versions can be updated.

## Validation

- `bun test` — 25 passed
- `bun run format:check`
- `bun run build`
