### PR TITLE
Add PMP11282 schematic rendering reproduction

### DIFF
--- a/examples/example35-pmp11282-isolated-dcdc.fixture.tsx
+++ b/examples/example35-pmp11282-isolated-dcdc.fixture.tsx
@@ -1,0 +1,22 @@
+import type { CircuitJson } from "circuit-json"
+import { SchematicViewer } from "lib/components/SchematicViewer"
+import circuitJson from "./pmp11282-isolated-dcdc.circuit.json"
+
+/**
+ * Visual reproduction from the source-derived PMP11282 isolated DC/DC TSX.
+ *
+ * The fixture intentionally uses the compiled Circuit JSON so this repository
+ * exercises only viewer/SVG behavior. In particular, the generic component
+ * bodies used for the transformer, coupled inductor, optocouplers, and dual
+ * diodes make their pin labels and component text crowd or escape the yellow
+ * schematic boxes at a full-sheet scale.
+ *
+ * Trace routing and fallback net-label generation are reproduced separately in
+ * schematic-trace-solver; this viewer fixture preserves their rendered output.
+ */
+export default () => (
+  <SchematicViewer
+    circuitJson={circuitJson as CircuitJson}
+    containerStyle={{ width: "100vw", height: "100vh" }}
+  />
+)

--- a/examples/pmp11282-isolated-dcdc.circuit.json
+++ b/examples/pmp11282-isolated-dcdc.circuit.json
@@ -1,0 +1,26584 @@
+[
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "is_subcircuit": true,
+    "was_automatically_named": true,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2"],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_capacitor",
+    "name": "C500",
+    "capacitance": 1.5e-9,
+    "display_capacitance": "1500pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_capacitor",
+    "name": "C501",
+    "capacitance": 4.7e-11,
+    "display_capacitance": "47pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_capacitor",
+    "name": "C502",
+    "capacitance": 4.7e-11,
+    "display_capacitance": "47pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_capacitor",
+    "name": "C503",
+    "capacitance": 4.7e-8,
+    "display_capacitance": "0.047uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "ftype": "simple_capacitor",
+    "name": "C504",
+    "capacitance": 1e-12,
+    "display_capacitance": "1pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_capacitor",
+    "name": "C505",
+    "capacitance": 2.2e-7,
+    "display_capacitance": "0.22uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_capacitor",
+    "name": "C506",
+    "capacitance": 0.000001,
+    "max_decoupling_trace_length": 1,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "ftype": "simple_capacitor",
+    "name": "C507",
+    "capacitance": 0.000001,
+    "max_decoupling_trace_length": 1,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_8",
+    "ftype": "simple_capacitor",
+    "name": "C508",
+    "capacitance": 0.000001,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_9",
+    "ftype": "simple_capacitor",
+    "name": "C509",
+    "capacitance": 0.000001,
+    "max_decoupling_trace_length": 1,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_10",
+    "ftype": "simple_capacitor",
+    "name": "C510",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_11",
+    "ftype": "simple_capacitor",
+    "name": "C511",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_12",
+    "ftype": "simple_capacitor",
+    "name": "C512",
+    "capacitance": 1e-7,
+    "display_capacitance": "0.1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_13",
+    "ftype": "simple_capacitor",
+    "name": "C513",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_14",
+    "ftype": "simple_capacitor",
+    "name": "C514",
+    "capacitance": 2.2e-10,
+    "display_capacitance": "220pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_15",
+    "ftype": "simple_capacitor",
+    "name": "C515",
+    "capacitance": 2.2e-10,
+    "display_capacitance": "220pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_16",
+    "ftype": "simple_capacitor",
+    "name": "C516",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_17",
+    "ftype": "simple_capacitor",
+    "name": "C517",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1"],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2"],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_18",
+    "ftype": "simple_capacitor",
+    "name": "C518",
+    "capacitance": 0.00068,
+    "display_capacitance": "680uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1"],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2"],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_19",
+    "ftype": "simple_capacitor",
+    "name": "C519",
+    "capacitance": 4.7e-8,
+    "display_capacitance": "0.047uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_20",
+    "ftype": "simple_capacitor",
+    "name": "C523",
+    "capacitance": 1e-7,
+    "display_capacitance": "0.1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net41"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_21",
+    "ftype": "simple_capacitor",
+    "name": "C525",
+    "capacitance": 1e-12,
+    "display_capacitance": "1pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_22",
+    "ftype": "simple_capacitor",
+    "name": "C526",
+    "capacitance": 1e-10,
+    "display_capacitance": "100pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_23",
+    "ftype": "simple_capacitor",
+    "name": "C527",
+    "capacitance": 4.7e-7,
+    "display_capacitance": "0.47uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_24",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_24",
+    "ftype": "simple_capacitor",
+    "name": "C528",
+    "capacitance": 1e-8,
+    "display_capacitance": "0.01uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_25",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_25",
+    "ftype": "simple_capacitor",
+    "name": "C529",
+    "capacitance": 1e-10,
+    "display_capacitance": "100pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "1", "left"],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "2", "right"],
+    "source_component_id": "source_component_26",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_26",
+    "ftype": "simple_capacitor",
+    "name": "C530",
+    "capacitance": 1e-8,
+    "display_capacitance": "0.01uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_27",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_27",
+    "ftype": "simple_capacitor",
+    "name": "C531",
+    "capacitance": 4.7e-12,
+    "display_capacitance": "4.7pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_28",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_28",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_28",
+    "ftype": "simple_capacitor",
+    "name": "C532",
+    "capacitance": 2.2e-7,
+    "max_decoupling_trace_length": 1,
+    "display_capacitance": "0.22uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_29",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_29",
+    "ftype": "simple_capacitor",
+    "name": "C533",
+    "capacitance": 0.000001,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_30",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_30",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_30",
+    "ftype": "simple_capacitor",
+    "name": "C534",
+    "capacitance": 1e-7,
+    "display_capacitance": "0.1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_31",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_31",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_31",
+    "ftype": "simple_capacitor",
+    "name": "C535",
+    "capacitance": 1e-7,
+    "display_capacitance": "0.1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "1", "left"],
+    "source_component_id": "source_component_32",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "2", "right"],
+    "source_component_id": "source_component_32",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_32",
+    "ftype": "simple_capacitor",
+    "name": "C536",
+    "capacitance": 0.000001,
+    "display_capacitance": "1uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_33",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_33",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_33",
+    "ftype": "simple_resistor",
+    "name": "R500",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_34",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_34",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_34",
+    "ftype": "simple_resistor",
+    "name": "R501",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_35",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_35",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_35",
+    "ftype": "simple_resistor",
+    "name": "R502",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_36",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_36",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_36",
+    "ftype": "simple_resistor",
+    "name": "R503",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_37",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_37",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_37",
+    "ftype": "simple_resistor",
+    "name": "R504",
+    "resistance": 0,
+    "display_resistance": "0Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_38",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_38",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net48"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_38",
+    "ftype": "simple_resistor",
+    "name": "R505",
+    "resistance": 100000,
+    "display_resistance": "100kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_39",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_39",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_39",
+    "ftype": "simple_resistor",
+    "name": "R506",
+    "resistance": 100000,
+    "display_resistance": "100kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_40",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_40",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_40",
+    "ftype": "simple_resistor",
+    "name": "R507",
+    "resistance": 3.3,
+    "display_resistance": "3.3Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_41",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_41",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net47"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_41",
+    "ftype": "simple_resistor",
+    "name": "R508",
+    "resistance": 221000,
+    "display_resistance": "221kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_42",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_42",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_42",
+    "ftype": "simple_resistor",
+    "name": "R509",
+    "resistance": 221000,
+    "display_resistance": "221kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_43",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_43",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_43",
+    "ftype": "simple_resistor",
+    "name": "R510",
+    "resistance": 3,
+    "display_resistance": "3Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_44",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_44",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_44",
+    "ftype": "simple_resistor",
+    "name": "R511",
+    "resistance": 20000,
+    "display_resistance": "20kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_45",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net40"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_45",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_45",
+    "ftype": "simple_resistor",
+    "name": "R512",
+    "resistance": 0,
+    "display_resistance": "0Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_46",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_46",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_46",
+    "ftype": "simple_resistor",
+    "name": "R513",
+    "resistance": 0.01,
+    "display_resistance": "10mΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_94",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_47",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_95",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_47",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_47",
+    "ftype": "simple_resistor",
+    "name": "R514",
+    "resistance": 0.01,
+    "display_resistance": "10mΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_96",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_48",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_97",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_48",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_48",
+    "ftype": "simple_resistor",
+    "name": "R515",
+    "resistance": 21500,
+    "display_resistance": "21.5kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_98",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_49",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_99",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_49",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_49",
+    "ftype": "simple_resistor",
+    "name": "R516",
+    "resistance": 0,
+    "display_resistance": "0Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_100",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_50",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_101",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_50",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_50",
+    "ftype": "simple_resistor",
+    "name": "R517",
+    "resistance": 0.01,
+    "display_resistance": "10mΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_102",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_51",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_103",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_51",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_51",
+    "ftype": "simple_resistor",
+    "name": "R518",
+    "resistance": 3,
+    "display_resistance": "3Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_104",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_52",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_105",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_52",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_52",
+    "ftype": "simple_resistor",
+    "name": "R520",
+    "resistance": 0.01,
+    "display_resistance": "10mΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_106",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_53",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_107",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_53",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_53",
+    "ftype": "simple_resistor",
+    "name": "R521",
+    "resistance": 20000,
+    "display_resistance": "20kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_108",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_54",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net41"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_109",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_54",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_54",
+    "ftype": "simple_resistor",
+    "name": "R522",
+    "resistance": 0,
+    "display_resistance": "0Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_110",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_55",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_111",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_55",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_55",
+    "ftype": "simple_resistor",
+    "name": "R523",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_112",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_56",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_113",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_56",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_56",
+    "ftype": "simple_resistor",
+    "name": "R524",
+    "resistance": 51,
+    "display_resistance": "51Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_114",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_57",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_115",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_57",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_57",
+    "ftype": "simple_resistor",
+    "name": "R525",
+    "resistance": 1000000,
+    "display_resistance": "1MΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_116",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_58",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_117",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_58",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_58",
+    "ftype": "simple_resistor",
+    "name": "R526",
+    "resistance": 4990,
+    "display_resistance": "4.99kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_118",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_59",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_119",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_59",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_59",
+    "ftype": "simple_resistor",
+    "name": "R527",
+    "resistance": 51,
+    "display_resistance": "51Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_120",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_60",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_121",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_60",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_60",
+    "ftype": "simple_resistor",
+    "name": "R528",
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_122",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_61",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_123",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_61",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_61",
+    "ftype": "simple_resistor",
+    "name": "R530",
+    "resistance": 15,
+    "display_resistance": "15Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_124",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_62",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_125",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_62",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_62",
+    "ftype": "simple_resistor",
+    "name": "R531",
+    "resistance": 511,
+    "display_resistance": "511Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_126",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_63",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_127",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_63",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_63",
+    "ftype": "simple_resistor",
+    "name": "R534",
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_128",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_64",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_129",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_64",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_64",
+    "ftype": "simple_resistor",
+    "name": "R535",
+    "resistance": 30100,
+    "display_resistance": "30.1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_130",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_65",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_131",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_65",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_65",
+    "ftype": "simple_resistor",
+    "name": "R536",
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_132",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_66",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_133",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_66",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_66",
+    "ftype": "simple_resistor",
+    "name": "R537",
+    "resistance": 15,
+    "display_resistance": "15Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_134",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_67",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_135",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_67",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_67",
+    "ftype": "simple_resistor",
+    "name": "R538",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_136",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_68",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_137",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_68",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_68",
+    "ftype": "simple_resistor",
+    "name": "R539",
+    "resistance": 100000,
+    "display_resistance": "100kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_138",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_69",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_139",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_69",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_69",
+    "ftype": "simple_resistor",
+    "name": "R540",
+    "resistance": 0,
+    "display_resistance": "0Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_140",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_70",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_141",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_70",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_70",
+    "ftype": "simple_resistor",
+    "name": "R541",
+    "resistance": 200,
+    "display_resistance": "200Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_142",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_71",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_143",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_71",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_71",
+    "ftype": "simple_resistor",
+    "name": "R542",
+    "resistance": 20000,
+    "display_resistance": "20kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_144",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_72",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_145",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_72",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_72",
+    "ftype": "simple_resistor",
+    "name": "R543",
+    "resistance": 3400,
+    "display_resistance": "3.4kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_146",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_73",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_147",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_73",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_73",
+    "ftype": "simple_resistor",
+    "name": "R544",
+    "resistance": 10,
+    "display_resistance": "10Ω",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_148",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_74",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_149",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_74",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_74",
+    "ftype": "simple_resistor",
+    "name": "R545",
+    "resistance": 2490,
+    "display_resistance": "2.49kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_150",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_75",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_151",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_75",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_75",
+    "ftype": "simple_resistor",
+    "name": "R546",
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_152",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
+    "source_component_id": "source_component_76",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_153",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
+    "source_component_id": "source_component_76",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_76",
+    "ftype": "simple_resistor",
+    "name": "R547",
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_154",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_77",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_155",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_77",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_77",
+    "ftype": "simple_diode",
+    "name": "D500",
+    "manufacturer_part_number": "BAS316,115",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_156",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_78",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_157",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_78",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_78",
+    "ftype": "simple_diode",
+    "name": "D501",
+    "manufacturer_part_number": "BAS316,115",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_158",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_79",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_159",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_79",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_79",
+    "ftype": "simple_diode",
+    "name": "D502",
+    "manufacturer_part_number": "MURA160T3G",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_160",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_80",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_161",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_80",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_80",
+    "ftype": "simple_diode",
+    "name": "D503",
+    "manufacturer_part_number": "BAT54HT1G",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_162",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_81",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_163",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_81",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_81",
+    "ftype": "simple_diode",
+    "name": "D504",
+    "manufacturer_part_number": "BAT54HT1G",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_164",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "pos", "anode", "left", "1"],
+    "source_component_id": "source_component_82",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_165",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "neg", "cathode", "right", "2"],
+    "source_component_id": "source_component_82",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_82",
+    "ftype": "simple_diode",
+    "name": "D507",
+    "manufacturer_part_number": "MMSZ5254B-7-F",
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_166",
+    "name": "A",
+    "pin_number": 1,
+    "port_hints": ["A", "pin1", "1"],
+    "source_component_id": "source_component_83",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_167",
+    "name": "C",
+    "pin_number": 2,
+    "port_hints": ["C", "pin2", "2"],
+    "source_component_id": "source_component_83",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_168",
+    "name": "K",
+    "pin_number": 3,
+    "port_hints": ["K", "pin3", "3"],
+    "source_component_id": "source_component_83",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_83",
+    "ftype": "simple_chip",
+    "name": "D505",
+    "manufacturer_part_number": "BAV99WT1G",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_169",
+    "name": "A",
+    "pin_number": 1,
+    "port_hints": ["A", "pin1", "1"],
+    "source_component_id": "source_component_84",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_170",
+    "name": "C",
+    "pin_number": 2,
+    "port_hints": ["C", "pin2", "2"],
+    "source_component_id": "source_component_84",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_171",
+    "name": "K",
+    "pin_number": 3,
+    "port_hints": ["K", "pin3", "3"],
+    "source_component_id": "source_component_84",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_84",
+    "ftype": "simple_chip",
+    "name": "D506",
+    "manufacturer_part_number": "BAV99WT1G",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_172",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_85",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_173",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_85",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_174",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_85",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_85",
+    "ftype": "simple_mosfet",
+    "name": "Q500",
+    "manufacturer_part_number": "BSS123",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_175",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_86",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_176",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_86",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_177",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_86",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_86",
+    "ftype": "simple_mosfet",
+    "name": "Q501",
+    "manufacturer_part_number": "BSS123",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_178",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_87",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_179",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_87",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_180",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_87",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net40"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_87",
+    "ftype": "simple_mosfet",
+    "name": "Q502",
+    "manufacturer_part_number": "CSD18532KCS",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_181",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_88",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_182",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_88",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_183",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_88",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_88",
+    "ftype": "simple_mosfet",
+    "name": "Q503",
+    "manufacturer_part_number": "IPW50R190CE",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_184",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_89",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_185",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_89",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_186",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_89",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_89",
+    "ftype": "simple_mosfet",
+    "name": "Q504",
+    "manufacturer_part_number": "IPW50R190CE",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_187",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_90",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_188",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_90",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_189",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_90",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_90",
+    "ftype": "simple_mosfet",
+    "name": "Q505",
+    "manufacturer_part_number": "CSD18532KCS",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_190",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "drain", "1"],
+    "source_component_id": "source_component_91",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_191",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": ["pin2", "source", "2"],
+    "source_component_id": "source_component_91",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_192",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": ["pin3", "gate", "3"],
+    "source_component_id": "source_component_91",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_91",
+    "ftype": "simple_mosfet",
+    "name": "Q506",
+    "manufacturer_part_number": "2N7002-7-F",
+    "mosfet_mode": "enhancement",
+    "channel_type": "n",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_193",
+    "name": "IN_1",
+    "pin_number": 1,
+    "port_hints": ["IN_1", "pin1", "1"],
+    "source_component_id": "source_component_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_194",
+    "name": "IN_2",
+    "pin_number": 2,
+    "port_hints": ["IN_2", "pin2", "2"],
+    "source_component_id": "source_component_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_195",
+    "name": "OUT_11",
+    "pin_number": 3,
+    "port_hints": ["OUT_11", "pin3", "3"],
+    "source_component_id": "source_component_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_196",
+    "name": "OUT_12",
+    "pin_number": 4,
+    "port_hints": ["OUT_12", "pin4", "4"],
+    "source_component_id": "source_component_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_92",
+    "ftype": "simple_chip",
+    "name": "L500",
+    "manufacturer_part_number": "RLTI-1150",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_197",
+    "name": "PRI_3",
+    "pin_number": 1,
+    "port_hints": ["PRI_3", "pin1", "1"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_198",
+    "name": "PRI_4",
+    "pin_number": 2,
+    "port_hints": ["PRI_4", "pin2", "2"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_199",
+    "name": "SEC_13",
+    "pin_number": 3,
+    "port_hints": ["SEC_13", "pin3", "3"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_200",
+    "name": "SEC_14",
+    "pin_number": 4,
+    "port_hints": ["SEC_14", "pin4", "4"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_201",
+    "name": "CT_15",
+    "pin_number": 5,
+    "port_hints": ["CT_15", "pin5", "5"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_202",
+    "name": "CT_16",
+    "pin_number": 6,
+    "port_hints": ["CT_16", "pin6", "6"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_203",
+    "name": "CT_17",
+    "pin_number": 7,
+    "port_hints": ["CT_17", "pin7", "7"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_204",
+    "name": "CT_18",
+    "pin_number": 8,
+    "port_hints": ["CT_18", "pin8", "8"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_205",
+    "name": "SEC_19",
+    "pin_number": 9,
+    "port_hints": ["SEC_19", "pin9", "9"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_206",
+    "name": "SEC_20",
+    "pin_number": 10,
+    "port_hints": ["SEC_20", "pin10", "10"],
+    "source_component_id": "source_component_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_93",
+    "ftype": "simple_chip",
+    "name": "T500",
+    "manufacturer_part_number": "RLTI-1149",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_207",
+    "name": "SYNC",
+    "pin_number": 1,
+    "port_hints": ["SYNC", "pin1", "1"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_208",
+    "name": "EN_TOFF",
+    "pin_number": 2,
+    "port_hints": ["EN_TOFF", "pin2", "2"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net47"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_209",
+    "name": "TON",
+    "pin_number": 3,
+    "port_hints": ["TON", "pin3", "3"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net48"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_210",
+    "name": "VCC",
+    "pin_number": 4,
+    "port_hints": ["VCC", "pin4", "4"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_211",
+    "name": "GATE",
+    "pin_number": 5,
+    "port_hints": ["GATE", "pin5", "5"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_212",
+    "name": "GND",
+    "pin_number": 6,
+    "port_hints": ["GND", "pin6", "6"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_213",
+    "name": "VS",
+    "pin_number": 7,
+    "port_hints": ["VS", "pin7", "7"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_214",
+    "name": "VD",
+    "pin_number": 8,
+    "port_hints": ["VD", "pin8", "8"],
+    "source_component_id": "source_component_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_94",
+    "ftype": "simple_chip",
+    "name": "U500",
+    "manufacturer_part_number": "UCC24610D",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_215",
+    "name": "SYNC",
+    "pin_number": 1,
+    "port_hints": ["SYNC", "pin1", "1"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_216",
+    "name": "EN_TOFF",
+    "pin_number": 2,
+    "port_hints": ["EN_TOFF", "pin2", "2"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_217",
+    "name": "TON",
+    "pin_number": 3,
+    "port_hints": ["TON", "pin3", "3"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_218",
+    "name": "VCC",
+    "pin_number": 4,
+    "port_hints": ["VCC", "pin4", "4"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_219",
+    "name": "GATE",
+    "pin_number": 5,
+    "port_hints": ["GATE", "pin5", "5"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_220",
+    "name": "GND",
+    "pin_number": 6,
+    "port_hints": ["GND", "pin6", "6"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_221",
+    "name": "VS",
+    "pin_number": 7,
+    "port_hints": ["VS", "pin7", "7"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_222",
+    "name": "VD",
+    "pin_number": 8,
+    "port_hints": ["VD", "pin8", "8"],
+    "source_component_id": "source_component_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_95",
+    "ftype": "simple_chip",
+    "name": "U501",
+    "manufacturer_part_number": "UCC24610D",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_223",
+    "name": "HI",
+    "pin_number": 1,
+    "port_hints": ["HI", "pin1", "1"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_224",
+    "name": "LI",
+    "pin_number": 2,
+    "port_hints": ["LI", "pin2", "2"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_225",
+    "name": "VSS",
+    "pin_number": 3,
+    "port_hints": ["VSS", "pin3", "3"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_226",
+    "name": "NC_EN",
+    "pin_number": 4,
+    "port_hints": ["NC_EN", "pin4", "4"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_227",
+    "name": "COM",
+    "pin_number": 5,
+    "port_hints": ["COM", "pin5", "5"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_228",
+    "name": "LO",
+    "pin_number": 6,
+    "port_hints": ["LO", "pin6", "6"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_229",
+    "name": "VDD",
+    "pin_number": 7,
+    "port_hints": ["VDD", "pin7", "7"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_230",
+    "name": "NC_8",
+    "pin_number": 8,
+    "port_hints": ["NC_8", "pin8", "8"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_231",
+    "name": "NC_9",
+    "pin_number": 9,
+    "port_hints": ["NC_9", "pin9", "9"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_232",
+    "name": "NC_10",
+    "pin_number": 10,
+    "port_hints": ["NC_10", "pin10", "10"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_233",
+    "name": "HS",
+    "pin_number": 11,
+    "port_hints": ["HS", "pin11", "11"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_234",
+    "name": "HO",
+    "pin_number": 12,
+    "port_hints": ["HO", "pin12", "12"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_235",
+    "name": "HB",
+    "pin_number": 13,
+    "port_hints": ["HB", "pin13", "13"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_236",
+    "name": "NC_14",
+    "pin_number": 14,
+    "port_hints": ["NC_14", "pin14", "14"],
+    "source_component_id": "source_component_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_96",
+    "ftype": "simple_chip",
+    "name": "U502",
+    "manufacturer_part_number": "UCC27714D",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_237",
+    "name": "A",
+    "pin_number": 1,
+    "port_hints": ["A", "ANODE", "pin1", "1"],
+    "source_component_id": "source_component_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_238",
+    "name": "K",
+    "pin_number": 2,
+    "port_hints": ["K", "CATHODE", "pin2", "2"],
+    "source_component_id": "source_component_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_239",
+    "name": "E",
+    "pin_number": 3,
+    "port_hints": ["E", "EMITTER", "pin3", "3"],
+    "source_component_id": "source_component_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_240",
+    "name": "C",
+    "pin_number": 4,
+    "port_hints": ["C", "COLLECTOR", "pin4", "4"],
+    "source_component_id": "source_component_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_97",
+    "ftype": "simple_chip",
+    "name": "U503",
+    "manufacturer_part_number": "PC817X4NSZ0F",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_241",
+    "name": "DT",
+    "pin_number": 1,
+    "port_hints": ["DT", "pin1", "1"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_242",
+    "name": "RT",
+    "pin_number": 2,
+    "port_hints": ["RT", "pin2", "2"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_243",
+    "name": "OC",
+    "pin_number": 3,
+    "port_hints": ["OC", "pin3", "3"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_244",
+    "name": "SS",
+    "pin_number": 4,
+    "port_hints": ["SS", "pin4", "4"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_245",
+    "name": "GD2",
+    "pin_number": 5,
+    "port_hints": ["GD2", "pin5", "5"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_246",
+    "name": "GND",
+    "pin_number": 6,
+    "port_hints": ["GND", "pin6", "6"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_247",
+    "name": "VCC",
+    "pin_number": 7,
+    "port_hints": ["VCC", "pin7", "7"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_248",
+    "name": "GD1",
+    "pin_number": 8,
+    "port_hints": ["GD1", "pin8", "8"],
+    "source_component_id": "source_component_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_98",
+    "ftype": "simple_chip",
+    "name": "U504",
+    "manufacturer_part_number": "UCC25600D",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_249",
+    "name": "REF",
+    "pin_number": 1,
+    "port_hints": ["REF", "pin1", "1"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_250",
+    "name": "GND",
+    "pin_number": 2,
+    "port_hints": ["GND", "pin2", "2"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_251",
+    "name": "V_PLUS",
+    "pin_number": 3,
+    "port_hints": ["V_PLUS", "VS", "pin3", "3"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_252",
+    "name": "IN_PLUS",
+    "pin_number": 4,
+    "port_hints": ["IN_PLUS", "INP", "pin4", "4"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_253",
+    "name": "IN_MINUS",
+    "pin_number": 5,
+    "port_hints": ["IN_MINUS", "INN", "pin5", "5"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_254",
+    "name": "OUT",
+    "pin_number": 6,
+    "port_hints": ["OUT", "pin6", "6"],
+    "source_component_id": "source_component_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_99",
+    "ftype": "simple_chip",
+    "name": "U505",
+    "manufacturer_part_number": "INA213AIDCK",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_255",
+    "name": "K",
+    "pin_number": 1,
+    "port_hints": ["K", "CATHODE", "pin1", "1"],
+    "source_component_id": "source_component_100",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_256",
+    "name": "REF",
+    "pin_number": 2,
+    "port_hints": ["REF", "REFERENCE", "pin2", "2"],
+    "source_component_id": "source_component_100",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_257",
+    "name": "A",
+    "pin_number": 3,
+    "port_hints": ["A", "ANODE", "pin3", "3"],
+    "source_component_id": "source_component_100",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_100",
+    "ftype": "simple_chip",
+    "name": "U506",
+    "manufacturer_part_number": "TL431BIDBZR",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_258",
+    "name": "A",
+    "pin_number": 1,
+    "port_hints": ["A", "ANODE", "pin1", "1"],
+    "source_component_id": "source_component_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_259",
+    "name": "K",
+    "pin_number": 2,
+    "port_hints": ["K", "CATHODE", "pin2", "2"],
+    "source_component_id": "source_component_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_260",
+    "name": "E",
+    "pin_number": 3,
+    "port_hints": ["E", "EMITTER", "pin3", "3"],
+    "source_component_id": "source_component_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_261",
+    "name": "C",
+    "pin_number": 4,
+    "port_hints": ["C", "COLLECTOR", "pin4", "4"],
+    "source_component_id": "source_component_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_101",
+    "ftype": "simple_chip",
+    "name": "U507",
+    "manufacturer_part_number": "LTV-817",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_262",
+    "name": "20V2",
+    "pin_number": 1,
+    "port_hints": ["20V2", "pin1", "1"],
+    "source_component_id": "source_component_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_263",
+    "name": "20V2",
+    "pin_number": 2,
+    "port_hints": ["20V2", "pin2", "2"],
+    "source_component_id": "source_component_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_264",
+    "name": "SGND",
+    "pin_number": 3,
+    "port_hints": ["SGND", "pin3", "3"],
+    "source_component_id": "source_component_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_265",
+    "name": "SGND",
+    "pin_number": 4,
+    "port_hints": ["SGND", "pin4", "4"],
+    "source_component_id": "source_component_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_102",
+    "ftype": "simple_pin_header",
+    "name": "J500",
+    "pin_count": 4,
+    "gender": "male",
+    "are_pins_interchangeable": true,
+    "display_name": "24V OUTPUT",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_266",
+    "name": "MOUNT_1",
+    "pin_number": 1,
+    "port_hints": ["MOUNT_1", "pin1", "1"],
+    "source_component_id": "source_component_103",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_267",
+    "name": "MOUNT_2",
+    "pin_number": 2,
+    "port_hints": ["MOUNT_2", "pin2", "2"],
+    "source_component_id": "source_component_103",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_268",
+    "name": "MOUNT_3",
+    "pin_number": 3,
+    "port_hints": ["MOUNT_3", "pin3", "3"],
+    "source_component_id": "source_component_103",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_103",
+    "ftype": "simple_chip",
+    "name": "H500",
+    "manufacturer_part_number": "782653B04250G",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_269",
+    "name": "MOUNT_1",
+    "pin_number": 1,
+    "port_hints": ["MOUNT_1", "pin1", "1"],
+    "source_component_id": "source_component_104",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_270",
+    "name": "MOUNT_2",
+    "pin_number": 2,
+    "port_hints": ["MOUNT_2", "pin2", "2"],
+    "source_component_id": "source_component_104",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_104",
+    "ftype": "simple_chip",
+    "name": "H501",
+    "manufacturer_part_number": "513101B02500G",
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_271",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_105",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_105",
+    "ftype": "simple_test_point",
+    "name": "TP500",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_272",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_106",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_106",
+    "ftype": "simple_test_point",
+    "name": "TP501",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_273",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_107",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_107",
+    "ftype": "simple_test_point",
+    "name": "TP502",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_274",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_108",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_108",
+    "ftype": "simple_test_point",
+    "name": "TP503",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_275",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_109",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_109",
+    "ftype": "simple_test_point",
+    "name": "TP504",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_276",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_110",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_110",
+    "ftype": "simple_test_point",
+    "name": "TP505",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_277",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": ["pin1", "1"],
+    "source_component_id": "source_component_111",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_111",
+    "ftype": "simple_test_point",
+    "name": "TP506",
+    "footprint_variant": "through_hole",
+    "pad_shape": "circle",
+    "pad_diameter": 2,
+    "hole_diameter": 1,
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_278",
+    "name": "VBULK",
+    "port_hints": ["VBULK"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_279",
+    "name": "12V",
+    "port_hints": ["12V"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_280",
+    "name": "PWMCNTL1",
+    "port_hints": ["PWMCNTL1"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_281",
+    "name": "GND1",
+    "port_hints": ["GND1"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_282",
+    "name": "20V2",
+    "port_hints": ["20V2"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_283",
+    "name": "SGND",
+    "port_hints": ["SGND"],
+    "source_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_0",
+    "name": "GND1",
+    "member_source_group_ids": [],
+    "is_ground": true,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_1",
+    "name": "V20V1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_2",
+    "name": "V12Vs",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_3",
+    "name": "SGND",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_4",
+    "name": "VD_SR2",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_5",
+    "name": "VD_SR1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_6",
+    "name": "V20V2",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_7",
+    "name": "V5Vs",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_8",
+    "name": "VG_SR2",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_9",
+    "name": "VG_SR1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52"
+  },
+  {
+    "type": "source_refdes_convention_warning",
+    "warning_type": "source_refdes_convention_warning",
+    "message": "The \"L\" prefix is being used with a <chip />, try using it with an <inductor />",
+    "source_component_id": "source_component_92",
+    "refdes": "L500",
+    "source_component_ftype": "simple_chip",
+    "expected_prefixes": ["U", "IC"],
+    "actual_prefix": "L",
+    "source_refdes_convention_warning_id": "source_refdes_convention_warning_0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": ["source_port_243", "source_port_141"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin3 to R541.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_0",
+    "message": "<trace#1543(from:U504.pin3 to:R541.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": ["source_port_141", "source_port_58"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R541.pin2 to C533.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_1",
+    "message": "<trace#1544(from:R541.pin2 to:C533.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": ["source_port_58", "source_port_167"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C533.pin1 to D505.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_2",
+    "message": "<trace#1545(from:C533.pin1 to:D505.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": ["source_port_86", "source_port_160"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R510.pin1 to D503.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_3",
+    "message": "<trace#1546(from:R510.pin1 to:D503.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": ["source_port_160", "source_port_234"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D503.pin1 to U502.pin12",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_4",
+    "message": "<trace#1547(from:D503.pin1 to:U502.pin12) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": ["source_port_87", "source_port_161"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R510.pin2 to D503.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_5",
+    "message": "<trace#1548(from:R510.pin2 to:D503.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": ["source_port_161", "source_port_88"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D503.pin2 to R511.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_6",
+    "message": "<trace#1549(from:D503.pin2 to:R511.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": ["source_port_88", "source_port_183"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R511.pin1 to Q503.gate",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_7",
+    "message": "<trace#1550(from:R511.pin1 to:Q503.gate) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": ["source_port_89", "source_port_182"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R511.pin2 to Q503.source",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_8",
+    "message": "<trace#1551(from:R511.pin2 to:Q503.source) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": ["source_port_182", "source_port_193"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q503.source to L500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_9",
+    "message": "<trace#1552(from:Q503.source to:L500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": ["source_port_193", "source_port_194"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "L500.pin1 to L500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_10",
+    "message": "<trace#1553(from:L500.pin1 to:L500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": ["source_port_182", "source_port_184"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q503.source to Q504.drain",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_11",
+    "message": "<trace#1554(from:Q503.source to:Q504.drain) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": ["source_port_89", "source_port_233"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R511.pin2 to U502.pin11",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_12",
+    "message": "<trace#1555(from:R511.pin2 to:U502.pin11) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": ["source_port_233", "source_port_11"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin11 to C505.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_13",
+    "message": "<trace#1556(from:U502.pin11 to:C505.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": ["source_port_107", "source_port_185"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R521.pin2 to Q504.source",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_14",
+    "message": "<trace#1557(from:R521.pin2 to:Q504.source) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": ["source_port_185", "source_port_39"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q504.source to C519.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_15",
+    "message": "<trace#1558(from:Q504.source to:C519.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": ["source_port_185"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q504.source to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": ["source_port_102", "source_port_162"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R518.pin1 to D504.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_16",
+    "message": "<trace#1560(from:R518.pin1 to:D504.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": ["source_port_102", "source_port_228"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R518.pin1 to U502.pin6",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_17",
+    "message": "<trace#1561(from:R518.pin1 to:U502.pin6) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": ["source_port_103", "source_port_163"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R518.pin2 to D504.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_18",
+    "message": "<trace#1562(from:R518.pin2 to:D504.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": ["source_port_103", "source_port_186"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R518.pin2 to Q504.gate",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_19",
+    "message": "<trace#1563(from:R518.pin2 to:Q504.gate) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": ["source_port_186", "source_port_106"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q504.gate to R521.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_20",
+    "message": "<trace#1564(from:Q504.gate to:R521.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": ["source_port_0"],
+    "connected_source_net_ids": ["source_net_1"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C500.pin1 to net.V20V1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_23",
+    "connected_source_port_ids": ["source_port_246", "source_port_57"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U504.pin6 to C532.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_21",
+    "message": "<trace#1566(from:U504.pin6 to:C532.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_24",
+    "connected_source_port_ids": ["source_port_246"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin6 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_25",
+    "connected_source_port_ids": ["source_port_247", "source_port_56"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U504.pin7 to C532.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_22",
+    "message": "<trace#1568(from:U504.pin7 to:C532.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_25",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_26",
+    "connected_source_port_ids": ["source_port_241", "source_port_143"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin1 to R542.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_23",
+    "message": "<trace#1569(from:U504.pin1 to:R542.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_26",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_27",
+    "connected_source_port_ids": ["source_port_242", "source_port_124"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin2 to R531.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_24",
+    "message": "<trace#1570(from:U504.pin2 to:R531.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_27",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_28",
+    "connected_source_port_ids": ["source_port_124", "source_port_145"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R531.pin1 to R543.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_25",
+    "message": "<trace#1571(from:R531.pin1 to:R543.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_28",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_29",
+    "connected_source_port_ids": ["source_port_145", "source_port_261"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R543.pin2 to U507.pin4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_26",
+    "message": "<trace#1572(from:R543.pin2 to:U507.pin4) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_29",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_30",
+    "connected_source_port_ids": ["source_port_244", "source_port_46"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin4 to C527.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_27",
+    "message": "<trace#1573(from:U504.pin4 to:C527.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_30",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_31",
+    "connected_source_port_ids": ["source_port_46", "source_port_191"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C527.pin1 to Q506.source",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_28",
+    "message": "<trace#1574(from:C527.pin1 to:Q506.source) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_31",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_32",
+    "connected_source_port_ids": ["source_port_144"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R543.pin1 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_33",
+    "connected_source_port_ids": ["source_port_142"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R542.pin1 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_34",
+    "connected_source_port_ids": ["source_port_140"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R541.pin1 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_35",
+    "connected_source_port_ids": ["source_port_168", "source_port_44"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D505.pin3 to C526.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_29",
+    "message": "<trace#1578(from:D505.pin3 to:C526.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_35",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_36",
+    "connected_source_port_ids": ["source_port_166"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D505.pin1 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_37",
+    "connected_source_port_ids": ["source_port_59"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C533.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_38",
+    "connected_source_port_ids": ["source_port_47"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C527.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_39",
+    "connected_source_port_ids": ["source_port_49", "source_port_239"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C528.pin2 to U503.pin3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_30",
+    "message": "<trace#1582(from:C528.pin2 to:U503.pin3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_39",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_40",
+    "connected_source_port_ids": ["source_port_49"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C528.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_41",
+    "connected_source_port_ids": ["source_port_1"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C500.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_42",
+    "connected_source_port_ids": ["source_port_45", "source_port_38"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C526.pin2 to C519.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_31",
+    "message": "<trace#1585(from:C526.pin2 to:C519.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_42",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_43",
+    "connected_source_port_ids": ["source_port_38", "source_port_197"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C519.pin1 to T500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_32",
+    "message": "<trace#1586(from:C519.pin1 to:T500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_43",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_44",
+    "connected_source_port_ids": ["source_port_181", "source_port_6"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q503.drain to C503.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_33",
+    "message": "<trace#1587(from:Q503.drain to:C503.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_44",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_45",
+    "connected_source_port_ids": ["source_port_192", "source_port_115"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q506.gate to R525.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_34",
+    "message": "<trace#1588(from:Q506.gate to:R525.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_45",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_46",
+    "connected_source_port_ids": ["source_port_192", "source_port_110"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q506.gate to R523.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_35",
+    "message": "<trace#1589(from:Q506.gate to:R523.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_46",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_47",
+    "connected_source_port_ids": ["source_port_190"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q506.drain to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_48",
+    "connected_source_port_ids": ["source_port_269", "source_port_270"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "H501.pin1 to H501.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_36",
+    "message": "<trace#1591(from:H501.pin1 to:H501.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_48",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_49",
+    "connected_source_port_ids": ["source_port_270"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "H501.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_50",
+    "connected_source_port_ids": ["source_port_120", "source_port_51"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R528.pin1 to C529.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_37",
+    "message": "<trace#1593(from:R528.pin1 to:C529.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_50",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_51",
+    "connected_source_port_ids": ["source_port_51", "source_port_53"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C529.pin2 to C530.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_38",
+    "message": "<trace#1594(from:C529.pin2 to:C530.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_51",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_52",
+    "connected_source_port_ids": ["source_port_53", "source_port_255"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C530.pin2 to U506.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_39",
+    "message": "<trace#1595(from:C530.pin2 to:U506.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_52",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_53",
+    "connected_source_port_ids": ["source_port_120", "source_port_123"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R528.pin1 to R530.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_40",
+    "message": "<trace#1596(from:R528.pin1 to:R530.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_53",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_54",
+    "connected_source_port_ids": ["source_port_123", "source_port_274"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R530.pin2 to TP503.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_41",
+    "message": "<trace#1597(from:R530.pin2 to:TP503.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_54",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_55",
+    "connected_source_port_ids": ["source_port_123", "source_port_169"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R530.pin2 to D506.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_42",
+    "message": "<trace#1598(from:R530.pin2 to:D506.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_55",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_56",
+    "connected_source_port_ids": ["source_port_122", "source_port_273"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R530.pin1 to TP502.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_43",
+    "message": "<trace#1599(from:R530.pin1 to:TP502.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_56",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_57",
+    "connected_source_port_ids": ["source_port_273", "source_port_238"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "TP502.pin1 to U503.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_44",
+    "message": "<trace#1600(from:TP502.pin1 to:U503.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_57",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_58",
+    "connected_source_port_ids": ["source_port_121", "source_port_24"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R528.pin2 to C512.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_45",
+    "message": "<trace#1601(from:R528.pin2 to:C512.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_58",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_59",
+    "connected_source_port_ids": ["source_port_121", "source_port_117"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R528.pin2 to R526.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_46",
+    "message": "<trace#1602(from:R528.pin2 to:R526.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_59",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_60",
+    "connected_source_port_ids": ["source_port_117", "source_port_170"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R526.pin2 to D506.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_47",
+    "message": "<trace#1603(from:R526.pin2 to:D506.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_60",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_61",
+    "connected_source_port_ids": ["source_port_170", "source_port_136"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D506.pin2 to R539.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_48",
+    "message": "<trace#1604(from:D506.pin2 to:R539.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_61",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_62",
+    "connected_source_port_ids": ["source_port_24"],
+    "connected_source_net_ids": ["source_net_2"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C512.pin1 to net.V12Vs",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_63",
+    "connected_source_port_ids": ["source_port_64", "source_port_277"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C536.pin1 to TP506.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_49",
+    "message": "<trace#1606(from:C536.pin1 to:TP506.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_63",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_64",
+    "connected_source_port_ids": ["source_port_64"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C536.pin1 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_65",
+    "connected_source_port_ids": ["source_port_148"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R545.pin1 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_66",
+    "connected_source_port_ids": ["source_port_137", "source_port_65"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R539.pin2 to C536.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_50",
+    "message": "<trace#1609(from:R539.pin2 to:C536.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_66",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_67",
+    "connected_source_port_ids": ["source_port_65", "source_port_171"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C536.pin2 to D506.pin3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_51",
+    "message": "<trace#1610(from:C536.pin2 to:D506.pin3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_67",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_68",
+    "connected_source_port_ids": ["source_port_237", "source_port_116"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U503.pin1 to R526.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_52",
+    "message": "<trace#1611(from:U503.pin1 to:R526.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_68",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_69",
+    "connected_source_port_ids": ["source_port_126", "source_port_52"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R534.pin1 to C530.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_53",
+    "message": "<trace#1612(from:R534.pin1 to:C530.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_69",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_70",
+    "connected_source_port_ids": ["source_port_257"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U506.pin3 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_71",
+    "connected_source_port_ids": ["source_port_50", "source_port_127"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C529.pin1 to R534.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_54",
+    "message": "<trace#1614(from:C529.pin1 to:R534.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_71",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_72",
+    "connected_source_port_ids": ["source_port_127", "source_port_138"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R534.pin2 to R540.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_55",
+    "message": "<trace#1615(from:R534.pin2 to:R540.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_72",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_73",
+    "connected_source_port_ids": ["source_port_138", "source_port_256"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R540.pin1 to U506.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_56",
+    "message": "<trace#1616(from:R540.pin1 to:U506.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_73",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_74",
+    "connected_source_port_ids": ["source_port_48", "source_port_125"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C528.pin1 to R531.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_57",
+    "message": "<trace#1617(from:C528.pin1 to:R531.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_74",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_75",
+    "connected_source_port_ids": ["source_port_125", "source_port_240"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R531.pin2 to U503.pin4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_58",
+    "message": "<trace#1618(from:R531.pin2 to:U503.pin4) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_75",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_76",
+    "connected_source_port_ids": ["source_port_260"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U507.pin3 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_77",
+    "connected_source_port_ids": ["source_port_258", "source_port_153"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U507.pin1 to R547.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_59",
+    "message": "<trace#1620(from:U507.pin1 to:R547.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_77",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_78",
+    "connected_source_port_ids": ["source_port_153", "source_port_150"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R547.pin2 to R546.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_60",
+    "message": "<trace#1621(from:R547.pin2 to:R546.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_78",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_79",
+    "connected_source_port_ids": ["source_port_259", "source_port_152"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U507.pin2 to R547.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_61",
+    "message": "<trace#1622(from:U507.pin2 to:R547.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_79",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_80",
+    "connected_source_port_ids": ["source_port_152"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R547.pin1 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_81",
+    "connected_source_port_ids": ["source_port_225", "source_port_227"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin3 to U502.pin5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_62",
+    "message": "<trace#1624(from:U502.pin3 to:U502.pin5) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_81",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_82",
+    "connected_source_port_ids": ["source_port_225"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin3 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_83",
+    "connected_source_port_ids": ["source_port_224", "source_port_30"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin2 to C515.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_63",
+    "message": "<trace#1626(from:U502.pin2 to:C515.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_83",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_84",
+    "connected_source_port_ids": ["source_port_30", "source_port_119"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C515.pin1 to R527.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_64",
+    "message": "<trace#1627(from:C515.pin1 to:R527.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_84",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_85",
+    "connected_source_port_ids": ["source_port_223", "source_port_28"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin1 to C514.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_65",
+    "message": "<trace#1628(from:U502.pin1 to:C514.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_85",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_86",
+    "connected_source_port_ids": ["source_port_28", "source_port_113"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C514.pin1 to R524.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_66",
+    "message": "<trace#1629(from:C514.pin1 to:R524.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_86",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_87",
+    "connected_source_port_ids": ["source_port_229", "source_port_18"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U502.pin7 to C509.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_67",
+    "message": "<trace#1630(from:U502.pin7 to:C509.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_87",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_88",
+    "connected_source_port_ids": ["source_port_18", "source_port_16"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "C509.pin1 to C508.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_68",
+    "message": "<trace#1631(from:C509.pin1 to:C508.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_88",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_89",
+    "connected_source_port_ids": ["source_port_229", "source_port_80"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin7 to R507.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_69",
+    "message": "<trace#1632(from:U502.pin7 to:R507.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_89",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_90",
+    "connected_source_port_ids": ["source_port_29"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C514.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_91",
+    "connected_source_port_ids": ["source_port_31"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C515.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_92",
+    "connected_source_port_ids": ["source_port_81", "source_port_159"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R507.pin2 to D502.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_70",
+    "message": "<trace#1635(from:R507.pin2 to:D502.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_93",
+    "connected_source_port_ids": ["source_port_235", "source_port_10"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U502.pin13 to C505.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_71",
+    "message": "<trace#1636(from:U502.pin13 to:C505.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_94",
+    "connected_source_port_ids": ["source_port_10", "source_port_158"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C505.pin1 to D502.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_72",
+    "message": "<trace#1637(from:C505.pin1 to:D502.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_95",
+    "connected_source_port_ids": ["source_port_92", "source_port_94"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R513.pin1 to R514.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_73",
+    "message": "<trace#1638(from:R513.pin1 to:R514.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_96",
+    "connected_source_port_ids": ["source_port_94", "source_port_100"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R514.pin1 to R517.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_74",
+    "message": "<trace#1639(from:R514.pin1 to:R517.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_97",
+    "connected_source_port_ids": ["source_port_100", "source_port_104"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R517.pin1 to R520.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_75",
+    "message": "<trace#1640(from:R517.pin1 to:R520.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_98",
+    "connected_source_port_ids": ["source_port_94", "source_port_36"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R514.pin1 to C518.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_76",
+    "message": "<trace#1641(from:R514.pin1 to:C518.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_99",
+    "connected_source_port_ids": ["source_port_36", "source_port_34"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C518.pin1 to C517.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_77",
+    "message": "<trace#1642(from:C518.pin1 to:C517.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_100",
+    "connected_source_port_ids": ["source_port_34", "source_port_20"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C517.pin1 to C510.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_78",
+    "message": "<trace#1643(from:C517.pin1 to:C510.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_100",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_101",
+    "connected_source_port_ids": ["source_port_20", "source_port_22"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C510.pin1 to C511.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_79",
+    "message": "<trace#1644(from:C510.pin1 to:C511.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_102",
+    "connected_source_port_ids": ["source_port_20", "source_port_201"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C510.pin1 to T500.pin5",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_80",
+    "message": "<trace#1645(from:C510.pin1 to:T500.pin5) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_103",
+    "connected_source_port_ids": ["source_port_201", "source_port_202"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "T500.pin5 to T500.pin6",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_81",
+    "message": "<trace#1646(from:T500.pin5 to:T500.pin6) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_103",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_104",
+    "connected_source_port_ids": ["source_port_202", "source_port_203"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "T500.pin6 to T500.pin7",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_82",
+    "message": "<trace#1647(from:T500.pin6 to:T500.pin7) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_104",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_105",
+    "connected_source_port_ids": ["source_port_203", "source_port_204"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "T500.pin7 to T500.pin8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_83",
+    "message": "<trace#1648(from:T500.pin7 to:T500.pin8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_105",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_106",
+    "connected_source_port_ids": ["source_port_8", "source_port_179"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C504.pin1 to Q502.source",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_84",
+    "message": "<trace#1649(from:C504.pin1 to:Q502.source) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_106",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_107",
+    "connected_source_port_ids": ["source_port_8", "source_port_266"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C504.pin1 to H500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_85",
+    "message": "<trace#1650(from:C504.pin1 to:H500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_107",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_108",
+    "connected_source_port_ids": ["source_port_266", "source_port_267"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "H500.pin1 to H500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_86",
+    "message": "<trace#1651(from:H500.pin1 to:H500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_108",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_109",
+    "connected_source_port_ids": ["source_port_267", "source_port_268"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "H500.pin2 to H500.pin3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_87",
+    "message": "<trace#1652(from:H500.pin2 to:H500.pin3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_109",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_110",
+    "connected_source_port_ids": ["source_port_268", "source_port_21"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "H500.pin3 to C510.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_88",
+    "message": "<trace#1653(from:H500.pin3 to:C510.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_110",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_111",
+    "connected_source_port_ids": ["source_port_21", "source_port_23"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C510.pin2 to C511.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_89",
+    "message": "<trace#1654(from:C510.pin2 to:C511.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_111",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_112",
+    "connected_source_port_ids": ["source_port_23"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C511.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_113",
+    "connected_source_port_ids": ["source_port_9", "source_port_74"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C504.pin2 to R504.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_90",
+    "message": "<trace#1656(from:C504.pin2 to:R504.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_113",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_114",
+    "connected_source_port_ids": ["source_port_75", "source_port_178"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R504.pin2 to Q502.drain",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_91",
+    "message": "<trace#1657(from:R504.pin2 to:Q502.drain) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_114",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_115",
+    "connected_source_port_ids": ["source_port_178", "source_port_199"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q502.drain to T500.pin3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_92",
+    "message": "<trace#1658(from:Q502.drain to:T500.pin3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_115",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_116",
+    "connected_source_port_ids": ["source_port_199", "source_port_200"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "T500.pin3 to T500.pin4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_93",
+    "message": "<trace#1659(from:T500.pin3 to:T500.pin4) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_116",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_117",
+    "connected_source_port_ids": ["source_port_178"],
+    "connected_source_net_ids": ["source_net_4"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q502.drain to net.VD_SR2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_118",
+    "connected_source_port_ids": ["source_port_180", "source_port_90"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q502.gate to R512.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net40"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_94",
+    "message": "<trace#1661(from:Q502.gate to:R512.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_118",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_119",
+    "connected_source_port_ids": ["source_port_43", "source_port_108"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C525.pin2 to R522.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net41"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_95",
+    "message": "<trace#1662(from:C525.pin2 to:R522.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_119",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_120",
+    "connected_source_port_ids": ["source_port_109", "source_port_187"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R522.pin2 to Q505.drain",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_96",
+    "message": "<trace#1663(from:R522.pin2 to:Q505.drain) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_120",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_121",
+    "connected_source_port_ids": ["source_port_187", "source_port_206"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q505.drain to T500.pin10",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_97",
+    "message": "<trace#1664(from:Q505.drain to:T500.pin10) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_121",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_122",
+    "connected_source_port_ids": ["source_port_206", "source_port_205"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "T500.pin10 to T500.pin9",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_98",
+    "message": "<trace#1665(from:T500.pin10 to:T500.pin9) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_122",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_123",
+    "connected_source_port_ids": ["source_port_187"],
+    "connected_source_net_ids": ["source_net_5"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q505.drain to net.VD_SR1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_124",
+    "connected_source_port_ids": ["source_port_42", "source_port_188"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C525.pin1 to Q505.source",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_99",
+    "message": "<trace#1667(from:C525.pin1 to:Q505.source) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_124",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_125",
+    "connected_source_port_ids": ["source_port_188", "source_port_35"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q505.source to C517.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_100",
+    "message": "<trace#1668(from:Q505.source to:C517.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_125",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_126",
+    "connected_source_port_ids": ["source_port_35", "source_port_37"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C517.pin2 to C518.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_101",
+    "message": "<trace#1669(from:C517.pin2 to:C518.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_126",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_127",
+    "connected_source_port_ids": ["source_port_37"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C518.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_128",
+    "connected_source_port_ids": ["source_port_272", "source_port_265"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "TP501.pin1 to J500.pin4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_102",
+    "message": "<trace#1671(from:TP501.pin1 to:J500.pin4) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_128",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_129",
+    "connected_source_port_ids": ["source_port_265", "source_port_264"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J500.pin4 to J500.pin3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_103",
+    "message": "<trace#1672(from:J500.pin4 to:J500.pin3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_129",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_130",
+    "connected_source_port_ids": ["source_port_265", "source_port_41"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J500.pin4 to C523.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_104",
+    "message": "<trace#1673(from:J500.pin4 to:C523.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_130",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_131",
+    "connected_source_port_ids": ["source_port_41", "source_port_33"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C523.pin2 to C516.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_105",
+    "message": "<trace#1674(from:C523.pin2 to:C516.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_131",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_132",
+    "connected_source_port_ids": ["source_port_33", "source_port_27"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C516.pin2 to C513.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_106",
+    "message": "<trace#1675(from:C516.pin2 to:C513.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_132",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_133",
+    "connected_source_port_ids": ["source_port_27"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C513.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_134",
+    "connected_source_port_ids": ["source_port_271", "source_port_262"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "TP500.pin1 to J500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_107",
+    "message": "<trace#1677(from:TP500.pin1 to:J500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_134",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_135",
+    "connected_source_port_ids": ["source_port_262", "source_port_263"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J500.pin1 to J500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_108",
+    "message": "<trace#1678(from:J500.pin1 to:J500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_135",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_136",
+    "connected_source_port_ids": ["source_port_263", "source_port_40"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "J500.pin2 to C523.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_109",
+    "message": "<trace#1679(from:J500.pin2 to:C523.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_136",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_137",
+    "connected_source_port_ids": ["source_port_40", "source_port_32"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C523.pin1 to C516.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_110",
+    "message": "<trace#1680(from:C523.pin1 to:C516.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_137",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_138",
+    "connected_source_port_ids": ["source_port_32", "source_port_26"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C516.pin1 to C513.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_111",
+    "message": "<trace#1681(from:C516.pin1 to:C513.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_138",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_139",
+    "connected_source_port_ids": ["source_port_26", "source_port_95"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C513.pin1 to R514.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_112",
+    "message": "<trace#1682(from:C513.pin1 to:R514.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_139",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_140",
+    "connected_source_port_ids": ["source_port_95", "source_port_93"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R514.pin2 to R513.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_113",
+    "message": "<trace#1683(from:R514.pin2 to:R513.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_140",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_141",
+    "connected_source_port_ids": ["source_port_95", "source_port_101"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R514.pin2 to R517.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_114",
+    "message": "<trace#1684(from:R514.pin2 to:R517.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_141",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_142",
+    "connected_source_port_ids": ["source_port_101", "source_port_105"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R517.pin2 to R520.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_115",
+    "message": "<trace#1685(from:R517.pin2 to:R520.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_142",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_143",
+    "connected_source_port_ids": ["source_port_26"],
+    "connected_source_net_ids": ["source_net_6"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C513.pin1 to net.V20V2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_144",
+    "connected_source_port_ids": ["source_port_149", "source_port_139"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R545.pin2 to R540.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_116",
+    "message": "<trace#1687(from:R545.pin2 to:R540.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_144",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_145",
+    "connected_source_port_ids": ["source_port_139", "source_port_128"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R540.pin2 to R535.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_117",
+    "message": "<trace#1688(from:R540.pin2 to:R535.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_145",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_146",
+    "connected_source_port_ids": ["source_port_128", "source_port_96"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R535.pin1 to R515.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_118",
+    "message": "<trace#1689(from:R535.pin1 to:R515.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_146",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_147",
+    "connected_source_port_ids": ["source_port_97"],
+    "connected_source_net_ids": ["source_net_6"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R515.pin2 to net.V20V2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_148",
+    "connected_source_port_ids": ["source_port_208", "source_port_83"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin2 to R508.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net47"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_119",
+    "message": "<trace#1691(from:U500.pin2 to:R508.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_148",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_149",
+    "connected_source_port_ids": ["source_port_209", "source_port_77"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin3 to R505.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net48"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_120",
+    "message": "<trace#1692(from:U500.pin3 to:R505.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_149",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_150",
+    "connected_source_port_ids": ["source_port_210", "source_port_12"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U500.pin4 to C506.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_121",
+    "message": "<trace#1693(from:U500.pin4 to:C506.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_150",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_151",
+    "connected_source_port_ids": ["source_port_210"],
+    "connected_source_net_ids": ["source_net_7"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin4 to net.V5Vs",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_152",
+    "connected_source_port_ids": ["source_port_212", "source_port_13"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U500.pin6 to C506.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_122",
+    "message": "<trace#1695(from:U500.pin6 to:C506.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_152",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_153",
+    "connected_source_port_ids": ["source_port_212", "source_port_82"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin6 to R508.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_123",
+    "message": "<trace#1696(from:U500.pin6 to:R508.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_153",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_154",
+    "connected_source_port_ids": ["source_port_82", "source_port_76"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R508.pin1 to R505.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_124",
+    "message": "<trace#1697(from:R508.pin1 to:R505.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_154",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_155",
+    "connected_source_port_ids": ["source_port_82"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R508.pin1 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_156",
+    "connected_source_port_ids": ["source_port_91"],
+    "connected_source_net_ids": ["source_net_8"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R512.pin2 to net.VG_SR2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_157",
+    "connected_source_port_ids": ["source_port_99"],
+    "connected_source_net_ids": ["source_net_9"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R516.pin2 to net.VG_SR1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_158",
+    "connected_source_port_ids": ["source_port_213", "source_port_3"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin7 to C501.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_125",
+    "message": "<trace#1701(from:U500.pin7 to:C501.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_158",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_159",
+    "connected_source_port_ids": ["source_port_3", "source_port_70"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C501.pin2 to R502.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_126",
+    "message": "<trace#1702(from:C501.pin2 to:R502.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_159",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_160",
+    "connected_source_port_ids": ["source_port_214", "source_port_2"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U500.pin8 to C501.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_127",
+    "message": "<trace#1703(from:U500.pin8 to:C501.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_160",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_161",
+    "connected_source_port_ids": ["source_port_2", "source_port_66"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C501.pin1 to R500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_128",
+    "message": "<trace#1704(from:C501.pin1 to:R500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_161",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_162",
+    "connected_source_port_ids": ["source_port_172", "source_port_67"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q500.drain to R500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_129",
+    "message": "<trace#1705(from:Q500.drain to:R500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_162",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_163",
+    "connected_source_port_ids": ["source_port_67", "source_port_155"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R500.pin2 to D500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_130",
+    "message": "<trace#1706(from:R500.pin2 to:D500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_163",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_164",
+    "connected_source_port_ids": ["source_port_174", "source_port_154"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q500.gate to D500.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_131",
+    "message": "<trace#1707(from:Q500.gate to:D500.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_164",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_165",
+    "connected_source_port_ids": ["source_port_154"],
+    "connected_source_net_ids": ["source_net_7"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D500.pin1 to net.V5Vs",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_166",
+    "connected_source_port_ids": ["source_port_71"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R502.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_167",
+    "connected_source_port_ids": ["source_port_216", "source_port_85"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin2 to R509.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_132",
+    "message": "<trace#1710(from:U501.pin2 to:R509.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_167",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_168",
+    "connected_source_port_ids": ["source_port_217", "source_port_79"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin3 to R506.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_133",
+    "message": "<trace#1711(from:U501.pin3 to:R506.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_168",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_169",
+    "connected_source_port_ids": ["source_port_218", "source_port_14"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U501.pin4 to C507.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_134",
+    "message": "<trace#1712(from:U501.pin4 to:C507.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_169",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_170",
+    "connected_source_port_ids": ["source_port_218"],
+    "connected_source_net_ids": ["source_net_7"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin4 to net.V5Vs",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_171",
+    "connected_source_port_ids": ["source_port_220", "source_port_15"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "U501.pin6 to C507.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_135",
+    "message": "<trace#1714(from:U501.pin6 to:C507.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_171",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_172",
+    "connected_source_port_ids": ["source_port_220", "source_port_84"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin6 to R509.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_136",
+    "message": "<trace#1715(from:U501.pin6 to:R509.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_172",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_173",
+    "connected_source_port_ids": ["source_port_84", "source_port_78"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R509.pin1 to R506.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_137",
+    "message": "<trace#1716(from:R509.pin1 to:R506.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_173",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_174",
+    "connected_source_port_ids": ["source_port_84"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R509.pin1 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_175",
+    "connected_source_port_ids": ["source_port_221", "source_port_5"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin7 to C502.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_138",
+    "message": "<trace#1718(from:U501.pin7 to:C502.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_175",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_176",
+    "connected_source_port_ids": ["source_port_5", "source_port_72"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C502.pin2 to R503.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_139",
+    "message": "<trace#1719(from:C502.pin2 to:R503.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_176",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_177",
+    "connected_source_port_ids": ["source_port_222", "source_port_4"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U501.pin8 to C502.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_140",
+    "message": "<trace#1720(from:U501.pin8 to:C502.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_177",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_178",
+    "connected_source_port_ids": ["source_port_4", "source_port_68"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C502.pin1 to R501.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_141",
+    "message": "<trace#1721(from:C502.pin1 to:R501.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_178",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_179",
+    "connected_source_port_ids": ["source_port_175", "source_port_69"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q501.drain to R501.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_142",
+    "message": "<trace#1722(from:Q501.drain to:R501.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_179",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_180",
+    "connected_source_port_ids": ["source_port_69", "source_port_157"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R501.pin2 to D501.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_143",
+    "message": "<trace#1723(from:R501.pin2 to:D501.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_180",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_181",
+    "connected_source_port_ids": ["source_port_177", "source_port_156"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q501.gate to D501.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_144",
+    "message": "<trace#1724(from:Q501.gate to:D501.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_181",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_182",
+    "connected_source_port_ids": ["source_port_156"],
+    "connected_source_net_ids": ["source_net_7"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D501.pin1 to net.V5Vs",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_183",
+    "connected_source_port_ids": ["source_port_73"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R503.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_184",
+    "connected_source_port_ids": ["source_port_164"],
+    "connected_source_net_ids": ["source_net_6"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "D507.pin1 to net.V20V2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_185",
+    "connected_source_port_ids": ["source_port_250", "source_port_249"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin2 to U505.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_145",
+    "message": "<trace#1728(from:U505.pin2 to:U505.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_185",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_186",
+    "connected_source_port_ids": ["source_port_250"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_187",
+    "connected_source_port_ids": ["source_port_251", "source_port_62"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin3 to C535.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_146",
+    "message": "<trace#1730(from:U505.pin3 to:C535.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_187",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_188",
+    "connected_source_port_ids": ["source_port_254", "source_port_133"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin6 to R537.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_147",
+    "message": "<trace#1731(from:U505.pin6 to:R537.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_188",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_189",
+    "connected_source_port_ids": ["source_port_133", "source_port_276"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R537.pin2 to TP505.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_148",
+    "message": "<trace#1732(from:R537.pin2 to:TP505.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_189",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_190",
+    "connected_source_port_ids": ["source_port_275", "source_port_131"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "TP504.pin1 to R536.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_149",
+    "message": "<trace#1733(from:TP504.pin1 to:R536.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_190",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_191",
+    "connected_source_port_ids": ["source_port_131", "source_port_132"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R536.pin2 to R537.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_150",
+    "message": "<trace#1734(from:R536.pin2 to:R537.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_191",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_192",
+    "connected_source_port_ids": ["source_port_63"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C535.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_193",
+    "connected_source_port_ids": ["source_port_253", "source_port_54"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin5 to C531.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_151",
+    "message": "<trace#1736(from:U505.pin5 to:C531.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_193",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_194",
+    "connected_source_port_ids": ["source_port_54", "source_port_134"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C531.pin1 to R538.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_152",
+    "message": "<trace#1737(from:C531.pin1 to:R538.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_194",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_195",
+    "connected_source_port_ids": ["source_port_252", "source_port_55"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U505.pin4 to C531.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_153",
+    "message": "<trace#1738(from:U505.pin4 to:C531.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_195",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_196",
+    "connected_source_port_ids": ["source_port_55", "source_port_146"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C531.pin2 to R544.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_154",
+    "message": "<trace#1739(from:C531.pin2 to:R544.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_196",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_197",
+    "connected_source_port_ids": ["source_port_135"],
+    "connected_source_net_ids": ["source_net_6"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R538.pin2 to net.V20V2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_198",
+    "connected_source_port_ids": ["source_port_147"],
+    "connected_source_net_ids": ["source_net_1"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R544.pin2 to net.V20V1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_199",
+    "connected_source_port_ids": ["source_port_60", "source_port_130"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C534.pin1 to R536.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_155",
+    "message": "<trace#1742(from:C534.pin1 to:R536.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_199",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_200",
+    "connected_source_port_ids": ["source_port_130", "source_port_129"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R536.pin1 to R535.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_156",
+    "message": "<trace#1743(from:R536.pin1 to:R535.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_200",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_201",
+    "connected_source_port_ids": ["source_port_61"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C534.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_202",
+    "connected_source_port_ids": ["source_port_195", "source_port_196"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "L500.pin3 to L500.pin4",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_157",
+    "message": "<trace#1745(from:L500.pin3 to:L500.pin4) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_202",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_203",
+    "connected_source_port_ids": ["source_port_196", "source_port_198"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "L500.pin4 to T500.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_158",
+    "message": "<trace#1746(from:L500.pin4 to:T500.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_203",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_204",
+    "connected_source_port_ids": ["source_port_248", "source_port_118"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin8 to R527.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_159",
+    "message": "<trace#1747(from:U504.pin8 to:R527.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_204",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_205",
+    "connected_source_port_ids": ["source_port_245", "source_port_112"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "U504.pin5 to R524.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_160",
+    "message": "<trace#1748(from:U504.pin5 to:R524.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_205",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_206",
+    "connected_source_port_ids": ["source_port_25"],
+    "connected_source_net_ids": ["source_net_3"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C512.pin2 to net.SGND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_207",
+    "connected_source_port_ids": ["source_port_114"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R525.pin1 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_208",
+    "connected_source_port_ids": ["source_port_151", "source_port_165"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "R546.pin2 to D507.pin2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_161",
+    "message": "<trace#1751(from:R546.pin2 to:D507.pin2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_208",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_209",
+    "connected_source_port_ids": ["source_port_19"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 1,
+    "display_name": "C509.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_210",
+    "connected_source_port_ids": ["source_port_17"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C508.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_211",
+    "connected_source_port_ids": ["source_port_189", "source_port_98"],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "Q505.gate to R516.pin1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_162",
+    "message": "<trace#1754(from:Q505.gate to:R516.pin1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_211",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_212",
+    "connected_source_port_ids": ["source_port_7"],
+    "connected_source_net_ids": ["source_net_0"],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": "C503.pin2 to net.GND1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "source_pin_missing_trace_warning",
+    "source_pin_missing_trace_warning_id": "source_pin_missing_trace_warning_0",
+    "message": "Port pin2 on R523 is missing a trace",
+    "source_component_id": "source_component_55",
+    "source_port_id": "source_port_111",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_pin_missing_trace_warning"
+  },
+  {
+    "type": "source_pin_missing_trace_warning",
+    "source_pin_missing_trace_warning_id": "source_pin_missing_trace_warning_1",
+    "message": "Port pin2 on Q500 is missing a trace",
+    "source_component_id": "source_component_85",
+    "source_port_id": "source_port_173",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_pin_missing_trace_warning"
+  },
+  {
+    "type": "source_pin_missing_trace_warning",
+    "source_pin_missing_trace_warning_id": "source_pin_missing_trace_warning_2",
+    "message": "Port pin2 on Q501 is missing a trace",
+    "source_component_id": "source_component_86",
+    "source_port_id": "source_port_176",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_pin_missing_trace_warning"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -3.19375,
+      "y": 6.57
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_0",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1500pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 6.3875,
+      "y": 6.66125
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_1",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "47pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 12.045,
+      "y": 6.66125
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_2",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "47pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 6.11375
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_3",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.047uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 1.55125,
+      "y": 5.84
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_4",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -9.581249999999999,
+      "y": 4.745
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_5",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "0.22uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 7.75625,
+      "y": 4.38
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_6",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 13.41375,
+      "y": 4.38
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_7",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -14.4175,
+      "y": 4.4712499999999995
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_8",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": -13.6875,
+      "y": 4.4712499999999995
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_9",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.65,
+      "y": 4.097125
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_10",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 4.5625,
+      "y": 4.097125
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_11",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 2.7375,
+      "y": -2.09875
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_12",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 6.935,
+      "y": 2.1078749999999995
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_13",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -14.0525,
+      "y": 2.46375
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_14",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "220pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -13.3225,
+      "y": 2.46375
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_15",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "220pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 7.8475,
+      "y": 2.1078749999999995
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_16",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 3.4675,
+      "y": 1.9253749999999994
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_17",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 4.38,
+      "y": 1.9253749999999994
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_18",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "680uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -4.10625,
+      "y": 0.9125
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_19",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "0.047uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 8.76,
+      "y": 2.09875
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_20",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 1.55125,
+      "y": 0.365
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_21",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "1pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": -5.74875,
+      "y": -0.9125
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_22",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -8.5775,
+      "y": -1.18625
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_23",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.47uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": -4.745,
+      "y": -3.3762499999999998
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_24",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.01uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 2.6462499999999998,
+      "y": -3.65
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_25",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 2.28125,
+      "y": -4.38
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_26",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "0.01uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 10.219999999999999,
+      "y": -4.83625
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_27",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "4.7pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": -8.76,
+      "y": -5.01875
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_28",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.22uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": -7.3,
+      "y": -5.01875
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_29",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 5.475,
+      "y": -5.38375
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_30",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_31",
+    "center": {
+      "x": 6.57,
+      "y": -5.38375
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_31",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "0.1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_32",
+    "center": {
+      "x": 0.365,
+      "y": -5.56625
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_32",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "1uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_33",
+    "center": {
+      "x": 5.84,
+      "y": 6.935
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_33",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_34",
+    "center": {
+      "x": 11.4975,
+      "y": 6.935
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_34",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_35",
+    "center": {
+      "x": 5.84,
+      "y": 6.205
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_35",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_36",
+    "center": {
+      "x": 11.4975,
+      "y": 6.205
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_36",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_37",
+    "center": {
+      "x": 0.73,
+      "y": 5.84
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_37",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "0Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_38",
+    "center": {
+      "x": 6.7524999999999995,
+      "y": 5.84
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_38",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_39",
+    "center": {
+      "x": 12.41,
+      "y": 5.84
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_39",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_40",
+    "center": {
+      "x": -12.2275,
+      "y": 5.6575
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_40",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "3.3Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_41",
+    "center": {
+      "x": 6.7524999999999995,
+      "y": 5.2924999999999995
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_41",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "221kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_42",
+    "center": {
+      "x": 12.41,
+      "y": 5.2924999999999995
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_42",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "221kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_43",
+    "center": {
+      "x": -8.2125,
+      "y": 4.9275
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_43",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "3Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_44",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 4.1975
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_44",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "20kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_45",
+    "center": {
+      "x": 1.825,
+      "y": 3.8325
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_45",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "0Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_46",
+    "center": {
+      "x": 6.0225,
+      "y": 3.1025
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_46",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10mΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_47",
+    "center": {
+      "x": 6.0225,
+      "y": 2.5549999999999997
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_47",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10mΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_48",
+    "center": {
+      "x": 4.5625,
+      "y": -3.65
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_48",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "21.5kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_49",
+    "center": {
+      "x": 1.825,
+      "y": 2.19
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_49",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "0Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_50",
+    "center": {
+      "x": 6.0225,
+      "y": 2.0075
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_50",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10mΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_51",
+    "center": {
+      "x": -8.03,
+      "y": 1.825
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_51",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "3Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_52",
+    "center": {
+      "x": 6.0225,
+      "y": 1.46
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_52",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10mΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_53",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 1.2774999999999999
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_53",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "20kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_54",
+    "center": {
+      "x": 0.73,
+      "y": 0.365
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_54",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "0Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_55",
+    "center": {
+      "x": -10.4025,
+      "y": -0.73
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_55",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_56",
+    "center": {
+      "x": -14.965,
+      "y": -0.73
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_56",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "51Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_57",
+    "center": {
+      "x": -9.855,
+      "y": -1.095
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_57",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "1MΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_58",
+    "center": {
+      "x": 0.5475,
+      "y": -1.46
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_58",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "4.99kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_59",
+    "center": {
+      "x": -14.4175,
+      "y": -1.46
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_59",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "51Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_60",
+    "center": {
+      "x": 1.825,
+      "y": -2.3725
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_60",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_61",
+    "center": {
+      "x": -0.365,
+      "y": -2.5549999999999997
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_61",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "15Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_62",
+    "center": {
+      "x": -5.2924999999999995,
+      "y": -2.7375
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_62",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "511Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_63",
+    "center": {
+      "x": 3.1025,
+      "y": -4.38
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_63",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_64",
+    "center": {
+      "x": 4.9275,
+      "y": -4.5625
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_64",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "30.1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_65",
+    "center": {
+      "x": 5.84,
+      "y": -4.5625
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_65",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_66",
+    "center": {
+      "x": 6.7524999999999995,
+      "y": -4.5625
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_66",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "15Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_67",
+    "center": {
+      "x": 11.1325,
+      "y": -4.5625
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_67",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_68",
+    "center": {
+      "x": 1.2774999999999999,
+      "y": -4.5625
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_68",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "100kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_69",
+    "center": {
+      "x": 4.015,
+      "y": -4.9275
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_69",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "0Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_70",
+    "center": {
+      "x": -8.03,
+      "y": -4.9275
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_70",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "200Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_71",
+    "center": {
+      "x": -6.57,
+      "y": -4.9275
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_71",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "20kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_72",
+    "center": {
+      "x": -5.84,
+      "y": -4.9275
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_72",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "3.4kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_73",
+    "center": {
+      "x": 11.1325,
+      "y": -5.109999999999999
+    },
+    "size": {
+      "width": 0.6,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_73",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "10Ω",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_74",
+    "center": {
+      "x": 4.5625,
+      "y": -5.475
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_74",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "2.49kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_75",
+    "center": {
+      "x": -1.46,
+      "y": -6.205
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_75",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_76",
+    "center": {
+      "x": -1.46,
+      "y": -7.1175
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_76",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_77",
+    "center": {
+      "x": 5.475,
+      "y": 7.665
+    },
+    "size": {
+      "width": 0.54,
+      "height": 1.04
+    },
+    "source_component_id": "source_component_77",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_down",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_78",
+    "center": {
+      "x": 11.1325,
+      "y": 7.665
+    },
+    "size": {
+      "width": 0.54,
+      "height": 1.04
+    },
+    "source_component_id": "source_component_78",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_down",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_79",
+    "center": {
+      "x": -11.1325,
+      "y": 5.6575
+    },
+    "size": {
+      "width": 1.04,
+      "height": 0.54
+    },
+    "source_component_id": "source_component_79",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_80",
+    "center": {
+      "x": -8.322,
+      "y": 4.1975
+    },
+    "size": {
+      "width": 1.04,
+      "height": 0.54
+    },
+    "source_component_id": "source_component_80",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_81",
+    "center": {
+      "x": -8.1395,
+      "y": 1.095
+    },
+    "size": {
+      "width": 1.04,
+      "height": 0.54
+    },
+    "source_component_id": "source_component_81",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_82",
+    "center": {
+      "x": -1.46,
+      "y": -5.34725
+    },
+    "size": {
+      "width": 0.54,
+      "height": 1.04
+    },
+    "source_component_id": "source_component_82",
+    "is_box_with_pins": true,
+    "symbol_name": "diode_down",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_83",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": -0.9125
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "A",
+      "pin2": "C",
+      "pin3": "K"
+    },
+    "source_component_id": "source_component_83",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "BAV99WT1G",
+    "schematic_component_id": "schematic_component_83",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.352499999999999,
+      "y": -1.3424999999999998
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "D505",
+    "schematic_component_id": "schematic_component_83",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -7.352499999999999,
+      "y": -0.48249999999999993
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_84",
+    "center": {
+      "x": 0.365,
+      "y": -4.015
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "A",
+      "pin2": "C",
+      "pin3": "K"
+    },
+    "source_component_id": "source_component_84",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "BAV99WT1G",
+    "schematic_component_id": "schematic_component_84",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.2350000000000001,
+      "y": -4.444999999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "D506",
+    "schematic_component_id": "schematic_component_84",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.2350000000000001,
+      "y": -3.585
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_85",
+    "center": {
+      "x": 4.745,
+      "y": 6.998874999999999
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_85",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_86",
+    "center": {
+      "x": 10.4025,
+      "y": 6.998874999999999
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_86",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_87",
+    "center": {
+      "x": 1.46,
+      "y": 4.681125000000001
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_87",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_88",
+    "center": {
+      "x": -5.903875,
+      "y": 4.745
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_88",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_89",
+    "center": {
+      "x": -5.903875,
+      "y": 1.825
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_89",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_90",
+    "center": {
+      "x": 1.46,
+      "y": 1.5238750000000003
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_90",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_91",
+    "center": {
+      "x": -9.188875,
+      "y": -0.73
+    },
+    "size": {
+      "width": 0.84,
+      "height": 1.1
+    },
+    "source_component_id": "source_component_91",
+    "is_box_with_pins": true,
+    "symbol_name": "n_channel_e_mosfet_transistor_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_92",
+    "center": {
+      "x": -4.015,
+      "y": 4.7906249999999995
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.1,
+      "height": 0.46
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [1, 2],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [3, 4],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "IN_1",
+      "pin2": "IN_2",
+      "pin3": "OUT_11",
+      "pin4": "OUT_12"
+    },
+    "source_component_id": "source_component_92",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "text": "RLTI-1150",
+    "schematic_component_id": "schematic_component_92",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -4.5649999999999995,
+      "y": 4.430624999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "text": "L500",
+    "schematic_component_id": "schematic_component_92",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -4.5649999999999995,
+      "y": 5.150625
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -2.509375,
+      "y": 3.1025
+    },
+    "rotation": 0,
+    "size": {
+      "width": 0.4,
+      "height": 2.56
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [1, 2],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [3, 4, 5, 6, 7, 8, 9, 10],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "PRI_3",
+      "pin2": "PRI_4",
+      "pin3": "SEC_13",
+      "pin4": "SEC_14",
+      "pin5": "CT_15",
+      "pin6": "CT_16",
+      "pin7": "CT_17",
+      "pin8": "CT_18",
+      "pin9": "SEC_19",
+      "pin10": "SEC_20"
+    },
+    "source_component_id": "source_component_93",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "text": "RLTI-1149",
+    "schematic_component_id": "schematic_component_93",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -2.709375,
+      "y": 1.6925
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "text": "T500",
+    "schematic_component_id": "schematic_component_93",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -2.709375,
+      "y": 4.5125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 8.2125,
+      "y": 6.0225
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.1,
+      "height": 2.56
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [8, 5, 7, 3, 2, 6],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [1, 4],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "SYNC",
+      "pin2": "EN_TOFF",
+      "pin3": "TON",
+      "pin4": "VCC",
+      "pin5": "GATE",
+      "pin6": "GND",
+      "pin7": "VS",
+      "pin8": "VD"
+    },
+    "source_component_id": "source_component_94",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_8",
+    "text": "UCC24610D",
+    "schematic_component_id": "schematic_component_94",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 7.6625000000000005,
+      "y": 4.6125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_9",
+    "text": "U500",
+    "schematic_component_id": "schematic_component_94",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 7.6625000000000005,
+      "y": 7.4325
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 13.87,
+      "y": 6.0225
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.1,
+      "height": 2.56
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [8, 5, 7, 3, 2, 6],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [1, 4],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "SYNC",
+      "pin2": "EN_TOFF",
+      "pin3": "TON",
+      "pin4": "VCC",
+      "pin5": "GATE",
+      "pin6": "GND",
+      "pin7": "VS",
+      "pin8": "VD"
+    },
+    "source_component_id": "source_component_95",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_10",
+    "text": "UCC24610D",
+    "schematic_component_id": "schematic_component_95",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 13.319999999999999,
+      "y": 4.6125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_11",
+    "text": "U501",
+    "schematic_component_id": "schematic_component_95",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 13.319999999999999,
+      "y": 7.4325
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -11.315,
+      "y": 3.4675
+    },
+    "rotation": 0,
+    "size": {
+      "width": 2.19,
+      "height": 3.29
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [7, 4, 1, 2, 8, 9, 10, 14],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [13, 12, 11, 6, 5, 3],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "HI",
+      "pin2": "LI",
+      "pin3": "VSS",
+      "pin4": "NC_EN",
+      "pin5": "COM",
+      "pin6": "LO",
+      "pin7": "VDD",
+      "pin8": "NC_8",
+      "pin9": "NC_9",
+      "pin10": "NC_10",
+      "pin11": "HS",
+      "pin12": "HO",
+      "pin13": "HB",
+      "pin14": "NC_14"
+    },
+    "source_component_id": "source_component_96",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_12",
+    "text": "UCC27714D",
+    "schematic_component_id": "schematic_component_96",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -12.41,
+      "y": 1.6925
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_13",
+    "text": "U502",
+    "schematic_component_id": "schematic_component_96",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -12.41,
+      "y": 5.2425
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_97",
+    "center": {
+      "x": -2.7375,
+      "y": -1.6425
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.3,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "A",
+      "pin2": "K",
+      "pin3": "E",
+      "pin4": "C"
+    },
+    "source_component_id": "source_component_97",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_14",
+    "text": "PC817X4NSZ0F",
+    "schematic_component_id": "schematic_component_97",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.3874999999999997,
+      "y": -2.0725000000000002
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_15",
+    "text": "U503",
+    "schematic_component_id": "schematic_component_97",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.3874999999999997,
+      "y": -1.2125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -9.855,
+      "y": -3.1025
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.1,
+      "height": 1.83
+    },
+    "port_arrangement": {
+      "left_side": {
+        "pins": [8, 5, 6],
+        "direction": "top-to-bottom"
+      },
+      "right_side": {
+        "pins": [4, 2, 1, 3, 7],
+        "direction": "top-to-bottom"
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "DT",
+      "pin2": "RT",
+      "pin3": "OC",
+      "pin4": "SS",
+      "pin5": "GD2",
+      "pin6": "GND",
+      "pin7": "VCC",
+      "pin8": "GD1"
+    },
+    "source_component_id": "source_component_98",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_16",
+    "text": "UCC25600D",
+    "schematic_component_id": "schematic_component_98",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.405000000000001,
+      "y": -4.1475
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_17",
+    "text": "U504",
+    "schematic_component_id": "schematic_component_98",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.405000000000001,
+      "y": -2.0575
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 8.5775,
+      "y": -4.5625
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.6,
+      "height": 0.8
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "REF",
+      "pin2": "GND",
+      "pin3": "V_PLUS",
+      "pin4": "IN_PLUS",
+      "pin5": "IN_MINUS",
+      "pin6": "OUT"
+    },
+    "source_component_id": "source_component_99",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_18",
+    "text": "INA213AIDCK",
+    "schematic_component_id": "schematic_component_99",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 7.777500000000001,
+      "y": -5.0925
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_19",
+    "text": "U505",
+    "schematic_component_id": "schematic_component_99",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 7.777500000000001,
+      "y": -4.0325
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_100",
+    "center": {
+      "x": 1.91625,
+      "y": -5.34725
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.3,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "K",
+      "pin2": "REF",
+      "pin3": "A"
+    },
+    "source_component_id": "source_component_100",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_20",
+    "text": "TL431BIDBZR",
+    "schematic_component_id": "schematic_component_100",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 1.2662499999999999,
+      "y": -5.7772499999999996
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_21",
+    "text": "U506",
+    "schematic_component_id": "schematic_component_100",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 1.2662499999999999,
+      "y": -4.91725
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_101",
+    "center": {
+      "x": -2.7375,
+      "y": -6.935
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.3,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "A",
+      "pin2": "K",
+      "pin3": "E",
+      "pin4": "C"
+    },
+    "source_component_id": "source_component_101",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_22",
+    "text": "LTV-817",
+    "schematic_component_id": "schematic_component_101",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.3874999999999997,
+      "y": -7.364999999999999
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_23",
+    "text": "U507",
+    "schematic_component_id": "schematic_component_101",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -3.3874999999999997,
+      "y": -6.505
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_102",
+    "center": {
+      "x": 10.584999999999999,
+      "y": 2.28125
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.5,
+      "height": 1
+    },
+    "port_arrangement": {
+      "right_side": {
+        "direction": "top-to-bottom",
+        "pins": ["pin1", "pin2", "pin3", "pin4"]
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "1": "20V2",
+      "2": "20V2",
+      "3": "SGND",
+      "4": "SGND"
+    },
+    "source_component_id": "source_component_102",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_24",
+    "text": "",
+    "schematic_component_id": "schematic_component_102",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 9.834999999999999,
+      "y": 1.65125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_25",
+    "text": "24V OUTPUT",
+    "schematic_component_id": "schematic_component_102",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 9.834999999999999,
+      "y": 2.91125
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_103",
+    "center": {
+      "x": 3.257624999999999,
+      "y": 5.989650000000001
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.8000000000000003,
+      "height": 0.6000000000000001
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "MOUNT_1",
+      "pin2": "MOUNT_2",
+      "pin3": "MOUNT_3"
+    },
+    "source_component_id": "source_component_103",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_26",
+    "text": "782653B04250G",
+    "schematic_component_id": "schematic_component_103",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 2.3576249999999987,
+      "y": 5.559650000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_27",
+    "text": "H500",
+    "schematic_component_id": "schematic_component_103",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 2.3576249999999987,
+      "y": 6.419650000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_104",
+    "center": {
+      "x": -5.319875,
+      "y": 2.1571500000000015
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.8000000000000003,
+      "height": 0.4
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "MOUNT_1",
+      "pin2": "MOUNT_2"
+    },
+    "source_component_id": "source_component_104",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_28",
+    "text": "513101B02500G",
+    "schematic_component_id": "schematic_component_104",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -6.219875,
+      "y": 1.8271500000000014
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_29",
+    "text": "H501",
+    "schematic_component_id": "schematic_component_104",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -6.219875,
+      "y": 2.4871500000000015
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_105",
+    "center": {
+      "x": 10.0375,
+      "y": 3.540500000000001
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_105",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_106",
+    "center": {
+      "x": 10.0375,
+      "y": 1.0220000000000002
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_106",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_107",
+    "center": {
+      "x": -0.10949999999999896,
+      "y": -2.0075
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_107",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_108",
+    "center": {
+      "x": -0.10949999999999896,
+      "y": -2.92
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_108",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_109",
+    "center": {
+      "x": 6.205,
+      "y": -3.7595
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_109",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_110",
+    "center": {
+      "x": 7.1175,
+      "y": -3.7595
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_110",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_111",
+    "center": {
+      "x": 0.10949999999999896,
+      "y": -5.84
+    },
+    "size": {
+      "width": 0.325,
+      "height": 0.2
+    },
+    "source_component_id": "source_component_111",
+    "is_box_with_pins": true,
+    "symbol_name": "testpoint_right",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "name": "unnamed_group1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -3.49375,
+      "y": 6.57
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -2.8937500000000003,
+      "y": 6.57
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 6.3875,
+      "y": 6.96125
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": 6.3875,
+      "y": 6.36125
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 12.045,
+      "y": 6.96125
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": 12.045,
+      "y": 6.36125
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 6.413749999999999
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 5.81375
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 1.25125,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 1.85125,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -9.88125,
+      "y": 4.745
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -9.281249999999998,
+      "y": 4.745
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 7.45625,
+      "y": 4.38
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 8.05625,
+      "y": 4.38
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 13.11375,
+      "y": 4.38
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 13.713750000000001,
+      "y": 4.38
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -14.4175,
+      "y": 4.771249999999999
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -14.4175,
+      "y": 4.17125
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": -13.6875,
+      "y": 4.771249999999999
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": -13.6875,
+      "y": 4.17125
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.65,
+      "y": 4.397125
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.65,
+      "y": 3.7971250000000003
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 4.5625,
+      "y": 4.397125
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 4.5625,
+      "y": 3.7971250000000003
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 2.7375,
+      "y": -1.7987499999999998
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": 2.7375,
+      "y": -2.3987499999999997
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 6.935,
+      "y": 2.4078749999999993
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": 6.935,
+      "y": 1.8078749999999995
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -14.0525,
+      "y": 2.76375
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -14.0525,
+      "y": 2.1637500000000003
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -13.3225,
+      "y": 2.76375
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": -13.3225,
+      "y": 2.1637500000000003
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 7.8475,
+      "y": 2.4078749999999993
+    },
+    "source_port_id": "source_port_32",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 7.8475,
+      "y": 1.8078749999999995
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 3.4675,
+      "y": 2.225374999999999
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": 3.4675,
+      "y": 1.6253749999999993
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 4.38,
+      "y": 2.225374999999999
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 4.38,
+      "y": 1.6253749999999993
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -4.40625,
+      "y": 0.9125
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": -3.8062500000000004,
+      "y": 0.9125
+    },
+    "source_port_id": "source_port_39",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 8.76,
+      "y": 2.3987499999999997
+    },
+    "source_port_id": "source_port_40",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_20",
+    "center": {
+      "x": 8.76,
+      "y": 1.7987499999999998
+    },
+    "source_port_id": "source_port_41",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 1.25125,
+      "y": 0.365
+    },
+    "source_port_id": "source_port_42",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_21",
+    "center": {
+      "x": 1.85125,
+      "y": 0.365
+    },
+    "source_port_id": "source_port_43",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": -6.04875,
+      "y": -0.9125
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_22",
+    "center": {
+      "x": -5.44875,
+      "y": -0.9125
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -8.5775,
+      "y": -0.88625
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_23",
+    "center": {
+      "x": -8.5775,
+      "y": -1.48625
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": -4.745,
+      "y": -3.07625
+    },
+    "source_port_id": "source_port_48",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_24",
+    "center": {
+      "x": -4.745,
+      "y": -3.6762499999999996
+    },
+    "source_port_id": "source_port_49",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 2.34625,
+      "y": -3.65
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_25",
+    "center": {
+      "x": 2.9462499999999996,
+      "y": -3.65
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 1.98125,
+      "y": -4.38
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_26",
+    "center": {
+      "x": 2.58125,
+      "y": -4.38
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 10.219999999999999,
+      "y": -4.53625
+    },
+    "source_port_id": "source_port_54",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_27",
+    "center": {
+      "x": 10.219999999999999,
+      "y": -5.1362499999999995
+    },
+    "source_port_id": "source_port_55",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": -8.76,
+      "y": -4.71875
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_28",
+    "center": {
+      "x": -8.76,
+      "y": -5.31875
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": -7.3,
+      "y": -4.71875
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_29",
+    "center": {
+      "x": -7.3,
+      "y": -5.31875
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 5.475,
+      "y": -5.08375
+    },
+    "source_port_id": "source_port_60",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_30",
+    "center": {
+      "x": 5.475,
+      "y": -5.68375
+    },
+    "source_port_id": "source_port_61",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_31",
+    "center": {
+      "x": 6.57,
+      "y": -5.08375
+    },
+    "source_port_id": "source_port_62",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_31",
+    "center": {
+      "x": 6.57,
+      "y": -5.68375
+    },
+    "source_port_id": "source_port_63",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_64",
+    "schematic_component_id": "schematic_component_32",
+    "center": {
+      "x": 0.365,
+      "y": -5.26625
+    },
+    "source_port_id": "source_port_64",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_65",
+    "schematic_component_id": "schematic_component_32",
+    "center": {
+      "x": 0.365,
+      "y": -5.86625
+    },
+    "source_port_id": "source_port_65",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_66",
+    "schematic_component_id": "schematic_component_33",
+    "center": {
+      "x": 5.54,
+      "y": 6.935
+    },
+    "source_port_id": "source_port_66",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_67",
+    "schematic_component_id": "schematic_component_33",
+    "center": {
+      "x": 6.14,
+      "y": 6.935
+    },
+    "source_port_id": "source_port_67",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_68",
+    "schematic_component_id": "schematic_component_34",
+    "center": {
+      "x": 11.1975,
+      "y": 6.935
+    },
+    "source_port_id": "source_port_68",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_69",
+    "schematic_component_id": "schematic_component_34",
+    "center": {
+      "x": 11.797500000000001,
+      "y": 6.935
+    },
+    "source_port_id": "source_port_69",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_70",
+    "schematic_component_id": "schematic_component_35",
+    "center": {
+      "x": 5.54,
+      "y": 6.205
+    },
+    "source_port_id": "source_port_70",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_71",
+    "schematic_component_id": "schematic_component_35",
+    "center": {
+      "x": 6.14,
+      "y": 6.205
+    },
+    "source_port_id": "source_port_71",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_72",
+    "schematic_component_id": "schematic_component_36",
+    "center": {
+      "x": 11.1975,
+      "y": 6.205
+    },
+    "source_port_id": "source_port_72",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_73",
+    "schematic_component_id": "schematic_component_36",
+    "center": {
+      "x": 11.797500000000001,
+      "y": 6.205
+    },
+    "source_port_id": "source_port_73",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_74",
+    "schematic_component_id": "schematic_component_37",
+    "center": {
+      "x": 0.43,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_75",
+    "schematic_component_id": "schematic_component_37",
+    "center": {
+      "x": 1.03,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_76",
+    "schematic_component_id": "schematic_component_38",
+    "center": {
+      "x": 6.4525,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_77",
+    "schematic_component_id": "schematic_component_38",
+    "center": {
+      "x": 7.052499999999999,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_78",
+    "schematic_component_id": "schematic_component_39",
+    "center": {
+      "x": 12.11,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_78",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_79",
+    "schematic_component_id": "schematic_component_39",
+    "center": {
+      "x": 12.71,
+      "y": 5.84
+    },
+    "source_port_id": "source_port_79",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_80",
+    "schematic_component_id": "schematic_component_40",
+    "center": {
+      "x": -12.5275,
+      "y": 5.6575
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_81",
+    "schematic_component_id": "schematic_component_40",
+    "center": {
+      "x": -11.927499999999998,
+      "y": 5.6575
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_82",
+    "schematic_component_id": "schematic_component_41",
+    "center": {
+      "x": 6.4525,
+      "y": 5.2924999999999995
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_83",
+    "schematic_component_id": "schematic_component_41",
+    "center": {
+      "x": 7.052499999999999,
+      "y": 5.2924999999999995
+    },
+    "source_port_id": "source_port_83",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_84",
+    "schematic_component_id": "schematic_component_42",
+    "center": {
+      "x": 12.11,
+      "y": 5.2924999999999995
+    },
+    "source_port_id": "source_port_84",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_85",
+    "schematic_component_id": "schematic_component_42",
+    "center": {
+      "x": 12.71,
+      "y": 5.2924999999999995
+    },
+    "source_port_id": "source_port_85",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_86",
+    "schematic_component_id": "schematic_component_43",
+    "center": {
+      "x": -8.512500000000001,
+      "y": 4.9275
+    },
+    "source_port_id": "source_port_86",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_87",
+    "schematic_component_id": "schematic_component_43",
+    "center": {
+      "x": -7.9125000000000005,
+      "y": 4.9275
+    },
+    "source_port_id": "source_port_87",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_88",
+    "schematic_component_id": "schematic_component_44",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 4.4975
+    },
+    "source_port_id": "source_port_88",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_89",
+    "schematic_component_id": "schematic_component_44",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 3.8975
+    },
+    "source_port_id": "source_port_89",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_90",
+    "schematic_component_id": "schematic_component_45",
+    "center": {
+      "x": 1.525,
+      "y": 3.8325
+    },
+    "source_port_id": "source_port_90",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_91",
+    "schematic_component_id": "schematic_component_45",
+    "center": {
+      "x": 2.125,
+      "y": 3.8325
+    },
+    "source_port_id": "source_port_91",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_92",
+    "schematic_component_id": "schematic_component_46",
+    "center": {
+      "x": 5.7225,
+      "y": 3.1025
+    },
+    "source_port_id": "source_port_92",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_93",
+    "schematic_component_id": "schematic_component_46",
+    "center": {
+      "x": 6.3225,
+      "y": 3.1025
+    },
+    "source_port_id": "source_port_93",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_94",
+    "schematic_component_id": "schematic_component_47",
+    "center": {
+      "x": 5.7225,
+      "y": 2.5549999999999997
+    },
+    "source_port_id": "source_port_94",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_95",
+    "schematic_component_id": "schematic_component_47",
+    "center": {
+      "x": 6.3225,
+      "y": 2.5549999999999997
+    },
+    "source_port_id": "source_port_95",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_96",
+    "schematic_component_id": "schematic_component_48",
+    "center": {
+      "x": 4.5625,
+      "y": -3.35
+    },
+    "source_port_id": "source_port_96",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_97",
+    "schematic_component_id": "schematic_component_48",
+    "center": {
+      "x": 4.5625,
+      "y": -3.9499999999999997
+    },
+    "source_port_id": "source_port_97",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_98",
+    "schematic_component_id": "schematic_component_49",
+    "center": {
+      "x": 1.525,
+      "y": 2.19
+    },
+    "source_port_id": "source_port_98",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_99",
+    "schematic_component_id": "schematic_component_49",
+    "center": {
+      "x": 2.125,
+      "y": 2.19
+    },
+    "source_port_id": "source_port_99",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_100",
+    "schematic_component_id": "schematic_component_50",
+    "center": {
+      "x": 5.7225,
+      "y": 2.0075
+    },
+    "source_port_id": "source_port_100",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_101",
+    "schematic_component_id": "schematic_component_50",
+    "center": {
+      "x": 6.3225,
+      "y": 2.0075
+    },
+    "source_port_id": "source_port_101",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_102",
+    "schematic_component_id": "schematic_component_51",
+    "center": {
+      "x": -8.33,
+      "y": 1.825
+    },
+    "source_port_id": "source_port_102",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_103",
+    "schematic_component_id": "schematic_component_51",
+    "center": {
+      "x": -7.7299999999999995,
+      "y": 1.825
+    },
+    "source_port_id": "source_port_103",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_104",
+    "schematic_component_id": "schematic_component_52",
+    "center": {
+      "x": 5.7225,
+      "y": 1.46
+    },
+    "source_port_id": "source_port_104",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_105",
+    "schematic_component_id": "schematic_component_52",
+    "center": {
+      "x": 6.3225,
+      "y": 1.46
+    },
+    "source_port_id": "source_port_105",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_106",
+    "schematic_component_id": "schematic_component_53",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 1.5775
+    },
+    "source_port_id": "source_port_106",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_107",
+    "schematic_component_id": "schematic_component_53",
+    "center": {
+      "x": -6.7524999999999995,
+      "y": 0.9774999999999998
+    },
+    "source_port_id": "source_port_107",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_108",
+    "schematic_component_id": "schematic_component_54",
+    "center": {
+      "x": 0.43,
+      "y": 0.365
+    },
+    "source_port_id": "source_port_108",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_109",
+    "schematic_component_id": "schematic_component_54",
+    "center": {
+      "x": 1.03,
+      "y": 0.365
+    },
+    "source_port_id": "source_port_109",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_110",
+    "schematic_component_id": "schematic_component_55",
+    "center": {
+      "x": -10.7025,
+      "y": -0.73
+    },
+    "source_port_id": "source_port_110",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_111",
+    "schematic_component_id": "schematic_component_55",
+    "center": {
+      "x": -10.1025,
+      "y": -0.73
+    },
+    "source_port_id": "source_port_111",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_112",
+    "schematic_component_id": "schematic_component_56",
+    "center": {
+      "x": -14.965,
+      "y": -0.43
+    },
+    "source_port_id": "source_port_112",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_113",
+    "schematic_component_id": "schematic_component_56",
+    "center": {
+      "x": -14.965,
+      "y": -1.03
+    },
+    "source_port_id": "source_port_113",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_114",
+    "schematic_component_id": "schematic_component_57",
+    "center": {
+      "x": -9.855,
+      "y": -0.7949999999999999
+    },
+    "source_port_id": "source_port_114",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_115",
+    "schematic_component_id": "schematic_component_57",
+    "center": {
+      "x": -9.855,
+      "y": -1.395
+    },
+    "source_port_id": "source_port_115",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_116",
+    "schematic_component_id": "schematic_component_58",
+    "center": {
+      "x": 0.2475,
+      "y": -1.46
+    },
+    "source_port_id": "source_port_116",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_117",
+    "schematic_component_id": "schematic_component_58",
+    "center": {
+      "x": 0.8474999999999999,
+      "y": -1.46
+    },
+    "source_port_id": "source_port_117",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_118",
+    "schematic_component_id": "schematic_component_59",
+    "center": {
+      "x": -14.4175,
+      "y": -1.16
+    },
+    "source_port_id": "source_port_118",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_119",
+    "schematic_component_id": "schematic_component_59",
+    "center": {
+      "x": -14.4175,
+      "y": -1.76
+    },
+    "source_port_id": "source_port_119",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_120",
+    "schematic_component_id": "schematic_component_60",
+    "center": {
+      "x": 1.825,
+      "y": -2.0725000000000002
+    },
+    "source_port_id": "source_port_120",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_121",
+    "schematic_component_id": "schematic_component_60",
+    "center": {
+      "x": 1.825,
+      "y": -2.6725
+    },
+    "source_port_id": "source_port_121",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_122",
+    "schematic_component_id": "schematic_component_61",
+    "center": {
+      "x": -0.365,
+      "y": -2.255
+    },
+    "source_port_id": "source_port_122",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_123",
+    "schematic_component_id": "schematic_component_61",
+    "center": {
+      "x": -0.365,
+      "y": -2.8549999999999995
+    },
+    "source_port_id": "source_port_123",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_124",
+    "schematic_component_id": "schematic_component_62",
+    "center": {
+      "x": -5.592499999999999,
+      "y": -2.7375
+    },
+    "source_port_id": "source_port_124",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_125",
+    "schematic_component_id": "schematic_component_62",
+    "center": {
+      "x": -4.9925,
+      "y": -2.7375
+    },
+    "source_port_id": "source_port_125",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_126",
+    "schematic_component_id": "schematic_component_63",
+    "center": {
+      "x": 2.8025,
+      "y": -4.38
+    },
+    "source_port_id": "source_port_126",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_127",
+    "schematic_component_id": "schematic_component_63",
+    "center": {
+      "x": 3.4025,
+      "y": -4.38
+    },
+    "source_port_id": "source_port_127",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_128",
+    "schematic_component_id": "schematic_component_64",
+    "center": {
+      "x": 4.6275,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_128",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_129",
+    "schematic_component_id": "schematic_component_64",
+    "center": {
+      "x": 5.2275,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_129",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_130",
+    "schematic_component_id": "schematic_component_65",
+    "center": {
+      "x": 5.54,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_130",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_131",
+    "schematic_component_id": "schematic_component_65",
+    "center": {
+      "x": 6.14,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_131",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_132",
+    "schematic_component_id": "schematic_component_66",
+    "center": {
+      "x": 6.4525,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_132",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_133",
+    "schematic_component_id": "schematic_component_66",
+    "center": {
+      "x": 7.052499999999999,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_133",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_134",
+    "schematic_component_id": "schematic_component_67",
+    "center": {
+      "x": 10.8325,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_134",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_135",
+    "schematic_component_id": "schematic_component_67",
+    "center": {
+      "x": 11.432500000000001,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_135",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_136",
+    "schematic_component_id": "schematic_component_68",
+    "center": {
+      "x": 1.2774999999999999,
+      "y": -4.2625
+    },
+    "source_port_id": "source_port_136",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_137",
+    "schematic_component_id": "schematic_component_68",
+    "center": {
+      "x": 1.2774999999999999,
+      "y": -4.8625
+    },
+    "source_port_id": "source_port_137",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_138",
+    "schematic_component_id": "schematic_component_69",
+    "center": {
+      "x": 3.715,
+      "y": -4.9275
+    },
+    "source_port_id": "source_port_138",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_139",
+    "schematic_component_id": "schematic_component_69",
+    "center": {
+      "x": 4.3149999999999995,
+      "y": -4.9275
+    },
+    "source_port_id": "source_port_139",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_140",
+    "schematic_component_id": "schematic_component_70",
+    "center": {
+      "x": -8.03,
+      "y": -4.6275
+    },
+    "source_port_id": "source_port_140",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_141",
+    "schematic_component_id": "schematic_component_70",
+    "center": {
+      "x": -8.03,
+      "y": -5.2275
+    },
+    "source_port_id": "source_port_141",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_142",
+    "schematic_component_id": "schematic_component_71",
+    "center": {
+      "x": -6.57,
+      "y": -4.6275
+    },
+    "source_port_id": "source_port_142",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_143",
+    "schematic_component_id": "schematic_component_71",
+    "center": {
+      "x": -6.57,
+      "y": -5.2275
+    },
+    "source_port_id": "source_port_143",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_144",
+    "schematic_component_id": "schematic_component_72",
+    "center": {
+      "x": -5.84,
+      "y": -4.6275
+    },
+    "source_port_id": "source_port_144",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_145",
+    "schematic_component_id": "schematic_component_72",
+    "center": {
+      "x": -5.84,
+      "y": -5.2275
+    },
+    "source_port_id": "source_port_145",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_146",
+    "schematic_component_id": "schematic_component_73",
+    "center": {
+      "x": 10.8325,
+      "y": -5.109999999999999
+    },
+    "source_port_id": "source_port_146",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_147",
+    "schematic_component_id": "schematic_component_73",
+    "center": {
+      "x": 11.432500000000001,
+      "y": -5.109999999999999
+    },
+    "source_port_id": "source_port_147",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_148",
+    "schematic_component_id": "schematic_component_74",
+    "center": {
+      "x": 4.5625,
+      "y": -5.175
+    },
+    "source_port_id": "source_port_148",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_149",
+    "schematic_component_id": "schematic_component_74",
+    "center": {
+      "x": 4.5625,
+      "y": -5.7749999999999995
+    },
+    "source_port_id": "source_port_149",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_150",
+    "schematic_component_id": "schematic_component_75",
+    "center": {
+      "x": -1.46,
+      "y": -5.905
+    },
+    "source_port_id": "source_port_150",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_151",
+    "schematic_component_id": "schematic_component_75",
+    "center": {
+      "x": -1.46,
+      "y": -6.505
+    },
+    "source_port_id": "source_port_151",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_152",
+    "schematic_component_id": "schematic_component_76",
+    "center": {
+      "x": -1.46,
+      "y": -6.8175
+    },
+    "source_port_id": "source_port_152",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_153",
+    "schematic_component_id": "schematic_component_76",
+    "center": {
+      "x": -1.46,
+      "y": -7.4174999999999995
+    },
+    "source_port_id": "source_port_153",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_154",
+    "schematic_component_id": "schematic_component_77",
+    "center": {
+      "x": 5.475,
+      "y": 8.185
+    },
+    "source_port_id": "source_port_154",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_155",
+    "schematic_component_id": "schematic_component_77",
+    "center": {
+      "x": 5.475,
+      "y": 7.145
+    },
+    "source_port_id": "source_port_155",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_156",
+    "schematic_component_id": "schematic_component_78",
+    "center": {
+      "x": 11.1325,
+      "y": 8.185
+    },
+    "source_port_id": "source_port_156",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_157",
+    "schematic_component_id": "schematic_component_78",
+    "center": {
+      "x": 11.1325,
+      "y": 7.145
+    },
+    "source_port_id": "source_port_157",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_158",
+    "schematic_component_id": "schematic_component_79",
+    "center": {
+      "x": -11.6525,
+      "y": 5.6575
+    },
+    "source_port_id": "source_port_158",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_159",
+    "schematic_component_id": "schematic_component_79",
+    "center": {
+      "x": -10.6125,
+      "y": 5.6575
+    },
+    "source_port_id": "source_port_159",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_160",
+    "schematic_component_id": "schematic_component_80",
+    "center": {
+      "x": -8.841999999999999,
+      "y": 4.1975
+    },
+    "source_port_id": "source_port_160",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_161",
+    "schematic_component_id": "schematic_component_80",
+    "center": {
+      "x": -7.802,
+      "y": 4.1975
+    },
+    "source_port_id": "source_port_161",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_162",
+    "schematic_component_id": "schematic_component_81",
+    "center": {
+      "x": -8.6595,
+      "y": 1.095
+    },
+    "source_port_id": "source_port_162",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_163",
+    "schematic_component_id": "schematic_component_81",
+    "center": {
+      "x": -7.6195,
+      "y": 1.095
+    },
+    "source_port_id": "source_port_163",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_164",
+    "schematic_component_id": "schematic_component_82",
+    "center": {
+      "x": -1.46,
+      "y": -4.827249999999999
+    },
+    "source_port_id": "source_port_164",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_165",
+    "schematic_component_id": "schematic_component_82",
+    "center": {
+      "x": -1.46,
+      "y": -5.86725
+    },
+    "source_port_id": "source_port_165",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_166",
+    "schematic_component_id": "schematic_component_83",
+    "center": {
+      "x": -7.7524999999999995,
+      "y": -0.8125
+    },
+    "source_port_id": "source_port_166",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "A",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_167",
+    "schematic_component_id": "schematic_component_83",
+    "center": {
+      "x": -7.7524999999999995,
+      "y": -1.0125
+    },
+    "source_port_id": "source_port_167",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "C",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_168",
+    "schematic_component_id": "schematic_component_83",
+    "center": {
+      "x": -5.7524999999999995,
+      "y": -0.9125
+    },
+    "source_port_id": "source_port_168",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_169",
+    "schematic_component_id": "schematic_component_84",
+    "center": {
+      "x": -0.635,
+      "y": -3.9149999999999996
+    },
+    "source_port_id": "source_port_169",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_170",
+    "schematic_component_id": "schematic_component_84",
+    "center": {
+      "x": -0.635,
+      "y": -4.114999999999999
+    },
+    "source_port_id": "source_port_170",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "C",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_171",
+    "schematic_component_id": "schematic_component_84",
+    "center": {
+      "x": 1.365,
+      "y": -4.015
+    },
+    "source_port_id": "source_port_171",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_172",
+    "schematic_component_id": "schematic_component_85",
+    "center": {
+      "x": 5.045,
+      "y": 7.548874999999999
+    },
+    "source_port_id": "source_port_172",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_173",
+    "schematic_component_id": "schematic_component_85",
+    "center": {
+      "x": 5.055,
+      "y": 6.448874999999999
+    },
+    "source_port_id": "source_port_173",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_174",
+    "schematic_component_id": "schematic_component_85",
+    "center": {
+      "x": 4.325,
+      "y": 6.898874999999999
+    },
+    "source_port_id": "source_port_174",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_175",
+    "schematic_component_id": "schematic_component_86",
+    "center": {
+      "x": 10.7025,
+      "y": 7.548874999999999
+    },
+    "source_port_id": "source_port_175",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_176",
+    "schematic_component_id": "schematic_component_86",
+    "center": {
+      "x": 10.7125,
+      "y": 6.448874999999999
+    },
+    "source_port_id": "source_port_176",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_177",
+    "schematic_component_id": "schematic_component_86",
+    "center": {
+      "x": 9.9825,
+      "y": 6.898874999999999
+    },
+    "source_port_id": "source_port_177",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_178",
+    "schematic_component_id": "schematic_component_87",
+    "center": {
+      "x": 1.76,
+      "y": 5.2311250000000005
+    },
+    "source_port_id": "source_port_178",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_179",
+    "schematic_component_id": "schematic_component_87",
+    "center": {
+      "x": 1.77,
+      "y": 4.131125000000001
+    },
+    "source_port_id": "source_port_179",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_180",
+    "schematic_component_id": "schematic_component_87",
+    "center": {
+      "x": 1.04,
+      "y": 4.581125000000001
+    },
+    "source_port_id": "source_port_180",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_181",
+    "schematic_component_id": "schematic_component_88",
+    "center": {
+      "x": -5.603875,
+      "y": 5.295
+    },
+    "source_port_id": "source_port_181",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_182",
+    "schematic_component_id": "schematic_component_88",
+    "center": {
+      "x": -5.593875000000001,
+      "y": 4.195
+    },
+    "source_port_id": "source_port_182",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_183",
+    "schematic_component_id": "schematic_component_88",
+    "center": {
+      "x": -6.323875,
+      "y": 4.6450000000000005
+    },
+    "source_port_id": "source_port_183",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_184",
+    "schematic_component_id": "schematic_component_89",
+    "center": {
+      "x": -5.603875,
+      "y": 2.375
+    },
+    "source_port_id": "source_port_184",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_185",
+    "schematic_component_id": "schematic_component_89",
+    "center": {
+      "x": -5.593875000000001,
+      "y": 1.275
+    },
+    "source_port_id": "source_port_185",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_186",
+    "schematic_component_id": "schematic_component_89",
+    "center": {
+      "x": -6.323875,
+      "y": 1.7249999999999999
+    },
+    "source_port_id": "source_port_186",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_187",
+    "schematic_component_id": "schematic_component_90",
+    "center": {
+      "x": 1.76,
+      "y": 2.073875
+    },
+    "source_port_id": "source_port_187",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_188",
+    "schematic_component_id": "schematic_component_90",
+    "center": {
+      "x": 1.77,
+      "y": 0.9738750000000003
+    },
+    "source_port_id": "source_port_188",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_189",
+    "schematic_component_id": "schematic_component_90",
+    "center": {
+      "x": 1.04,
+      "y": 1.4238750000000002
+    },
+    "source_port_id": "source_port_189",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_190",
+    "schematic_component_id": "schematic_component_91",
+    "center": {
+      "x": -8.888874999999999,
+      "y": -0.17999999999999994
+    },
+    "source_port_id": "source_port_190",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "drain",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_191",
+    "schematic_component_id": "schematic_component_91",
+    "center": {
+      "x": -8.878874999999999,
+      "y": -1.28
+    },
+    "source_port_id": "source_port_191",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "source",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_192",
+    "schematic_component_id": "schematic_component_91",
+    "center": {
+      "x": -9.608875,
+      "y": -0.83
+    },
+    "source_port_id": "source_port_192",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 3,
+    "display_pin_label": "gate",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_193",
+    "schematic_component_id": "schematic_component_92",
+    "center": {
+      "x": -4.965,
+      "y": 4.890624999999999
+    },
+    "source_port_id": "source_port_193",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "IN_1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_194",
+    "schematic_component_id": "schematic_component_92",
+    "center": {
+      "x": -4.965,
+      "y": 4.690625
+    },
+    "source_port_id": "source_port_194",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "IN_2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_195",
+    "schematic_component_id": "schematic_component_92",
+    "center": {
+      "x": -3.0649999999999995,
+      "y": 4.890624999999999
+    },
+    "source_port_id": "source_port_195",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "OUT_11",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_196",
+    "schematic_component_id": "schematic_component_92",
+    "center": {
+      "x": -3.0649999999999995,
+      "y": 4.690625
+    },
+    "source_port_id": "source_port_196",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "OUT_12",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_197",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -3.109375,
+      "y": 3.2025
+    },
+    "source_port_id": "source_port_197",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "PRI_3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_198",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -3.109375,
+      "y": 3.0025
+    },
+    "source_port_id": "source_port_198",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "PRI_4",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_199",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 3.8025
+    },
+    "source_port_id": "source_port_199",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "SEC_13",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_200",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 3.6025
+    },
+    "source_port_id": "source_port_200",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SEC_14",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_201",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 3.4025
+    },
+    "source_port_id": "source_port_201",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "CT_15",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_202",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 3.2025
+    },
+    "source_port_id": "source_port_202",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "CT_16",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_203",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 3.0025000000000004
+    },
+    "source_port_id": "source_port_203",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "CT_17",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_204",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 2.8025
+    },
+    "source_port_id": "source_port_204",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "CT_18",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_205",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 2.6025
+    },
+    "source_port_id": "source_port_205",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "SEC_19",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_206",
+    "schematic_component_id": "schematic_component_93",
+    "center": {
+      "x": -1.9093749999999998,
+      "y": 2.4025
+    },
+    "source_port_id": "source_port_206",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "SEC_20",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_207",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 9.1625,
+      "y": 6.1225
+    },
+    "source_port_id": "source_port_207",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "SYNC",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_208",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 5.7225
+    },
+    "source_port_id": "source_port_208",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EN_TOFF",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_209",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 5.922499999999999
+    },
+    "source_port_id": "source_port_209",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "TON",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_210",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 9.1625,
+      "y": 5.9225
+    },
+    "source_port_id": "source_port_210",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_211",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 6.3225
+    },
+    "source_port_id": "source_port_211",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "GATE",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_212",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 5.5225
+    },
+    "source_port_id": "source_port_212",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_213",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 6.1225
+    },
+    "source_port_id": "source_port_213",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_214",
+    "schematic_component_id": "schematic_component_94",
+    "center": {
+      "x": 7.2625,
+      "y": 6.5225
+    },
+    "source_port_id": "source_port_214",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "VD",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_215",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 14.819999999999999,
+      "y": 6.1225
+    },
+    "source_port_id": "source_port_215",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "SYNC",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_216",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 5.7225
+    },
+    "source_port_id": "source_port_216",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EN_TOFF",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_217",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 5.922499999999999
+    },
+    "source_port_id": "source_port_217",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "TON",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_218",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 14.819999999999999,
+      "y": 5.9225
+    },
+    "source_port_id": "source_port_218",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_219",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 6.3225
+    },
+    "source_port_id": "source_port_219",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "GATE",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_220",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 5.5225
+    },
+    "source_port_id": "source_port_220",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_221",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 6.1225
+    },
+    "source_port_id": "source_port_221",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_222",
+    "schematic_component_id": "schematic_component_95",
+    "center": {
+      "x": 12.92,
+      "y": 6.5225
+    },
+    "source_port_id": "source_port_222",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "VD",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_223",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 3.7674999999999996
+    },
+    "source_port_id": "source_port_223",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "HI",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_224",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 3.5675
+    },
+    "source_port_id": "source_port_224",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "LI",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_225",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 2.9675
+    },
+    "source_port_id": "source_port_225",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "VSS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_226",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 3.9675
+    },
+    "source_port_id": "source_port_226",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "NC_EN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_227",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 3.1675
+    },
+    "source_port_id": "source_port_227",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "COM",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_228",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 3.3674999999999997
+    },
+    "source_port_id": "source_port_228",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "LO",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_229",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 4.1674999999999995
+    },
+    "source_port_id": "source_port_229",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VDD",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_230",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 3.3674999999999997
+    },
+    "source_port_id": "source_port_230",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "NC_8",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_231",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 3.1674999999999995
+    },
+    "source_port_id": "source_port_231",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "NC_9",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_232",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 2.9675
+    },
+    "source_port_id": "source_port_232",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "NC_10",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_233",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 3.5675
+    },
+    "source_port_id": "source_port_233",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "display_pin_label": "HS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_234",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 3.7675
+    },
+    "source_port_id": "source_port_234",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "display_pin_label": "HO",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_235",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -9.82,
+      "y": 3.9675
+    },
+    "source_port_id": "source_port_235",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "HB",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_236",
+    "schematic_component_id": "schematic_component_96",
+    "center": {
+      "x": -12.809999999999999,
+      "y": 2.7675
+    },
+    "source_port_id": "source_port_236",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "NC_14",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_237",
+    "schematic_component_id": "schematic_component_97",
+    "center": {
+      "x": -3.7874999999999996,
+      "y": -1.5425
+    },
+    "source_port_id": "source_port_237",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "A",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_238",
+    "schematic_component_id": "schematic_component_97",
+    "center": {
+      "x": -3.7874999999999996,
+      "y": -1.7425000000000002
+    },
+    "source_port_id": "source_port_238",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "K",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_239",
+    "schematic_component_id": "schematic_component_97",
+    "center": {
+      "x": -1.6874999999999998,
+      "y": -1.7425000000000002
+    },
+    "source_port_id": "source_port_239",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "E",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_240",
+    "schematic_component_id": "schematic_component_97",
+    "center": {
+      "x": -1.6874999999999998,
+      "y": -1.5425
+    },
+    "source_port_id": "source_port_240",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "C",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_241",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -8.905000000000001,
+      "y": -3.1025
+    },
+    "source_port_id": "source_port_241",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "DT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_242",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -8.905000000000001,
+      "y": -2.9025
+    },
+    "source_port_id": "source_port_242",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "RT",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_243",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -8.905000000000001,
+      "y": -3.3025
+    },
+    "source_port_id": "source_port_243",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "OC",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_244",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -8.905000000000001,
+      "y": -2.7025
+    },
+    "source_port_id": "source_port_244",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_245",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -10.805,
+      "y": -3.1025
+    },
+    "source_port_id": "source_port_245",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "GD2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_246",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -10.805,
+      "y": -3.3025
+    },
+    "source_port_id": "source_port_246",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_247",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -8.905000000000001,
+      "y": -3.5025
+    },
+    "source_port_id": "source_port_247",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_248",
+    "schematic_component_id": "schematic_component_98",
+    "center": {
+      "x": -10.805,
+      "y": -2.9025
+    },
+    "source_port_id": "source_port_248",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "GD1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_249",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 7.3775,
+      "y": -4.3625
+    },
+    "source_port_id": "source_port_249",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "REF",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_250",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 7.3775,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_250",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_251",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 7.3775,
+      "y": -4.7625
+    },
+    "source_port_id": "source_port_251",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "V_PLUS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_252",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 9.7775,
+      "y": -4.7625
+    },
+    "source_port_id": "source_port_252",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "IN_PLUS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_253",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 9.7775,
+      "y": -4.5625
+    },
+    "source_port_id": "source_port_253",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "IN_MINUS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_254",
+    "schematic_component_id": "schematic_component_99",
+    "center": {
+      "x": 9.7775,
+      "y": -4.3625
+    },
+    "source_port_id": "source_port_254",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "OUT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_255",
+    "schematic_component_id": "schematic_component_100",
+    "center": {
+      "x": 0.86625,
+      "y": -5.24725
+    },
+    "source_port_id": "source_port_255",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_256",
+    "schematic_component_id": "schematic_component_100",
+    "center": {
+      "x": 0.86625,
+      "y": -5.4472499999999995
+    },
+    "source_port_id": "source_port_256",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "REF",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_257",
+    "schematic_component_id": "schematic_component_100",
+    "center": {
+      "x": 2.96625,
+      "y": -5.34725
+    },
+    "source_port_id": "source_port_257",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_258",
+    "schematic_component_id": "schematic_component_101",
+    "center": {
+      "x": -3.7874999999999996,
+      "y": -6.835
+    },
+    "source_port_id": "source_port_258",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "A",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_259",
+    "schematic_component_id": "schematic_component_101",
+    "center": {
+      "x": -3.7874999999999996,
+      "y": -7.034999999999999
+    },
+    "source_port_id": "source_port_259",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "K",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_260",
+    "schematic_component_id": "schematic_component_101",
+    "center": {
+      "x": -1.6874999999999998,
+      "y": -7.034999999999999
+    },
+    "source_port_id": "source_port_260",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "E",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_261",
+    "schematic_component_id": "schematic_component_101",
+    "center": {
+      "x": -1.6874999999999998,
+      "y": -6.835
+    },
+    "source_port_id": "source_port_261",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "C",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_262",
+    "schematic_component_id": "schematic_component_102",
+    "center": {
+      "x": 11.735,
+      "y": 2.58125
+    },
+    "source_port_id": "source_port_262",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "20V2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_263",
+    "schematic_component_id": "schematic_component_102",
+    "center": {
+      "x": 11.735,
+      "y": 2.38125
+    },
+    "source_port_id": "source_port_263",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "20V2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_264",
+    "schematic_component_id": "schematic_component_102",
+    "center": {
+      "x": 11.735,
+      "y": 2.18125
+    },
+    "source_port_id": "source_port_264",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "SGND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_265",
+    "schematic_component_id": "schematic_component_102",
+    "center": {
+      "x": 11.735,
+      "y": 1.98125
+    },
+    "source_port_id": "source_port_265",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "SGND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_266",
+    "schematic_component_id": "schematic_component_103",
+    "center": {
+      "x": 1.9576249999999988,
+      "y": 6.089650000000001
+    },
+    "source_port_id": "source_port_266",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "MOUNT_1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_267",
+    "schematic_component_id": "schematic_component_103",
+    "center": {
+      "x": 1.9576249999999988,
+      "y": 5.889650000000001
+    },
+    "source_port_id": "source_port_267",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "MOUNT_2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_268",
+    "schematic_component_id": "schematic_component_103",
+    "center": {
+      "x": 4.557625,
+      "y": 5.989650000000001
+    },
+    "source_port_id": "source_port_268",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "MOUNT_3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_269",
+    "schematic_component_id": "schematic_component_104",
+    "center": {
+      "x": -6.619875,
+      "y": 2.1571500000000015
+    },
+    "source_port_id": "source_port_269",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "MOUNT_1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_270",
+    "schematic_component_id": "schematic_component_104",
+    "center": {
+      "x": -4.019874999999999,
+      "y": 2.1571500000000015
+    },
+    "source_port_id": "source_port_270",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "MOUNT_2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_271",
+    "schematic_component_id": "schematic_component_105",
+    "center": {
+      "x": 9.8375,
+      "y": 3.540500000000001
+    },
+    "source_port_id": "source_port_271",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_272",
+    "schematic_component_id": "schematic_component_106",
+    "center": {
+      "x": 9.8375,
+      "y": 1.0220000000000002
+    },
+    "source_port_id": "source_port_272",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_273",
+    "schematic_component_id": "schematic_component_107",
+    "center": {
+      "x": -0.309499999999999,
+      "y": -2.0075
+    },
+    "source_port_id": "source_port_273",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_274",
+    "schematic_component_id": "schematic_component_108",
+    "center": {
+      "x": -0.309499999999999,
+      "y": -2.92
+    },
+    "source_port_id": "source_port_274",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_275",
+    "schematic_component_id": "schematic_component_109",
+    "center": {
+      "x": 6.005,
+      "y": -3.7595
+    },
+    "source_port_id": "source_port_275",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_276",
+    "schematic_component_id": "schematic_component_110",
+    "center": {
+      "x": 6.9174999999999995,
+      "y": -3.7595
+    },
+    "source_port_id": "source_port_276",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_277",
+    "schematic_component_id": "schematic_component_111",
+    "center": {
+      "x": -0.09050000000000105,
+      "y": -5.84
+    },
+    "source_port_id": "source_port_277",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_278",
+    "schematic_component_id": null,
+    "center": {
+      "x": -16.5,
+      "y": 6.1
+    },
+    "source_port_id": "source_port_278",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "display_pin_label": "VBULK",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_279",
+    "schematic_component_id": null,
+    "center": {
+      "x": -16.5,
+      "y": 4.7
+    },
+    "source_port_id": "source_port_279",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "display_pin_label": "12V",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_280",
+    "schematic_component_id": null,
+    "center": {
+      "x": -16.5,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_280",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "display_pin_label": "PWMCNTL1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_281",
+    "schematic_component_id": null,
+    "center": {
+      "x": -16.5,
+      "y": -2
+    },
+    "source_port_id": "source_port_281",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "display_pin_label": "GND1",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_282",
+    "schematic_component_id": null,
+    "center": {
+      "x": 15.5,
+      "y": 2.8
+    },
+    "source_port_id": "source_port_282",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "display_pin_label": "20V2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_283",
+    "schematic_component_id": null,
+    "center": {
+      "x": 15.5,
+      "y": 1.8
+    },
+    "source_port_id": "source_port_283",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "display_pin_label": "SGND",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_30",
+    "anchor": "left",
+    "text": "Notes: L500 and C100 are modified parts.",
+    "font_size": 0.4,
+    "color": "#d00000",
+    "position": {
+      "x": -12.2,
+      "y": 8.7
+    },
+    "rotation": 0
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_31",
+    "anchor": "center",
+    "text": "Current sharing control.",
+    "font_size": 0.4,
+    "color": "#0000cc",
+    "position": {
+      "x": 8.2,
+      "y": -6.3
+    },
+    "rotation": 0
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_32",
+    "anchor": "center",
+    "text": "40uH (modified part)",
+    "font_size": 0.25,
+    "color": "#000000",
+    "position": {
+      "x": -4.02,
+      "y": 3.95
+    },
+    "rotation": 0
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_33",
+    "anchor": "center",
+    "text": "210uH LLC transformer",
+    "font_size": 0.25,
+    "color": "#000000",
+    "position": {
+      "x": -2.39,
+      "y": 0.55
+    },
+    "rotation": 0
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "schematic_port_86-schematic_port_160",
+    "edges": [
+      {
+        "from": {
+          "x": -8.512500000000001,
+          "y": 4.9275
+        },
+        "to": {
+          "x": -9.041999999999998,
+          "y": 4.9275
+        }
+      },
+      {
+        "from": {
+          "x": -9.041999999999998,
+          "y": 4.9275
+        },
+        "to": {
+          "x": -9.041999999999998,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -9.041999999999998,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.983749999999999,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -8.983749999999999,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.904374999999998,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -8.904374999999998,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.841999999999999,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.041999999999998,
+        "y": 4.1975
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "schematic_port_234-schematic_port_160",
+    "edges": [
+      {
+        "from": {
+          "x": -9.82,
+          "y": 3.7675
+        },
+        "to": {
+          "x": -9.331,
+          "y": 3.7675
+        }
+      },
+      {
+        "from": {
+          "x": -9.331,
+          "y": 3.7675
+        },
+        "to": {
+          "x": -9.331,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -9.331,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -9.05875,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -9.05875,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.983749999999999,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -8.983749999999999,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.904375,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -8.904375,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -8.841999999999999,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.041999999999998,
+        "y": 4.1975
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "schematic_port_87-schematic_port_161",
+    "edges": [
+      {
+        "from": {
+          "x": -7.9125,
+          "y": 4.9275
+        },
+        "to": {
+          "x": -7.601999999999999,
+          "y": 4.9275
+        }
+      },
+      {
+        "from": {
+          "x": -7.601999999999999,
+          "y": 4.9275
+        },
+        "to": {
+          "x": -7.601999999999999,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -7.601999999999999,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.802,
+          "y": 4.1975
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -7.601999999999999,
+        "y": 4.1975
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_3",
+    "source_trace_id": "schematic_port_88-schematic_port_161",
+    "edges": [
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 4.4975
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 4.6975
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 4.6975
+        },
+        "to": {
+          "x": -7.2772499999999996,
+          "y": 4.6975
+        }
+      },
+      {
+        "from": {
+          "x": -7.2772499999999996,
+          "y": 4.6975
+        },
+        "to": {
+          "x": -7.2772499999999996,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -7.2772499999999996,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.364999999999999,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -7.364999999999999,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.4399999999999995,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.4399999999999995,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.465,
+          "y": 4.1975
+        }
+      },
+      {
+        "from": {
+          "x": -7.465,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.539999999999999,
+          "y": 4.1975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.539999999999999,
+          "y": 4.1975
+        },
+        "to": {
+          "x": -7.802,
+          "y": 4.1975
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -7.601999999999999,
+        "y": 4.1975
+      },
+      {
+        "x": -6.7524999999999995,
+        "y": 4.6450000000000005
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_4",
+    "source_trace_id": "schematic_port_183-schematic_port_88",
+    "edges": [
+      {
+        "from": {
+          "x": -6.323875,
+          "y": 4.6450000000000005
+        },
+        "to": {
+          "x": -6.383875,
+          "y": 4.6450000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -6.383875,
+          "y": 4.6450000000000005
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 4.6450000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 4.6450000000000005
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 4.4975
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 4.6450000000000005
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_5",
+    "source_trace_id": "schematic_port_233-schematic_port_11",
+    "edges": [
+      {
+        "from": {
+          "x": -9.82,
+          "y": 3.5675
+        },
+        "to": {
+          "x": -9.02125,
+          "y": 3.5675
+        }
+      },
+      {
+        "from": {
+          "x": -9.02125,
+          "y": 3.5675
+        },
+        "to": {
+          "x": -9.02125,
+          "y": 4.745
+        }
+      },
+      {
+        "from": {
+          "x": -9.02125,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.0795,
+          "y": 4.745
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -9.0795,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.22125,
+          "y": 4.745
+        }
+      },
+      {
+        "from": {
+          "x": -9.22125,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.281249999999998,
+          "y": 4.745
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.02125,
+        "y": 4.745
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_6",
+    "source_trace_id": "schematic_port_89-schematic_port_11",
+    "edges": [
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 3.8975
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -7.364999999999999,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -7.364999999999999,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -7.4399999999999995,
+          "y": 3.6975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.4399999999999995,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -7.465,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -7.465,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -7.539999999999999,
+          "y": 3.6975
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.539999999999999,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -8.866875,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -8.866875,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -8.866875,
+          "y": 4.745
+        }
+      },
+      {
+        "from": {
+          "x": -8.866875,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.0045,
+          "y": 4.745
+        }
+      },
+      {
+        "from": {
+          "x": -9.0045,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.0795,
+          "y": 4.745
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -9.0795,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.22125,
+          "y": 4.745
+        }
+      },
+      {
+        "from": {
+          "x": -9.22125,
+          "y": 4.745
+        },
+        "to": {
+          "x": -9.281249999999998,
+          "y": 4.745
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.02125,
+        "y": 4.745
+      },
+      {
+        "x": -6.7524999999999995,
+        "y": 3.6975
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_7",
+    "source_trace_id": "schematic_port_182-schematic_port_89",
+    "edges": [
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 4.195
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 3.6975
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 3.6975
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 3.8975
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 3.6975
+      },
+      {
+        "x": -5.593875000000001,
+        "y": 3.995
+      },
+      {
+        "x": -5.593875000000001,
+        "y": 3.6975
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_8",
+    "source_trace_id": "schematic_port_194-schematic_port_182",
+    "edges": [
+      {
+        "from": {
+          "x": -4.965,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -5.065,
+          "y": 4.690625
+        }
+      },
+      {
+        "from": {
+          "x": -5.065,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -5.065,
+          "y": 3.995
+        }
+      },
+      {
+        "from": {
+          "x": -5.065,
+          "y": 3.995
+        },
+        "to": {
+          "x": -5.2275,
+          "y": 3.995
+        }
+      },
+      {
+        "from": {
+          "x": -5.2275,
+          "y": 3.995
+        },
+        "to": {
+          "x": -5.3025,
+          "y": 3.995
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.3025,
+          "y": 3.995
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 3.995
+        }
+      },
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 3.995
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 4.195
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.593875000000001,
+        "y": 3.995
+      },
+      {
+        "x": -5.065,
+        "y": 4.690625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_9",
+    "source_trace_id": "schematic_port_193-schematic_port_194",
+    "edges": [
+      {
+        "from": {
+          "x": -4.965,
+          "y": 4.890624999999999
+        },
+        "to": {
+          "x": -5.065,
+          "y": 4.890624999999999
+        }
+      },
+      {
+        "from": {
+          "x": -5.065,
+          "y": 4.890624999999999
+        },
+        "to": {
+          "x": -5.065,
+          "y": 4.690625
+        }
+      },
+      {
+        "from": {
+          "x": -5.065,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -4.965,
+          "y": 4.690625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.065,
+        "y": 4.690625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_10",
+    "source_trace_id": "schematic_port_184-schematic_port_182",
+    "edges": [
+      {
+        "from": {
+          "x": -5.603875,
+          "y": 2.375
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 2.375
+        }
+      },
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 2.375
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 4.195
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.593875000000001,
+        "y": 3.6975
+      },
+      {
+        "x": -5.593875000000001,
+        "y": 3.995
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_11",
+    "source_trace_id": "schematic_port_7-schematic_port_1",
+    "edges": [
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 5.81375
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 5.73375
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 5.73375
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -5.641375,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -5.641375,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -5.566374999999999,
+          "y": 5.7071875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.566374999999999,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -5.302499999999999,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -5.302499999999999,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -5.227499999999999,
+          "y": 5.7071875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.227499999999999,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -2.9024999999999994,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -2.9024999999999994,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -2.8274999999999992,
+          "y": 5.7071875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -2.8274999999999992,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -2.63375,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -2.63375,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -2.63375,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -2.63375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -2.83375,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -2.83375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -2.8937500000000003,
+          "y": 6.57
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 5.7071875
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_12",
+    "source_trace_id": "schematic_port_269-schematic_port_7",
+    "edges": [
+      {
+        "from": {
+          "x": -6.619875,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.265000000000001,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.265000000000001,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.340000000000001,
+          "y": 2.1571500000000015
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.340000000000001,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.365,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.365,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.44,
+          "y": 2.1571500000000015
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.44,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.502499999999999,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.502499999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.502499999999999,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -7.502499999999999,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -7.439999999999999,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -7.439999999999999,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -7.364999999999998,
+          "y": 5.7071875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.364999999999998,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 5.7071875
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 5.7071875
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 5.73375
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 5.73375
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 5.81375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 5.7071875
+      },
+      {
+        "x": -7.502499999999999,
+        "y": 2.1571500000000015
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_13",
+    "source_trace_id": "schematic_port_107-schematic_port_269",
+    "edges": [
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 0.9774999999999998
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 0.7774999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -7.364999999999999,
+          "y": 0.7774999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -7.364999999999999,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -7.4399999999999995,
+          "y": 0.7774999999999996
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.4399999999999995,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -7.502499999999999,
+          "y": 0.7774999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -7.502499999999999,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -7.502499999999999,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.502499999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.439999999999999,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.439999999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.364999999999998,
+          "y": 2.1571500000000015
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.364999999999998,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.339999999999999,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -7.339999999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -7.264999999999999,
+          "y": 2.1571500000000015
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.264999999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -6.619875,
+          "y": 2.1571500000000015
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -7.502499999999999,
+        "y": 2.1571500000000015
+      },
+      {
+        "x": -6.7524999999999995,
+        "y": 0.7774999999999996
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_14",
+    "source_trace_id": "schematic_port_185-schematic_port_107",
+    "edges": [
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 1.2750000000000001
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 0.7774999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 0.7774999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 0.7774999999999996
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 0.9774999999999998
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 0.7774999999999996
+      },
+      {
+        "x": -5.593875000000001,
+        "y": 0.7774999999999996
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_15",
+    "source_trace_id": "schematic_port_39-schematic_port_185",
+    "edges": [
+      {
+        "from": {
+          "x": -3.8062500000000004,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -3.6862500000000002,
+          "y": 0.9125000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -3.6862500000000002,
+          "y": 0.9125000000000001
+        },
+        "to": {
+          "x": -3.48625,
+          "y": 0.9125000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -3.48625,
+          "y": 0.9125000000000001
+        },
+        "to": {
+          "x": -3.48625,
+          "y": 0.2924999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -3.48625,
+          "y": 0.2924999999999999
+        },
+        "to": {
+          "x": -4.95,
+          "y": 0.2924999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -4.95,
+          "y": 0.2924999999999999
+        },
+        "to": {
+          "x": -5.025,
+          "y": 0.2924999999999999
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.025,
+          "y": 0.2924999999999999
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 0.2924999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -5.593875000000001,
+          "y": 0.2924999999999999
+        },
+        "to": {
+          "x": -5.593875000000001,
+          "y": 1.275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.593875000000001,
+        "y": 0.7774999999999996
+      },
+      {
+        "x": -3.48625,
+        "y": 0.9125000000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_16",
+    "source_trace_id": "schematic_port_270-schematic_port_39",
+    "edges": [
+      {
+        "from": {
+          "x": -4.019874999999999,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -3.48625,
+          "y": 2.1571500000000015
+        }
+      },
+      {
+        "from": {
+          "x": -3.48625,
+          "y": 2.1571500000000015
+        },
+        "to": {
+          "x": -3.48625,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -3.48625,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -3.6862500000000002,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -3.6862500000000002,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -3.8062500000000004,
+          "y": 0.9125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -3.48625,
+        "y": 0.9125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_17",
+    "source_trace_id": "schematic_port_190-schematic_port_47",
+    "edges": [
+      {
+        "from": {
+          "x": -8.888874999999999,
+          "y": -0.17999999999999994
+        },
+        "to": {
+          "x": -8.888874999999999,
+          "y": 0.24750000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -8.888874999999999,
+          "y": 0.24750000000000005
+        },
+        "to": {
+          "x": -7.602500000000001,
+          "y": 0.24750000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -7.602500000000001,
+          "y": 0.24750000000000005
+        },
+        "to": {
+          "x": -7.602500000000001,
+          "y": -0.4746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": -7.602500000000001,
+          "y": -0.4746875000000002
+        },
+        "to": {
+          "x": -5.24875,
+          "y": -0.4746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": -5.24875,
+          "y": -0.4746875000000002
+        },
+        "to": {
+          "x": -5.24875,
+          "y": -1.7662499999999997
+        }
+      },
+      {
+        "from": {
+          "x": -5.24875,
+          "y": -1.7662499999999997
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -1.7662499999999997
+        }
+      },
+      {
+        "from": {
+          "x": -8.5775,
+          "y": -1.7662499999999997
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -1.5662500000000004
+        }
+      },
+      {
+        "from": {
+          "x": -8.5775,
+          "y": -1.5662500000000004
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -1.48625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.888874999999999,
+        "y": 0.019999999999999574
+      },
+      {
+        "x": -8.5775,
+        "y": -1.7662499999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_18",
+    "source_trace_id": "schematic_port_144-schematic_port_142",
+    "edges": [
+      {
+        "from": {
+          "x": -5.84,
+          "y": -4.6275
+        },
+        "to": {
+          "x": -5.84,
+          "y": -4.1918750000000005
+        }
+      },
+      {
+        "from": {
+          "x": -5.84,
+          "y": -4.1918750000000005
+        },
+        "to": {
+          "x": -6.57,
+          "y": -4.1918750000000005
+        }
+      },
+      {
+        "from": {
+          "x": -6.57,
+          "y": -4.1918750000000005
+        },
+        "to": {
+          "x": -6.57,
+          "y": -4.6275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.84,
+        "y": -4.1918750000000005
+      },
+      {
+        "x": -6.57,
+        "y": -4.1918750000000005
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_19",
+    "source_trace_id": "schematic_port_49-schematic_port_144",
+    "edges": [
+      {
+        "from": {
+          "x": -4.745,
+          "y": -3.6762499999999996
+        },
+        "to": {
+          "x": -4.745,
+          "y": -3.7562500000000005
+        }
+      },
+      {
+        "from": {
+          "x": -4.745,
+          "y": -3.7562500000000005
+        },
+        "to": {
+          "x": -4.745,
+          "y": -4.1918750000000005
+        }
+      },
+      {
+        "from": {
+          "x": -4.745,
+          "y": -4.1918750000000005
+        },
+        "to": {
+          "x": -5.84,
+          "y": -4.1918750000000005
+        }
+      },
+      {
+        "from": {
+          "x": -5.84,
+          "y": -4.1918750000000005
+        },
+        "to": {
+          "x": -5.84,
+          "y": -4.6275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -5.84,
+        "y": -4.1918750000000005
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_20",
+    "source_trace_id": "schematic_port_227-schematic_port_225",
+    "edges": [
+      {
+        "from": {
+          "x": -9.82,
+          "y": 3.1675
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 3.1675
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 3.1675
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 2.9675
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 2.9675
+        },
+        "to": {
+          "x": -9.82,
+          "y": 2.9675
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.620000000000001,
+        "y": 2.9675
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_21",
+    "source_trace_id": "schematic_port_31-schematic_port_225",
+    "edges": [
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.1637500000000003
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.0837499999999998
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.0837499999999998
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 1.4024999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 1.4024999999999999
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 1.4024999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 1.4024999999999999
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 2.9675000000000007
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 2.9675000000000007
+        },
+        "to": {
+          "x": -9.82,
+          "y": 2.9675000000000007
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.620000000000001,
+        "y": 2.9675000000000007
+      },
+      {
+        "x": -13.3225,
+        "y": 1.8837500000000005
+      },
+      {
+        "x": -9.620000000000001,
+        "y": 1.4024999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_22",
+    "source_trace_id": "schematic_port_29-schematic_port_31",
+    "edges": [
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 2.1637500000000003
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 2.0837499999999998
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 2.0837499999999998
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 1.8837500000000005
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 1.8837500000000005
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 1.8837500000000005
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 1.8837500000000005
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.0837499999999998
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.0837499999999998
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.1637500000000003
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.3225,
+        "y": 1.8837500000000005
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_23",
+    "source_trace_id": "schematic_port_19-schematic_port_17",
+    "edges": [
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 4.17125
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 4.09125
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 4.09125
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 3.8912500000000003
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 3.8912500000000003
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 3.8912500000000003
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": 3.8912500000000003
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 4.09125
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": 4.09125
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 4.17125
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_24",
+    "source_trace_id": "schematic_port_239-schematic_port_39",
+    "edges": [
+      {
+        "from": {
+          "x": -1.6874999999999998,
+          "y": -1.7425000000000002
+        },
+        "to": {
+          "x": -1.5875,
+          "y": -1.7425000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -1.5875,
+          "y": -1.7425000000000002
+        },
+        "to": {
+          "x": -1.5875,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -1.5875,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -3.6862500000000002,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -3.6862500000000002,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -3.8062500000000004,
+          "y": 0.9125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -3.48625,
+        "y": 0.9125000000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_25",
+    "source_trace_id": "schematic_port_162-schematic_port_102",
+    "edges": [
+      {
+        "from": {
+          "x": -8.6595,
+          "y": 1.095
+        },
+        "to": {
+          "x": -8.859499999999999,
+          "y": 1.095
+        }
+      },
+      {
+        "from": {
+          "x": -8.859499999999999,
+          "y": 1.095
+        },
+        "to": {
+          "x": -8.859499999999999,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -8.859499999999999,
+          "y": 1.825
+        },
+        "to": {
+          "x": -8.33,
+          "y": 1.825
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.859499999999999,
+        "y": 1.825
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_26",
+    "source_trace_id": "schematic_port_228-schematic_port_102",
+    "edges": [
+      {
+        "from": {
+          "x": -9.82,
+          "y": 3.3674999999999997
+        },
+        "to": {
+          "x": -9.075,
+          "y": 3.3674999999999997
+        }
+      },
+      {
+        "from": {
+          "x": -9.075,
+          "y": 3.3674999999999997
+        },
+        "to": {
+          "x": -9.075,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -9.075,
+          "y": 1.825
+        },
+        "to": {
+          "x": -8.33,
+          "y": 1.825
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.859499999999999,
+        "y": 1.825
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_27",
+    "source_trace_id": "schematic_port_163-schematic_port_103",
+    "edges": [
+      {
+        "from": {
+          "x": -7.6195,
+          "y": 1.095
+        },
+        "to": {
+          "x": -7.54,
+          "y": 1.095
+        }
+      },
+      {
+        "from": {
+          "x": -7.54,
+          "y": 1.095
+        },
+        "to": {
+          "x": -7.465000000000001,
+          "y": 1.095
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.465000000000001,
+          "y": 1.095
+        },
+        "to": {
+          "x": -7.4195,
+          "y": 1.095
+        }
+      },
+      {
+        "from": {
+          "x": -7.4195,
+          "y": 1.095
+        },
+        "to": {
+          "x": -7.4195,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -7.4195,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.4399999999999995,
+          "y": 1.825
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.4399999999999995,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.465,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -7.465,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.54,
+          "y": 1.825
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.54,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.729999999999999,
+          "y": 1.825
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -7.4195,
+        "y": 1.825
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_28",
+    "source_trace_id": "schematic_port_106-schematic_port_103",
+    "edges": [
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 1.5775
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.265,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -7.265,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.34,
+          "y": 1.825
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.34,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.364999999999999,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -7.364999999999999,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.4399999999999995,
+          "y": 1.825
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.4399999999999995,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.465,
+          "y": 1.825
+        }
+      },
+      {
+        "from": {
+          "x": -7.465,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.539999999999999,
+          "y": 1.825
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.539999999999999,
+          "y": 1.825
+        },
+        "to": {
+          "x": -7.729999999999999,
+          "y": 1.825
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -7.4195,
+        "y": 1.825
+      },
+      {
+        "x": -6.7524999999999995,
+        "y": 1.7249999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_29",
+    "source_trace_id": "schematic_port_186-schematic_port_106",
+    "edges": [
+      {
+        "from": {
+          "x": -6.323875,
+          "y": 1.7249999999999999
+        },
+        "to": {
+          "x": -6.383875,
+          "y": 1.7249999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -6.383875,
+          "y": 1.7249999999999999
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 1.7249999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 1.7249999999999999
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 1.5775
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.7524999999999995,
+        "y": 1.7249999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_30",
+    "source_trace_id": "schematic_port_247-schematic_port_56",
+    "edges": [
+      {
+        "from": {
+          "x": -8.905000000000001,
+          "y": -3.5025
+        },
+        "to": {
+          "x": -8.76,
+          "y": -3.5025
+        }
+      },
+      {
+        "from": {
+          "x": -8.76,
+          "y": -3.5025
+        },
+        "to": {
+          "x": -8.76,
+          "y": -4.63875
+        }
+      },
+      {
+        "from": {
+          "x": -8.76,
+          "y": -4.63875
+        },
+        "to": {
+          "x": -8.76,
+          "y": -4.71875
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_31",
+    "source_trace_id": "schematic_port_242-schematic_port_124",
+    "edges": [
+      {
+        "from": {
+          "x": -8.905000000000001,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -8.0675,
+          "y": -2.9025
+        }
+      },
+      {
+        "from": {
+          "x": -8.0675,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -7.9925000000000015,
+          "y": -2.9025
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -7.9925000000000015,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -7.24875,
+          "y": -2.9025
+        }
+      },
+      {
+        "from": {
+          "x": -7.24875,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -7.24875,
+          "y": -2.7375
+        }
+      },
+      {
+        "from": {
+          "x": -7.24875,
+          "y": -2.7375
+        },
+        "to": {
+          "x": -6.6075,
+          "y": -2.7375
+        }
+      },
+      {
+        "from": {
+          "x": -6.6075,
+          "y": -2.7375
+        },
+        "to": {
+          "x": -6.532500000000001,
+          "y": -2.7375
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -6.532500000000001,
+          "y": -2.7375
+        },
+        "to": {
+          "x": -5.592499999999999,
+          "y": -2.7375
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_32",
+    "source_trace_id": "schematic_port_38-schematic_port_197",
+    "edges": [
+      {
+        "from": {
+          "x": -4.40625,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -4.52625,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -4.52625,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -5.556375,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -5.556375,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -5.631375,
+          "y": 0.9125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.631375,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -6.715,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -6.715,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -6.79,
+          "y": 0.9125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -6.79,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -7.302499999999999,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -7.302499999999999,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -7.302499999999999,
+          "y": 3.2025
+        }
+      },
+      {
+        "from": {
+          "x": -7.302499999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -5.631374999999999,
+          "y": 3.2025
+        }
+      },
+      {
+        "from": {
+          "x": -5.631374999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -5.556374999999999,
+          "y": 3.2025
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.556374999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -5.302499999999999,
+          "y": 3.2025
+        }
+      },
+      {
+        "from": {
+          "x": -5.302499999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -5.227499999999999,
+          "y": 3.2025
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.227499999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -3.109375,
+          "y": 3.2025
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -4.987500000000001,
+        "y": 0.9125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_33",
+    "source_trace_id": "schematic_port_181-schematic_port_6",
+    "edges": [
+      {
+        "from": {
+          "x": -5.603875,
+          "y": 5.295
+        },
+        "to": {
+          "x": -5.603875,
+          "y": 6.69375
+        }
+      },
+      {
+        "from": {
+          "x": -5.603875,
+          "y": 6.69375
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 6.69375
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 6.69375
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 6.4937499999999995
+        }
+      },
+      {
+        "from": {
+          "x": -6.7524999999999995,
+          "y": 6.4937499999999995
+        },
+        "to": {
+          "x": -6.7524999999999995,
+          "y": 6.413749999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_34",
+    "source_trace_id": "schematic_port_51-schematic_port_120",
+    "edges": [
+      {
+        "from": {
+          "x": 2.946249999999999,
+          "y": -3.65
+        },
+        "to": {
+          "x": 3.564999999999999,
+          "y": -3.65
+        }
+      },
+      {
+        "from": {
+          "x": 3.564999999999999,
+          "y": -3.65
+        },
+        "to": {
+          "x": 3.6399999999999992,
+          "y": -3.65
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.6399999999999992,
+          "y": -3.65
+        },
+        "to": {
+          "x": 3.6525000000000007,
+          "y": -3.65
+        }
+      },
+      {
+        "from": {
+          "x": 3.6525000000000007,
+          "y": -3.65
+        },
+        "to": {
+          "x": 3.6525000000000007,
+          "y": -1.6187499999999997
+        }
+      },
+      {
+        "from": {
+          "x": 3.6525000000000007,
+          "y": -1.6187499999999997
+        },
+        "to": {
+          "x": 2.775000000000001,
+          "y": -1.6187499999999997
+        }
+      },
+      {
+        "from": {
+          "x": 2.775000000000001,
+          "y": -1.6187499999999997
+        },
+        "to": {
+          "x": 2.7000000000000006,
+          "y": -1.6187499999999997
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 2.7000000000000006,
+          "y": -1.6187499999999997
+        },
+        "to": {
+          "x": 1.825,
+          "y": -1.6187499999999997
+        }
+      },
+      {
+        "from": {
+          "x": 1.825,
+          "y": -1.6187499999999997
+        },
+        "to": {
+          "x": 1.825,
+          "y": -2.0725000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.5025,
+        "y": -3.65
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_35",
+    "source_trace_id": "schematic_port_274-schematic_port_169",
+    "edges": [
+      {
+        "from": {
+          "x": -0.309499999999999,
+          "y": -2.92
+        },
+        "to": {
+          "x": -0.835,
+          "y": -2.92
+        }
+      },
+      {
+        "from": {
+          "x": -0.835,
+          "y": -2.92
+        },
+        "to": {
+          "x": -0.835,
+          "y": -3.9149999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -0.835,
+          "y": -3.9149999999999996
+        },
+        "to": {
+          "x": -0.635,
+          "y": -3.9149999999999996
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.365,
+        "y": -2.92
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_36",
+    "source_trace_id": "schematic_port_123-schematic_port_274",
+    "edges": [
+      {
+        "from": {
+          "x": -0.365,
+          "y": -2.8549999999999995
+        },
+        "to": {
+          "x": -0.365,
+          "y": -2.92
+        }
+      },
+      {
+        "from": {
+          "x": -0.365,
+          "y": -2.92
+        },
+        "to": {
+          "x": -0.309499999999999,
+          "y": -2.92
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.365,
+        "y": -2.92
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_37",
+    "source_trace_id": "schematic_port_273-schematic_port_122",
+    "edges": [
+      {
+        "from": {
+          "x": -0.3094999999999988,
+          "y": -2.0075
+        },
+        "to": {
+          "x": -0.365,
+          "y": -2.0075
+        }
+      },
+      {
+        "from": {
+          "x": -0.365,
+          "y": -2.0075
+        },
+        "to": {
+          "x": -0.365,
+          "y": -2.255
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.365,
+        "y": -2.0075
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_38",
+    "source_trace_id": "schematic_port_238-schematic_port_273",
+    "edges": [
+      {
+        "from": {
+          "x": -3.7874999999999996,
+          "y": -1.7425000000000002
+        },
+        "to": {
+          "x": -3.9875,
+          "y": -1.7425000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -3.9875,
+          "y": -1.7425000000000002
+        },
+        "to": {
+          "x": -3.9875,
+          "y": -2.0075
+        }
+      },
+      {
+        "from": {
+          "x": -3.9875,
+          "y": -2.0075
+        },
+        "to": {
+          "x": -1.4249999999999998,
+          "y": -2.0075
+        }
+      },
+      {
+        "from": {
+          "x": -1.4249999999999998,
+          "y": -2.0075
+        },
+        "to": {
+          "x": -1.3499999999999996,
+          "y": -2.0075
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -1.3499999999999996,
+          "y": -2.0075
+        },
+        "to": {
+          "x": -0.309499999999999,
+          "y": -2.0075
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.365,
+        "y": -2.0075
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_39",
+    "source_trace_id": "schematic_port_24-schematic_port_117",
+    "edges": [
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -1.7987499999999998
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -1.7187499999999996
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -1.7187499999999996
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -1.46
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -1.46
+        },
+        "to": {
+          "x": 1.0887499999999999,
+          "y": -1.46
+        }
+      },
+      {
+        "from": {
+          "x": 1.0887499999999999,
+          "y": -1.46
+        },
+        "to": {
+          "x": 1.0137499999999997,
+          "y": -1.46
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 1.0137499999999997,
+          "y": -1.46
+        },
+        "to": {
+          "x": 0.9075,
+          "y": -1.46
+        }
+      },
+      {
+        "from": {
+          "x": 0.9075,
+          "y": -1.46
+        },
+        "to": {
+          "x": 0.8474999999999999,
+          "y": -1.46
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 1.1749999999999998,
+        "y": -1.46
+      },
+      {
+        "x": 2.7375,
+        "y": -1.46
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_40",
+    "source_trace_id": "schematic_port_121-schematic_port_24",
+    "edges": [
+      {
+        "from": {
+          "x": 1.825,
+          "y": -2.6725
+        },
+        "to": {
+          "x": 1.825,
+          "y": -2.8724999999999996
+        }
+      },
+      {
+        "from": {
+          "x": 1.825,
+          "y": -2.8724999999999996
+        },
+        "to": {
+          "x": 1.175,
+          "y": -2.8724999999999996
+        }
+      },
+      {
+        "from": {
+          "x": 1.175,
+          "y": -2.8724999999999996
+        },
+        "to": {
+          "x": 1.175,
+          "y": -1.4187499999999997
+        }
+      },
+      {
+        "from": {
+          "x": 1.175,
+          "y": -1.4187499999999997
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -1.4187499999999997
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -1.4187499999999997
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -1.7187499999999996
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -1.7187499999999996
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -1.7987499999999998
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 1.1749999999999998,
+        "y": -1.46
+      },
+      {
+        "x": 2.7375,
+        "y": -1.46
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_41",
+    "source_trace_id": "schematic_port_212-schematic_port_13",
+    "edges": [
+      {
+        "from": {
+          "x": 7.2625,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.2,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 7.2,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.125,
+          "y": 5.5225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.125,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.0825,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 7.0825,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.0825,
+          "y": 7.8425
+        }
+      },
+      {
+        "from": {
+          "x": 7.0825,
+          "y": 7.8425
+        },
+        "to": {
+          "x": 9.262500000000001,
+          "y": 7.8425
+        }
+      },
+      {
+        "from": {
+          "x": 9.262500000000001,
+          "y": 7.8425
+        },
+        "to": {
+          "x": 9.262500000000001,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 9.262500000000001,
+          "y": 4.38
+        },
+        "to": {
+          "x": 8.05625,
+          "y": 4.38
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 7.0825,
+        "y": 5.5225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_42",
+    "source_trace_id": "schematic_port_82-schematic_port_212",
+    "edges": [
+      {
+        "from": {
+          "x": 6.4525,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 6.35,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 6.35,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 6.425,
+          "y": 6.18125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 6.425,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 7.0575,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 7.0575,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 7.0575,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 7.0575,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.125,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 7.125,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.2,
+          "y": 5.5225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.2,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 7.2625,
+          "y": 5.5225
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 7.0825,
+        "y": 5.5225
+      },
+      {
+        "x": 6.2524999999999995,
+        "y": 5.84
+      },
+      {
+        "x": 6.34,
+        "y": 6.18125
+      },
+      {
+        "x": 6.2524999999999995,
+        "y": 6.0225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_43",
+    "source_trace_id": "schematic_port_76-schematic_port_82",
+    "edges": [
+      {
+        "from": {
+          "x": 6.4525,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.425,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 6.425,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.35,
+          "y": 5.84
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 6.35,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 6.4525,
+          "y": 5.2924999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.2524999999999995,
+        "y": 5.84
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_44",
+    "source_trace_id": "schematic_port_71-schematic_port_76",
+    "edges": [
+      {
+        "from": {
+          "x": 6.14,
+          "y": 6.205
+        },
+        "to": {
+          "x": 6.34,
+          "y": 6.205
+        }
+      },
+      {
+        "from": {
+          "x": 6.34,
+          "y": 6.205
+        },
+        "to": {
+          "x": 6.34,
+          "y": 6.0225
+        }
+      },
+      {
+        "from": {
+          "x": 6.34,
+          "y": 6.0225
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 6.0225
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 6.0225
+        },
+        "to": {
+          "x": 6.2524999999999995,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 6.2524999999999995,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.35,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 6.35,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.425,
+          "y": 5.84
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 6.425,
+          "y": 5.84
+        },
+        "to": {
+          "x": 6.4525,
+          "y": 5.84
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.34,
+        "y": 6.18125
+      },
+      {
+        "x": 6.2524999999999995,
+        "y": 6.0225
+      },
+      {
+        "x": 6.2524999999999995,
+        "y": 5.84
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_45",
+    "source_trace_id": "schematic_port_23-schematic_port_268",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 3.7971250000000003
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 3.7171249999999993
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 3.7171249999999993
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 3.517124999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 3.517124999999999
+        },
+        "to": {
+          "x": 5.4775,
+          "y": 3.517124999999999
+        }
+      },
+      {
+        "from": {
+          "x": 5.4775,
+          "y": 3.517124999999999
+        },
+        "to": {
+          "x": 5.4775,
+          "y": 4.7533875000000005
+        }
+      },
+      {
+        "from": {
+          "x": 5.4775,
+          "y": 4.7533875000000005
+        },
+        "to": {
+          "x": 5.14,
+          "y": 4.7533875000000005
+        }
+      },
+      {
+        "from": {
+          "x": 5.14,
+          "y": 4.7533875000000005
+        },
+        "to": {
+          "x": 5.14,
+          "y": 5.989650000000001
+        }
+      },
+      {
+        "from": {
+          "x": 5.14,
+          "y": 5.989650000000001
+        },
+        "to": {
+          "x": 4.557625,
+          "y": 5.989650000000001
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.5625,
+        "y": 3.517124999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_46",
+    "source_trace_id": "schematic_port_21-schematic_port_23",
+    "edges": [
+      {
+        "from": {
+          "x": 3.65,
+          "y": 3.7971250000000003
+        },
+        "to": {
+          "x": 3.65,
+          "y": 3.7171249999999993
+        }
+      },
+      {
+        "from": {
+          "x": 3.65,
+          "y": 3.7171249999999993
+        },
+        "to": {
+          "x": 3.65,
+          "y": 3.517124999999999
+        }
+      },
+      {
+        "from": {
+          "x": 3.65,
+          "y": 3.517124999999999
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 3.517124999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 3.517124999999999
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 3.7171249999999993
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 3.7171249999999993
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 3.7971250000000003
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.5625,
+        "y": 3.517124999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_47",
+    "source_trace_id": "schematic_port_37-schematic_port_35",
+    "edges": [
+      {
+        "from": {
+          "x": 4.38,
+          "y": 1.6253749999999993
+        },
+        "to": {
+          "x": 4.38,
+          "y": 1.545374999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 1.545374999999999
+        },
+        "to": {
+          "x": 4.38,
+          "y": 1.3453749999999989
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 1.3453749999999989
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 1.3453749999999989
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 1.3453749999999989
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 1.545374999999999
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 1.545374999999999
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 1.6253749999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.4675,
+        "y": 1.3453749999999989
+      },
+      {
+        "x": 4.38,
+        "y": 1.3453749999999989
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_48",
+    "source_trace_id": "schematic_port_188-schematic_port_35",
+    "edges": [
+      {
+        "from": {
+          "x": 1.77,
+          "y": 0.9738750000000003
+        },
+        "to": {
+          "x": 1.77,
+          "y": 0.8794375000000001
+        }
+      },
+      {
+        "from": {
+          "x": 1.77,
+          "y": 0.8794375000000001
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 0.8794375000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 0.8794375000000001
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 1.545374999999999
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 1.545374999999999
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 1.6253749999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.4675,
+        "y": 1.3453749999999989
+      },
+      {
+        "x": 1.77,
+        "y": 0.8794375000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_49",
+    "source_trace_id": "schematic_port_27-schematic_port_37",
+    "edges": [
+      {
+        "from": {
+          "x": 6.935,
+          "y": 1.8078749999999995
+        },
+        "to": {
+          "x": 6.935,
+          "y": 1.7278749999999992
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 1.7278749999999992
+        },
+        "to": {
+          "x": 6.935,
+          "y": 0.9200000000000002
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 0.9200000000000002
+        },
+        "to": {
+          "x": 4.38,
+          "y": 0.9200000000000002
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 0.9200000000000002
+        },
+        "to": {
+          "x": 4.38,
+          "y": 1.545374999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 1.545374999999999
+        },
+        "to": {
+          "x": 4.38,
+          "y": 1.6253749999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.38,
+        "y": 1.3453749999999989
+      },
+      {
+        "x": 6.935,
+        "y": 1.527874999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_50",
+    "source_trace_id": "schematic_port_33-schematic_port_27",
+    "edges": [
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 1.8078749999999995
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 1.7278749999999992
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 1.7278749999999992
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 1.527874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 1.527874999999999
+        },
+        "to": {
+          "x": 6.935,
+          "y": 1.527874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 1.527874999999999
+        },
+        "to": {
+          "x": 6.935,
+          "y": 1.7278749999999992
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 1.7278749999999992
+        },
+        "to": {
+          "x": 6.935,
+          "y": 1.8078749999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.935,
+        "y": 1.527874999999999
+      },
+      {
+        "x": 7.8475,
+        "y": 1.527874999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_51",
+    "source_trace_id": "schematic_port_41-schematic_port_33",
+    "edges": [
+      {
+        "from": {
+          "x": 8.76,
+          "y": 1.7987499999999998
+        },
+        "to": {
+          "x": 8.76,
+          "y": 1.71875
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 1.71875
+        },
+        "to": {
+          "x": 8.76,
+          "y": 1.5187500000000007
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 1.5187500000000007
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 1.5187500000000007
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 1.5187500000000007
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 1.7278749999999992
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 1.7278749999999992
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 1.8078749999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 7.8475,
+        "y": 1.527874999999999
+      },
+      {
+        "x": 8.76,
+        "y": 1.5187500000000007
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_52",
+    "source_trace_id": "schematic_port_272-schematic_port_41",
+    "edges": [
+      {
+        "from": {
+          "x": 9.8375,
+          "y": 1.0219999999999998
+        },
+        "to": {
+          "x": 8.76,
+          "y": 1.0219999999999998
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 1.0219999999999998
+        },
+        "to": {
+          "x": 8.76,
+          "y": 1.7187499999999996
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 1.7187499999999996
+        },
+        "to": {
+          "x": 8.76,
+          "y": 1.7987499999999998
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 8.76,
+        "y": 1.5187500000000007
+      },
+      {
+        "x": 9.637500000000001,
+        "y": 1.0220000000000002
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_53",
+    "source_trace_id": "schematic_port_265-schematic_port_272",
+    "edges": [
+      {
+        "from": {
+          "x": 11.735,
+          "y": 1.98125
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 1.98125
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 1.98125
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 1.5016250000000002
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 1.5016250000000002
+        },
+        "to": {
+          "x": 9.637500000000001,
+          "y": 1.5016250000000002
+        }
+      },
+      {
+        "from": {
+          "x": 9.637500000000001,
+          "y": 1.5016250000000002
+        },
+        "to": {
+          "x": 9.637500000000001,
+          "y": 1.0220000000000002
+        }
+      },
+      {
+        "from": {
+          "x": 9.637500000000001,
+          "y": 1.0220000000000002
+        },
+        "to": {
+          "x": 9.8375,
+          "y": 1.0220000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.637500000000001,
+        "y": 1.0220000000000002
+      },
+      {
+        "x": 11.834999999999999,
+        "y": 1.98125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_54",
+    "source_trace_id": "schematic_port_264-schematic_port_265",
+    "edges": [
+      {
+        "from": {
+          "x": 11.735,
+          "y": 2.18125
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 2.18125
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 2.18125
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 1.98125
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 1.98125
+        },
+        "to": {
+          "x": 11.735,
+          "y": 1.98125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 11.834999999999999,
+        "y": 1.98125
+      },
+      {
+        "x": 11.834999999999999,
+        "y": 2.18125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_55",
+    "source_trace_id": "schematic_port_84-schematic_port_264",
+    "edges": [
+      {
+        "from": {
+          "x": 12.11,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 11.91,
+          "y": 3.7368749999999995
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 3.7368749999999995
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 3.7368749999999995
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 3.7368749999999995
+        },
+        "to": {
+          "x": 11.834999999999999,
+          "y": 2.18125
+        }
+      },
+      {
+        "from": {
+          "x": 11.834999999999999,
+          "y": 2.18125
+        },
+        "to": {
+          "x": 11.735,
+          "y": 2.18125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 11.834999999999999,
+        "y": 2.18125
+      },
+      {
+        "x": 11.91,
+        "y": 5.2924999999999995
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_56",
+    "source_trace_id": "schematic_port_78-schematic_port_84",
+    "edges": [
+      {
+        "from": {
+          "x": 12.11,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.0825,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 12.0825,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.0075,
+          "y": 5.84
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.0075,
+          "y": 5.84
+        },
+        "to": {
+          "x": 11.91,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 5.84
+        },
+        "to": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 12.11,
+          "y": 5.2924999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 11.91,
+        "y": 5.2924999999999995
+      },
+      {
+        "x": 11.91,
+        "y": 5.84
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_57",
+    "source_trace_id": "schematic_port_73-schematic_port_78",
+    "edges": [
+      {
+        "from": {
+          "x": 11.797500000000001,
+          "y": 6.205
+        },
+        "to": {
+          "x": 11.9975,
+          "y": 6.205
+        }
+      },
+      {
+        "from": {
+          "x": 11.9975,
+          "y": 6.205
+        },
+        "to": {
+          "x": 11.9975,
+          "y": 6.0225
+        }
+      },
+      {
+        "from": {
+          "x": 11.9975,
+          "y": 6.0225
+        },
+        "to": {
+          "x": 11.91,
+          "y": 6.0225
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 6.0225
+        },
+        "to": {
+          "x": 11.91,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.0075,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 12.0075,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.0825,
+          "y": 5.84
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.0825,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.11,
+          "y": 5.84
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 11.91,
+        "y": 5.84
+      },
+      {
+        "x": 11.9975,
+        "y": 6.18125
+      },
+      {
+        "x": 11.91,
+        "y": 6.0225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_58",
+    "source_trace_id": "schematic_port_220-schematic_port_84",
+    "edges": [
+      {
+        "from": {
+          "x": 12.92,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.8575,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 12.8575,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.7825,
+          "y": 5.5225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.7825,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.715000000000002,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 12.715000000000002,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.715000000000002,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 12.715000000000002,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 12.082500000000001,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 12.082500000000001,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 12.007500000000002,
+          "y": 6.18125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.007500000000002,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 11.91,
+          "y": 6.18125
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 6.18125
+        },
+        "to": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 11.91,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 12.11,
+          "y": 5.2924999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 11.91,
+        "y": 5.2924999999999995
+      },
+      {
+        "x": 11.91,
+        "y": 5.84
+      },
+      {
+        "x": 11.9975,
+        "y": 6.18125
+      },
+      {
+        "x": 11.91,
+        "y": 6.0225
+      },
+      {
+        "x": 12.81,
+        "y": 5.5225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_59",
+    "source_trace_id": "schematic_port_15-schematic_port_220",
+    "edges": [
+      {
+        "from": {
+          "x": 13.713750000000001,
+          "y": 4.38
+        },
+        "to": {
+          "x": 13.91375,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 13.91375,
+          "y": 4.38
+        },
+        "to": {
+          "x": 13.91375,
+          "y": 3.6599999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 13.91375,
+          "y": 3.6599999999999997
+        },
+        "to": {
+          "x": 12.81,
+          "y": 3.6599999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 12.81,
+          "y": 3.6599999999999997
+        },
+        "to": {
+          "x": 12.81,
+          "y": 5.5225
+        }
+      },
+      {
+        "from": {
+          "x": 12.81,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.8575,
+          "y": 5.5225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.8575,
+          "y": 5.5225
+        },
+        "to": {
+          "x": 12.92,
+          "y": 5.5225
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.81,
+        "y": 5.5225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_60",
+    "source_trace_id": "schematic_port_257-schematic_port_25",
+    "edges": [
+      {
+        "from": {
+          "x": 2.96625,
+          "y": -5.347250000000001
+        },
+        "to": {
+          "x": 3.7025,
+          "y": -5.347250000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.7025,
+          "y": -5.347250000000001
+        },
+        "to": {
+          "x": 3.7025,
+          "y": -2.854375
+        }
+      },
+      {
+        "from": {
+          "x": 3.7025,
+          "y": -2.854375
+        },
+        "to": {
+          "x": 3.69,
+          "y": -2.854375
+        }
+      },
+      {
+        "from": {
+          "x": 3.69,
+          "y": -2.854375
+        },
+        "to": {
+          "x": 3.615,
+          "y": -2.854375
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.615,
+          "y": -2.854375
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -2.854375
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -2.854375
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -2.4787500000000002
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -2.4787500000000002
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -2.3987499999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.7025,
+        "y": -4.3875
+      },
+      {
+        "x": 3.4149999999999996,
+        "y": -5.347250000000001
+      },
+      {
+        "x": 2.7375,
+        "y": -2.6787500000000004
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_61",
+    "source_trace_id": "schematic_port_148-schematic_port_257",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -5.175
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.95,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.95,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.875,
+          "y": -4.3875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.875,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.7025,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.7025,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.7025,
+          "y": -5.34725
+        }
+      },
+      {
+        "from": {
+          "x": 3.7025,
+          "y": -5.34725
+        },
+        "to": {
+          "x": 2.96625,
+          "y": -5.34725
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.7025,
+        "y": -4.3875
+      },
+      {
+        "x": 3.4149999999999996,
+        "y": -5.34725
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_62",
+    "source_trace_id": "schematic_port_61-schematic_port_148",
+    "edges": [
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.68375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.76375
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.76375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 4.6,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 4.6,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 4.5249999999999995,
+          "y": -5.96375
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 4.5249999999999995,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 3.4149999999999996,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 3.4149999999999996,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 3.4149999999999996,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.4149999999999996,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.4649999999999994,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.4649999999999994,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.5399999999999996,
+          "y": -4.3875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.5399999999999996,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.5649999999999995,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.5649999999999995,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.6399999999999997,
+          "y": -4.3875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.6399999999999997,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.8749999999999996,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 3.8749999999999996,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 3.9499999999999997,
+          "y": -4.3875
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.9499999999999997,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -4.3875
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -4.3875
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -5.175
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.4149999999999996,
+        "y": -5.347250000000001
+      },
+      {
+        "x": 3.7025,
+        "y": -4.3875
+      },
+      {
+        "x": 5.475,
+        "y": -5.96375
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_63",
+    "source_trace_id": "schematic_port_63-schematic_port_61",
+    "edges": [
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.68375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.76375
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.76375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.76375
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.76375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.68375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.475,
+        "y": -5.96375
+      },
+      {
+        "x": 6.57,
+        "y": -5.96375
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_64",
+    "source_trace_id": "schematic_port_277-schematic_port_64",
+    "edges": [
+      {
+        "from": {
+          "x": -0.09050000000000105,
+          "y": -5.84
+        },
+        "to": {
+          "x": -0.2905000000000011,
+          "y": -5.84
+        }
+      },
+      {
+        "from": {
+          "x": -0.2905000000000011,
+          "y": -5.84
+        },
+        "to": {
+          "x": -0.2905000000000011,
+          "y": -4.98625
+        }
+      },
+      {
+        "from": {
+          "x": -0.2905000000000011,
+          "y": -4.98625
+        },
+        "to": {
+          "x": 0.365,
+          "y": -4.98625
+        }
+      },
+      {
+        "from": {
+          "x": 0.365,
+          "y": -4.98625
+        },
+        "to": {
+          "x": 0.365,
+          "y": -5.18625
+        }
+      },
+      {
+        "from": {
+          "x": 0.365,
+          "y": -5.18625
+        },
+        "to": {
+          "x": 0.365,
+          "y": -5.26625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.2905000000000011,
+        "y": -5.84
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_65",
+    "source_trace_id": "schematic_port_138-schematic_port_127",
+    "edges": [
+      {
+        "from": {
+          "x": 3.715,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 3.665,
+          "y": -4.9275
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.665,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 3.6025,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 3.6025,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 3.6025,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 3.6025,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.54,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 3.54,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.465,
+          "y": -4.38
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.465,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.4025,
+          "y": -4.38
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.6025,
+        "y": -4.38
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_66",
+    "source_trace_id": "schematic_port_50-schematic_port_127",
+    "edges": [
+      {
+        "from": {
+          "x": 2.34625,
+          "y": -3.65
+        },
+        "to": {
+          "x": 2.1462499999999998,
+          "y": -3.65
+        }
+      },
+      {
+        "from": {
+          "x": 2.1462499999999998,
+          "y": -3.65
+        },
+        "to": {
+          "x": 2.1462499999999998,
+          "y": -3.0299999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 2.1462499999999998,
+          "y": -3.0299999999999994
+        },
+        "to": {
+          "x": 3.6025,
+          "y": -3.0299999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.6025,
+          "y": -3.0299999999999994
+        },
+        "to": {
+          "x": 3.6025,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 3.6025,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.54,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 3.54,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.465,
+          "y": -4.38
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.465,
+          "y": -4.38
+        },
+        "to": {
+          "x": 3.4025,
+          "y": -4.38
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.6025,
+        "y": -4.38
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_67",
+    "source_trace_id": "schematic_port_48-schematic_port_125",
+    "edges": [
+      {
+        "from": {
+          "x": -4.745,
+          "y": -3.07625
+        },
+        "to": {
+          "x": -4.745,
+          "y": -2.9962499999999994
+        }
+      },
+      {
+        "from": {
+          "x": -4.745,
+          "y": -2.9962499999999994
+        },
+        "to": {
+          "x": -4.745,
+          "y": -2.7375
+        }
+      },
+      {
+        "from": {
+          "x": -4.745,
+          "y": -2.7375
+        },
+        "to": {
+          "x": -4.9925,
+          "y": -2.7375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -4.745,
+        "y": -2.7375
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_68",
+    "source_trace_id": "schematic_port_240-schematic_port_125",
+    "edges": [
+      {
+        "from": {
+          "x": -1.6874999999999998,
+          "y": -1.5425
+        },
+        "to": {
+          "x": -1.6249999999999998,
+          "y": -1.5425
+        }
+      },
+      {
+        "from": {
+          "x": -1.6249999999999998,
+          "y": -1.5425
+        },
+        "to": {
+          "x": -1.5499999999999998,
+          "y": -1.5425
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -1.5499999999999998,
+          "y": -1.5425
+        },
+        "to": {
+          "x": -1.3874999999999997,
+          "y": -1.5425
+        }
+      },
+      {
+        "from": {
+          "x": -1.3874999999999997,
+          "y": -1.5425
+        },
+        "to": {
+          "x": -1.3874999999999997,
+          "y": -2.7375
+        }
+      },
+      {
+        "from": {
+          "x": -1.3874999999999997,
+          "y": -2.7375
+        },
+        "to": {
+          "x": -4.9925,
+          "y": -2.7375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -4.745,
+        "y": -2.7375
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_69",
+    "source_trace_id": "schematic_port_153-schematic_port_150",
+    "edges": [
+      {
+        "from": {
+          "x": -1.46,
+          "y": -7.4174999999999995
+        },
+        "to": {
+          "x": -1.46,
+          "y": -7.6175
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -7.6175
+        },
+        "to": {
+          "x": -0.5200000000000001,
+          "y": -7.6175
+        }
+      },
+      {
+        "from": {
+          "x": -0.5200000000000001,
+          "y": -7.6175
+        },
+        "to": {
+          "x": -0.5200000000000001,
+          "y": -5.8950000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -0.5200000000000001,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -0.5825000000000001,
+          "y": -5.8950000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -0.5825000000000001,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -0.6575000000000002,
+          "y": -5.8950000000000005
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -0.6575000000000002,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -0.6825000000000001,
+          "y": -5.8950000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -0.6825000000000001,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -0.7575000000000002,
+          "y": -5.8950000000000005
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -0.7575000000000002,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -1.46,
+          "y": -5.8950000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -5.8950000000000005
+        },
+        "to": {
+          "x": -1.46,
+          "y": -5.904999999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.46,
+        "y": -7.6175
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_70",
+    "source_trace_id": "schematic_port_30-schematic_port_119",
+    "edges": [
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.76375
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.8437500000000018
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.8437500000000018
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.943750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -14.015,
+          "y": 2.943750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -14.015,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -14.09,
+          "y": 2.943750000000001
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -14.09,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -15.4775,
+          "y": 2.943750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -15.4775,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -15.5525,
+          "y": 2.943750000000001
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -15.5525,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -15.714999999999998,
+          "y": 2.943750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -15.714999999999998,
+          "y": 2.943750000000001
+        },
+        "to": {
+          "x": -15.714999999999998,
+          "y": -1.9599999999999993
+        }
+      },
+      {
+        "from": {
+          "x": -15.714999999999998,
+          "y": -1.9599999999999993
+        },
+        "to": {
+          "x": -14.4175,
+          "y": -1.9599999999999993
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": -1.9599999999999993
+        },
+        "to": {
+          "x": -14.4175,
+          "y": -1.76
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.3225,
+        "y": 2.943750000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_71",
+    "source_trace_id": "schematic_port_224-schematic_port_30",
+    "edges": [
+      {
+        "from": {
+          "x": -12.809999999999999,
+          "y": 3.5674999999999994
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 3.5674999999999994
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 3.5674999999999994
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.8437500000000004
+        }
+      },
+      {
+        "from": {
+          "x": -13.3225,
+          "y": 2.8437500000000004
+        },
+        "to": {
+          "x": -13.3225,
+          "y": 2.76375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.3225,
+        "y": 2.943750000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net31"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_72",
+    "source_trace_id": "schematic_port_28-schematic_port_113",
+    "edges": [
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 2.76375
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 2.843750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 2.843750000000001
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 3.1437500000000003
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 3.1437500000000003
+        },
+        "to": {
+          "x": -15.514999999999999,
+          "y": 3.1437500000000003
+        }
+      },
+      {
+        "from": {
+          "x": -15.514999999999999,
+          "y": 3.1437500000000003
+        },
+        "to": {
+          "x": -15.514999999999999,
+          "y": -1.2299999999999993
+        }
+      },
+      {
+        "from": {
+          "x": -15.514999999999999,
+          "y": -1.2299999999999993
+        },
+        "to": {
+          "x": -14.965,
+          "y": -1.2299999999999993
+        }
+      },
+      {
+        "from": {
+          "x": -14.965,
+          "y": -1.2299999999999993
+        },
+        "to": {
+          "x": -14.965,
+          "y": -1.03
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -14.0525,
+        "y": 3.1437500000000003
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_73",
+    "source_trace_id": "schematic_port_223-schematic_port_28",
+    "edges": [
+      {
+        "from": {
+          "x": -12.809999999999999,
+          "y": 3.7675000000000005
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 3.7675000000000005
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 3.7675000000000005
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 2.8437500000000004
+        }
+      },
+      {
+        "from": {
+          "x": -14.0525,
+          "y": 2.8437500000000004
+        },
+        "to": {
+          "x": -14.0525,
+          "y": 2.76375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -14.0525,
+        "y": 3.1437500000000003
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net32"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_74",
+    "source_trace_id": "schematic_port_18-schematic_port_16",
+    "edges": [
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 4.771249999999999
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 4.851249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 4.851249999999999
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 5.051249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 5.051249999999999
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 5.051249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": 5.051249999999999
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 4.851249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": 4.851249999999999
+        },
+        "to": {
+          "x": -14.4175,
+          "y": 4.771249999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.6875,
+        "y": 5.051249999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_75",
+    "source_trace_id": "schematic_port_229-schematic_port_18",
+    "edges": [
+      {
+        "from": {
+          "x": -12.809999999999999,
+          "y": 4.1674999999999995
+        },
+        "to": {
+          "x": -12.951249999999998,
+          "y": 4.1674999999999995
+        }
+      },
+      {
+        "from": {
+          "x": -12.951249999999998,
+          "y": 4.1674999999999995
+        },
+        "to": {
+          "x": -12.951249999999998,
+          "y": 5.051249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -12.951249999999998,
+          "y": 5.051249999999999
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 5.051249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 5.051249999999999
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 4.851249999999999
+        }
+      },
+      {
+        "from": {
+          "x": -13.6875,
+          "y": 4.851249999999999
+        },
+        "to": {
+          "x": -13.6875,
+          "y": 4.771249999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.6875,
+        "y": 5.051249999999999
+      },
+      {
+        "x": -13.009999999999998,
+        "y": 5.051249999999999
+      },
+      {
+        "x": -12.951249999999998,
+        "y": 4.1674999999999995
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_76",
+    "source_trace_id": "schematic_port_80-schematic_port_229",
+    "edges": [
+      {
+        "from": {
+          "x": -12.5275,
+          "y": 5.6575
+        },
+        "to": {
+          "x": -13.009999999999998,
+          "y": 5.6575
+        }
+      },
+      {
+        "from": {
+          "x": -13.009999999999998,
+          "y": 5.6575
+        },
+        "to": {
+          "x": -13.009999999999998,
+          "y": 4.1674999999999995
+        }
+      },
+      {
+        "from": {
+          "x": -13.009999999999998,
+          "y": 4.1674999999999995
+        },
+        "to": {
+          "x": -12.809999999999999,
+          "y": 4.1674999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -13.009999999999998,
+        "y": 5.051249999999999
+      },
+      {
+        "x": -12.951249999999998,
+        "y": 4.1674999999999995
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net33"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_77",
+    "source_trace_id": "schematic_port_104-schematic_port_100",
+    "edges": [
+      {
+        "from": {
+          "x": 5.7225,
+          "y": 1.46
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 1.46
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 1.46
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 2.0075
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 2.0075
+        },
+        "to": {
+          "x": 5.7225,
+          "y": 2.0075
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.5225,
+        "y": 2.0075
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_78",
+    "source_trace_id": "schematic_port_94-schematic_port_100",
+    "edges": [
+      {
+        "from": {
+          "x": 5.7225,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 2.0075
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 2.0075
+        },
+        "to": {
+          "x": 5.7225,
+          "y": 2.0075
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.5225,
+        "y": 2.0075
+      },
+      {
+        "x": 5.5225,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_79",
+    "source_trace_id": "schematic_port_92-schematic_port_94",
+    "edges": [
+      {
+        "from": {
+          "x": 5.7225,
+          "y": 3.1025
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 3.1025
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 3.1025
+        },
+        "to": {
+          "x": 5.5225,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 5.5225,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 5.7225,
+          "y": 2.5549999999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.5225,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_80",
+    "source_trace_id": "schematic_port_36-schematic_port_94",
+    "edges": [
+      {
+        "from": {
+          "x": 4.38,
+          "y": 2.225374999999999
+        },
+        "to": {
+          "x": 4.38,
+          "y": 2.3053749999999997
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 2.3053749999999997
+        },
+        "to": {
+          "x": 4.38,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 5.7225,
+          "y": 2.5549999999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.5225,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 4.38,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_81",
+    "source_trace_id": "schematic_port_34-schematic_port_36",
+    "edges": [
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 2.225374999999999
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 2.3053749999999997
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 2.3053749999999997
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 4.38,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 4.38,
+          "y": 2.3053749999999997
+        }
+      },
+      {
+        "from": {
+          "x": 4.38,
+          "y": 2.3053749999999997
+        },
+        "to": {
+          "x": 4.38,
+          "y": 2.225374999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.38,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 3.4675,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_82",
+    "source_trace_id": "schematic_port_22-schematic_port_20",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 4.397125
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 4.477125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 4.477125000000001
+        },
+        "to": {
+          "x": 4.5625,
+          "y": 4.677125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": 4.677125000000001
+        },
+        "to": {
+          "x": 3.65,
+          "y": 4.677125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.65,
+          "y": 4.677125000000001
+        },
+        "to": {
+          "x": 3.65,
+          "y": 4.477125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.65,
+          "y": 4.477125000000001
+        },
+        "to": {
+          "x": 3.65,
+          "y": 4.397125
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_83",
+    "source_trace_id": "schematic_port_204-schematic_port_34",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 2.8025
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 2.8025
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 2.8025
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 2.3053749999999997
+        }
+      },
+      {
+        "from": {
+          "x": 3.4675,
+          "y": 2.3053749999999997
+        },
+        "to": {
+          "x": 3.4675,
+          "y": 2.225374999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.4675,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": -1.7093749999999999,
+        "y": 2.8025
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_84",
+    "source_trace_id": "schematic_port_203-schematic_port_204",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 3.0025000000000004
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.0025000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.0025000000000004
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 2.8025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 2.8025
+        },
+        "to": {
+          "x": -1.9093749999999998,
+          "y": 2.8025
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.7093749999999999,
+        "y": 2.8025
+      },
+      {
+        "x": -1.7093749999999999,
+        "y": 3.0025000000000004
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_85",
+    "source_trace_id": "schematic_port_202-schematic_port_203",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.2025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.0025000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.0025000000000004
+        },
+        "to": {
+          "x": -1.9093749999999998,
+          "y": 3.0025000000000004
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.7093749999999999,
+        "y": 3.0025000000000004
+      },
+      {
+        "x": -1.7093749999999999,
+        "y": 3.2025
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_86",
+    "source_trace_id": "schematic_port_201-schematic_port_202",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 3.4025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.4025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.4025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.2025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.2025
+        },
+        "to": {
+          "x": -1.9093749999999998,
+          "y": 3.2025
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.7093749999999999,
+        "y": 3.2025
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_87",
+    "source_trace_id": "schematic_port_200-schematic_port_199",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 3.6025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.6025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.6025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 3.8025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 3.8025
+        },
+        "to": {
+          "x": -1.9093749999999998,
+          "y": 3.8025
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.7093749999999999,
+        "y": 3.8025
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_88",
+    "source_trace_id": "schematic_port_180-schematic_port_90",
+    "edges": [
+      {
+        "from": {
+          "x": 1.04,
+          "y": 4.581125000000001
+        },
+        "to": {
+          "x": 0.98,
+          "y": 4.581125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 0.98,
+          "y": 4.581125000000001
+        },
+        "to": {
+          "x": 0.78,
+          "y": 4.581125000000001
+        }
+      },
+      {
+        "from": {
+          "x": 0.78,
+          "y": 4.581125000000001
+        },
+        "to": {
+          "x": 0.78,
+          "y": 3.8325
+        }
+      },
+      {
+        "from": {
+          "x": 0.78,
+          "y": 3.8325
+        },
+        "to": {
+          "x": 1.525,
+          "y": 3.8325
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net40"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_89",
+    "source_trace_id": "schematic_port_43-schematic_port_108",
+    "edges": [
+      {
+        "from": {
+          "x": 1.85125,
+          "y": 0.365
+        },
+        "to": {
+          "x": 2.05125,
+          "y": 0.365
+        }
+      },
+      {
+        "from": {
+          "x": 2.05125,
+          "y": 0.365
+        },
+        "to": {
+          "x": 2.05125,
+          "y": -0.25499999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 2.05125,
+          "y": -0.25499999999999995
+        },
+        "to": {
+          "x": 1.08875,
+          "y": -0.25499999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 1.08875,
+          "y": -0.25499999999999995
+        },
+        "to": {
+          "x": 1.01375,
+          "y": -0.25499999999999995
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 1.01375,
+          "y": -0.25499999999999995
+        },
+        "to": {
+          "x": 0.22999999999999998,
+          "y": -0.25499999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 0.22999999999999998,
+          "y": -0.25499999999999995
+        },
+        "to": {
+          "x": 0.22999999999999998,
+          "y": 0.365
+        }
+      },
+      {
+        "from": {
+          "x": 0.22999999999999998,
+          "y": 0.365
+        },
+        "to": {
+          "x": 0.42999999999999994,
+          "y": 0.365
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net41"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_90",
+    "source_trace_id": "schematic_port_205-schematic_port_206",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 2.6025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 2.6025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 2.6025
+        },
+        "to": {
+          "x": -1.7093749999999999,
+          "y": 2.4025
+        }
+      },
+      {
+        "from": {
+          "x": -1.7093749999999999,
+          "y": 2.4025
+        },
+        "to": {
+          "x": -1.9093749999999998,
+          "y": 2.4025
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net42"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_91",
+    "source_trace_id": "schematic_port_105-schematic_port_101",
+    "edges": [
+      {
+        "from": {
+          "x": 6.3225,
+          "y": 1.46
+        },
+        "to": {
+          "x": 6.459375,
+          "y": 1.46
+        }
+      },
+      {
+        "from": {
+          "x": 6.459375,
+          "y": 1.46
+        },
+        "to": {
+          "x": 6.459375,
+          "y": 2.0075
+        }
+      },
+      {
+        "from": {
+          "x": 6.459375,
+          "y": 2.0075
+        },
+        "to": {
+          "x": 6.3225,
+          "y": 2.0075
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.459375,
+        "y": 2.0075
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_92",
+    "source_trace_id": "schematic_port_95-schematic_port_101",
+    "edges": [
+      {
+        "from": {
+          "x": 6.3225,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.459375,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 6.459375,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.459375,
+          "y": 2.0075
+        }
+      },
+      {
+        "from": {
+          "x": 6.459375,
+          "y": 2.0075
+        },
+        "to": {
+          "x": 6.3225,
+          "y": 2.0075
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.459375,
+        "y": 2.0075
+      },
+      {
+        "x": 6.459375,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_93",
+    "source_trace_id": "schematic_port_93-schematic_port_95",
+    "edges": [
+      {
+        "from": {
+          "x": 6.3225,
+          "y": 3.1025
+        },
+        "to": {
+          "x": 6.5225,
+          "y": 3.1025
+        }
+      },
+      {
+        "from": {
+          "x": 6.5225,
+          "y": 3.1025
+        },
+        "to": {
+          "x": 6.5225,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 6.5225,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.3225,
+          "y": 2.5549999999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.459375,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 6.5225,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_94",
+    "source_trace_id": "schematic_port_26-schematic_port_95",
+    "edges": [
+      {
+        "from": {
+          "x": 6.935,
+          "y": 2.4078749999999993
+        },
+        "to": {
+          "x": 6.935,
+          "y": 2.487875
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 2.487875
+        },
+        "to": {
+          "x": 6.935,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.3225,
+          "y": 2.5549999999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.459375,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 6.5225,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 6.935,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_95",
+    "source_trace_id": "schematic_port_32-schematic_port_26",
+    "edges": [
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 2.4078749999999993
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 2.487875
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 2.487875
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.935,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 6.935,
+          "y": 2.487875
+        }
+      },
+      {
+        "from": {
+          "x": 6.935,
+          "y": 2.487875
+        },
+        "to": {
+          "x": 6.935,
+          "y": 2.4078749999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.935,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 7.8475,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_96",
+    "source_trace_id": "schematic_port_40-schematic_port_32",
+    "edges": [
+      {
+        "from": {
+          "x": 8.76,
+          "y": 2.3987499999999997
+        },
+        "to": {
+          "x": 8.76,
+          "y": 2.4787500000000002
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 2.4787500000000002
+        },
+        "to": {
+          "x": 8.76,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 2.5549999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 2.5549999999999997
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 2.487875
+        }
+      },
+      {
+        "from": {
+          "x": 7.8475,
+          "y": 2.487875
+        },
+        "to": {
+          "x": 7.8475,
+          "y": 2.4078749999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 7.8475,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 8.76,
+        "y": 2.5549999999999997
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_97",
+    "source_trace_id": "schematic_port_271-schematic_port_40",
+    "edges": [
+      {
+        "from": {
+          "x": 9.8375,
+          "y": 3.540500000000002
+        },
+        "to": {
+          "x": 8.76,
+          "y": 3.540500000000002
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 3.540500000000002
+        },
+        "to": {
+          "x": 8.76,
+          "y": 2.4787500000000002
+        }
+      },
+      {
+        "from": {
+          "x": 8.76,
+          "y": 2.4787500000000002
+        },
+        "to": {
+          "x": 8.76,
+          "y": 2.3987499999999997
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 8.76,
+        "y": 2.5549999999999997
+      },
+      {
+        "x": 9.637500000000001,
+        "y": 3.540500000000001
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_98",
+    "source_trace_id": "schematic_port_262-schematic_port_271",
+    "edges": [
+      {
+        "from": {
+          "x": 11.735,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 11.7975,
+          "y": 2.58125
+        }
+      },
+      {
+        "from": {
+          "x": 11.7975,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 2.58125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": 2.58125
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": 3.0608750000000002
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": 3.0608750000000002
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 3.0608750000000002
+        }
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 3.0608750000000002
+        },
+        "to": {
+          "x": 11.797499999999998,
+          "y": 3.0608750000000002
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.797499999999998,
+          "y": 3.0608750000000002
+        },
+        "to": {
+          "x": 9.637500000000001,
+          "y": 3.0608750000000002
+        }
+      },
+      {
+        "from": {
+          "x": 9.637500000000001,
+          "y": 3.0608750000000002
+        },
+        "to": {
+          "x": 9.637500000000001,
+          "y": 3.540500000000001
+        }
+      },
+      {
+        "from": {
+          "x": 9.637500000000001,
+          "y": 3.540500000000001
+        },
+        "to": {
+          "x": 9.8375,
+          "y": 3.540500000000001
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.637500000000001,
+        "y": 3.540500000000001
+      },
+      {
+        "x": 12.034999999999998,
+        "y": 2.58125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_99",
+    "source_trace_id": "schematic_port_263-schematic_port_262",
+    "edges": [
+      {
+        "from": {
+          "x": 11.735,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 11.7975,
+          "y": 2.38125
+        }
+      },
+      {
+        "from": {
+          "x": 11.7975,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 2.38125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": 2.38125
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": 2.58125
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 2.58125
+        }
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 11.797499999999998,
+          "y": 2.58125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.797499999999998,
+          "y": 2.58125
+        },
+        "to": {
+          "x": 11.735,
+          "y": 2.58125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.034999999999998,
+        "y": 2.58125
+      },
+      {
+        "x": 12.034999999999998,
+        "y": 2.38125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_100",
+    "source_trace_id": "schematic_port_135-schematic_port_263",
+    "edges": [
+      {
+        "from": {
+          "x": 11.432500000000001,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 11.595,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 11.595,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 11.670000000000002,
+          "y": -4.5625
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.670000000000002,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 12.034999999999998,
+          "y": 2.38125
+        }
+      },
+      {
+        "from": {
+          "x": 12.034999999999998,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 2.38125
+        }
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 11.797499999999998,
+          "y": 2.38125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.797499999999998,
+          "y": 2.38125
+        },
+        "to": {
+          "x": 11.735,
+          "y": 2.38125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.034999999999998,
+        "y": 2.38125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_101",
+    "source_trace_id": "schematic_port_139-schematic_port_128",
+    "edges": [
+      {
+        "from": {
+          "x": 4.3149999999999995,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 4.3675,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 4.3675,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 4.3675,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 4.3675,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.5249999999999995,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 4.5249999999999995,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.5675,
+          "y": -4.5625
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 4.5675,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.6275,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.3675,
+        "y": -4.9275
+      },
+      {
+        "x": 4.3675,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_102",
+    "source_trace_id": "schematic_port_149-schematic_port_139",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -5.7749999999999995
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -5.975
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -5.975
+        },
+        "to": {
+          "x": 7.30625,
+          "y": -5.975
+        }
+      },
+      {
+        "from": {
+          "x": 7.30625,
+          "y": -5.975
+        },
+        "to": {
+          "x": 7.30625,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 7.30625,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 7.2525,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 7.2525,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 7.1775,
+          "y": -4.9275
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.1775,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 5.5125,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 5.5125,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 5.4375,
+          "y": -4.9275
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.4375,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 4.6000000000000005,
+          "y": -4.9275
+        }
+      },
+      {
+        "from": {
+          "x": 4.6000000000000005,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 4.525,
+          "y": -4.9275
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 4.525,
+          "y": -4.9275
+        },
+        "to": {
+          "x": 4.3149999999999995,
+          "y": -4.9275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.3675,
+        "y": -4.9275
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_103",
+    "source_trace_id": "schematic_port_96-schematic_port_128",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -3.35
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -3.15
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -3.15
+        },
+        "to": {
+          "x": 3.9124999999999996,
+          "y": -3.15
+        }
+      },
+      {
+        "from": {
+          "x": 3.9124999999999996,
+          "y": -3.15
+        },
+        "to": {
+          "x": 3.9124999999999996,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 3.9124999999999996,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.5249999999999995,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 4.5249999999999995,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.5675,
+          "y": -4.5625
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 4.5675,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 4.6275,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 4.3675,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net46"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_104",
+    "source_trace_id": "schematic_port_208-schematic_port_83",
+    "edges": [
+      {
+        "from": {
+          "x": 7.2625,
+          "y": 5.7225
+        },
+        "to": {
+          "x": 7.1625,
+          "y": 5.7225
+        }
+      },
+      {
+        "from": {
+          "x": 7.1625,
+          "y": 5.7225
+        },
+        "to": {
+          "x": 7.1625,
+          "y": 5.5075
+        }
+      },
+      {
+        "from": {
+          "x": 7.1625,
+          "y": 5.5075
+        },
+        "to": {
+          "x": 7.2524999999999995,
+          "y": 5.5075
+        }
+      },
+      {
+        "from": {
+          "x": 7.2524999999999995,
+          "y": 5.5075
+        },
+        "to": {
+          "x": 7.2524999999999995,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 7.2524999999999995,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 7.052499999999999,
+          "y": 5.2924999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net47"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_105",
+    "source_trace_id": "schematic_port_209-schematic_port_77",
+    "edges": [
+      {
+        "from": {
+          "x": 7.2625,
+          "y": 5.922499999999999
+        },
+        "to": {
+          "x": 7.125624999999999,
+          "y": 5.922499999999999
+        }
+      },
+      {
+        "from": {
+          "x": 7.125624999999999,
+          "y": 5.922499999999999
+        },
+        "to": {
+          "x": 7.125624999999999,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 7.125624999999999,
+          "y": 5.84
+        },
+        "to": {
+          "x": 7.119999999999999,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 7.119999999999999,
+          "y": 5.84
+        },
+        "to": {
+          "x": 7.052499999999999,
+          "y": 5.84
+        },
+        "is_crossing": true
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net48"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_106",
+    "source_trace_id": "schematic_port_210-schematic_port_12",
+    "edges": [
+      {
+        "from": {
+          "x": 9.162500000000001,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.225000000000001,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 9.225000000000001,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.3,
+          "y": 5.9225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 9.3,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.4625,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 9.4625,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.4625,
+          "y": 3.76
+        }
+      },
+      {
+        "from": {
+          "x": 9.4625,
+          "y": 3.76
+        },
+        "to": {
+          "x": 7.256249999999999,
+          "y": 3.76
+        }
+      },
+      {
+        "from": {
+          "x": 7.256249999999999,
+          "y": 3.76
+        },
+        "to": {
+          "x": 7.256249999999999,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 7.256249999999999,
+          "y": 4.38
+        },
+        "to": {
+          "x": 7.456249999999999,
+          "y": 4.38
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.4625,
+        "y": 5.9225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_107",
+    "source_trace_id": "schematic_port_177-schematic_port_210",
+    "edges": [
+      {
+        "from": {
+          "x": 9.9825,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.3,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 9.3,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.225,
+          "y": 5.9225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 9.225,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.162500000000001,
+          "y": 5.9225
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.4625,
+        "y": 5.9225
+      },
+      {
+        "x": 9.7225,
+        "y": 6.898874999999999
+      },
+      {
+        "x": 9.7225,
+        "y": 5.9225
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_108",
+    "source_trace_id": "schematic_port_156-schematic_port_177",
+    "edges": [
+      {
+        "from": {
+          "x": 11.1325,
+          "y": 8.185
+        },
+        "to": {
+          "x": 11.1325,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 11.1325,
+          "y": 8.285
+        },
+        "to": {
+          "x": 10.870000000000001,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 10.870000000000001,
+          "y": 8.285
+        },
+        "to": {
+          "x": 10.795,
+          "y": 8.285
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 10.795,
+          "y": 8.285
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 8.285
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.9825,
+          "y": 6.898874999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.7225,
+        "y": 6.898874999999999
+      },
+      {
+        "x": 9.7225,
+        "y": 8.285
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_109",
+    "source_trace_id": "schematic_port_14-schematic_port_210",
+    "edges": [
+      {
+        "from": {
+          "x": 13.11375,
+          "y": 4.38
+        },
+        "to": {
+          "x": 12.8475,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 12.8475,
+          "y": 4.38
+        },
+        "to": {
+          "x": 12.772499999999999,
+          "y": 4.38
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.772499999999999,
+          "y": 4.38
+        },
+        "to": {
+          "x": 11.9475,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 11.9475,
+          "y": 4.38
+        },
+        "to": {
+          "x": 11.872499999999999,
+          "y": 4.38
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.872499999999999,
+          "y": 4.38
+        },
+        "to": {
+          "x": 10.797500000000001,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 10.797500000000001,
+          "y": 4.38
+        },
+        "to": {
+          "x": 10.797500000000001,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 10.797500000000001,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.3,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 9.3,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.225000000000001,
+          "y": 5.9225
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 9.225000000000001,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 9.162500000000001,
+          "y": 5.9225
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.4625,
+        "y": 5.9225
+      },
+      {
+        "x": 9.7225,
+        "y": 5.9225
+      },
+      {
+        "x": 12.91375,
+        "y": 4.38
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_110",
+    "source_trace_id": "schematic_port_218-schematic_port_14",
+    "edges": [
+      {
+        "from": {
+          "x": 14.819999999999999,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 15.019999999999998,
+          "y": 5.9225
+        }
+      },
+      {
+        "from": {
+          "x": 15.019999999999998,
+          "y": 5.9225
+        },
+        "to": {
+          "x": 15.019999999999998,
+          "y": 3.86
+        }
+      },
+      {
+        "from": {
+          "x": 15.019999999999998,
+          "y": 3.86
+        },
+        "to": {
+          "x": 13.951249999999998,
+          "y": 3.86
+        }
+      },
+      {
+        "from": {
+          "x": 13.951249999999998,
+          "y": 3.86
+        },
+        "to": {
+          "x": 13.876249999999997,
+          "y": 3.86
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 13.876249999999997,
+          "y": 3.86
+        },
+        "to": {
+          "x": 12.91375,
+          "y": 3.86
+        }
+      },
+      {
+        "from": {
+          "x": 12.91375,
+          "y": 3.86
+        },
+        "to": {
+          "x": 12.91375,
+          "y": 4.38
+        }
+      },
+      {
+        "from": {
+          "x": 12.91375,
+          "y": 4.38
+        },
+        "to": {
+          "x": 13.11375,
+          "y": 4.38
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.91375,
+        "y": 4.38
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_111",
+    "source_trace_id": "schematic_port_174-schematic_port_177",
+    "edges": [
+      {
+        "from": {
+          "x": 4.325,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 4.265000000000001,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.265000000000001,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 4.065,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.065,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 4.065,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 4.065,
+          "y": 8.285
+        },
+        "to": {
+          "x": 5.1375,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 5.1375,
+          "y": 8.285
+        },
+        "to": {
+          "x": 5.2125,
+          "y": 8.285
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.2125,
+          "y": 8.285
+        },
+        "to": {
+          "x": 6.35,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 6.35,
+          "y": 8.285
+        },
+        "to": {
+          "x": 6.425000000000001,
+          "y": 8.285
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 6.425000000000001,
+          "y": 8.285
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 8.285
+        },
+        "to": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.7225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 9.9225,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 9.9825,
+          "y": 6.898874999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 9.7225,
+        "y": 6.898874999999999
+      },
+      {
+        "x": 9.7225,
+        "y": 8.285
+      },
+      {
+        "x": 5.475,
+        "y": 8.285
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_112",
+    "source_trace_id": "schematic_port_154-schematic_port_174",
+    "edges": [
+      {
+        "from": {
+          "x": 5.475,
+          "y": 8.185
+        },
+        "to": {
+          "x": 5.475,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": 8.285
+        },
+        "to": {
+          "x": 5.2124999999999995,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 5.2124999999999995,
+          "y": 8.285
+        },
+        "to": {
+          "x": 5.137499999999999,
+          "y": 8.285
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.137499999999999,
+          "y": 8.285
+        },
+        "to": {
+          "x": 4.065,
+          "y": 8.285
+        }
+      },
+      {
+        "from": {
+          "x": 4.065,
+          "y": 8.285
+        },
+        "to": {
+          "x": 4.065,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.065,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 4.265000000000001,
+          "y": 6.898874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 4.265000000000001,
+          "y": 6.898874999999999
+        },
+        "to": {
+          "x": 4.325,
+          "y": 6.898874999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.475,
+        "y": 8.285
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net64"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_113",
+    "source_trace_id": "schematic_port_3-schematic_port_213",
+    "edges": [
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 6.36125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.28125
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 6.28125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.279999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 7.045,
+          "y": 6.279999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 7.045,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 7.12,
+          "y": 6.279999999999999
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.12,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 7.1575,
+          "y": 6.279999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 7.1575,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 7.1575,
+          "y": 6.1225
+        }
+      },
+      {
+        "from": {
+          "x": 7.1575,
+          "y": 6.1225
+        },
+        "to": {
+          "x": 7.2625,
+          "y": 6.1225
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.3875,
+        "y": 6.279999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_114",
+    "source_trace_id": "schematic_port_70-schematic_port_3",
+    "edges": [
+      {
+        "from": {
+          "x": 5.54,
+          "y": 6.205
+        },
+        "to": {
+          "x": 5.34,
+          "y": 6.205
+        }
+      },
+      {
+        "from": {
+          "x": 5.34,
+          "y": 6.205
+        },
+        "to": {
+          "x": 5.34,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 5.34,
+          "y": 5.665
+        },
+        "to": {
+          "x": 6.215,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 6.215,
+          "y": 5.665
+        },
+        "to": {
+          "x": 6.29,
+          "y": 5.665
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 6.29,
+          "y": 5.665
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 5.665
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.28125
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 6.28125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.36125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.3875,
+        "y": 6.279999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net53"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_115",
+    "source_trace_id": "schematic_port_66-schematic_port_2",
+    "edges": [
+      {
+        "from": {
+          "x": 5.54,
+          "y": 6.935
+        },
+        "to": {
+          "x": 5.174999999999999,
+          "y": 6.935
+        }
+      },
+      {
+        "from": {
+          "x": 5.174999999999999,
+          "y": 6.935
+        },
+        "to": {
+          "x": 5.174999999999999,
+          "y": 8.485
+        }
+      },
+      {
+        "from": {
+          "x": 5.174999999999999,
+          "y": 8.485
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 8.485
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 8.485
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 7.04125
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 7.04125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.96125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.3875,
+        "y": 7.24125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_116",
+    "source_trace_id": "schematic_port_214-schematic_port_2",
+    "edges": [
+      {
+        "from": {
+          "x": 7.2625,
+          "y": 6.5225
+        },
+        "to": {
+          "x": 7.1225000000000005,
+          "y": 6.5225
+        }
+      },
+      {
+        "from": {
+          "x": 7.1225000000000005,
+          "y": 6.5225
+        },
+        "to": {
+          "x": 7.1225000000000005,
+          "y": 7.24125
+        }
+      },
+      {
+        "from": {
+          "x": 7.1225000000000005,
+          "y": 7.24125
+        },
+        "to": {
+          "x": 7.12,
+          "y": 7.24125
+        }
+      },
+      {
+        "from": {
+          "x": 7.12,
+          "y": 7.24125
+        },
+        "to": {
+          "x": 7.045000000000001,
+          "y": 7.24125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.045000000000001,
+          "y": 7.24125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 7.24125
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 7.24125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 7.04125
+        }
+      },
+      {
+        "from": {
+          "x": 6.3875,
+          "y": 7.04125
+        },
+        "to": {
+          "x": 6.3875,
+          "y": 6.96125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.3875,
+        "y": 7.24125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net54"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_117",
+    "source_trace_id": "schematic_port_172-schematic_port_155",
+    "edges": [
+      {
+        "from": {
+          "x": 5.045,
+          "y": 7.548874999999999
+        },
+        "to": {
+          "x": 5.045,
+          "y": 7.748874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 5.045,
+          "y": 7.748874999999999
+        },
+        "to": {
+          "x": 5.1375,
+          "y": 7.748874999999999
+        }
+      },
+      {
+        "from": {
+          "x": 5.1375,
+          "y": 7.748874999999999
+        },
+        "to": {
+          "x": 5.195,
+          "y": 7.748874999999999
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.195,
+          "y": 7.748874999999999
+        },
+        "to": {
+          "x": 5.195,
+          "y": 6.944999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 5.195,
+          "y": 6.944999999999999
+        },
+        "to": {
+          "x": 5.475,
+          "y": 6.944999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": 6.944999999999999
+        },
+        "to": {
+          "x": 5.475,
+          "y": 7.145
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_118",
+    "source_trace_id": "schematic_port_216-schematic_port_85",
+    "edges": [
+      {
+        "from": {
+          "x": 12.92,
+          "y": 5.7225
+        },
+        "to": {
+          "x": 12.82,
+          "y": 5.7225
+        }
+      },
+      {
+        "from": {
+          "x": 12.82,
+          "y": 5.7225
+        },
+        "to": {
+          "x": 12.82,
+          "y": 5.5075
+        }
+      },
+      {
+        "from": {
+          "x": 12.82,
+          "y": 5.5075
+        },
+        "to": {
+          "x": 12.91,
+          "y": 5.5075
+        }
+      },
+      {
+        "from": {
+          "x": 12.91,
+          "y": 5.5075
+        },
+        "to": {
+          "x": 12.91,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 12.91,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 12.8475,
+          "y": 5.2924999999999995
+        }
+      },
+      {
+        "from": {
+          "x": 12.8475,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 12.7725,
+          "y": 5.2924999999999995
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 12.7725,
+          "y": 5.2924999999999995
+        },
+        "to": {
+          "x": 12.71,
+          "y": 5.2924999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net57"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_119",
+    "source_trace_id": "schematic_port_217-schematic_port_79",
+    "edges": [
+      {
+        "from": {
+          "x": 12.92,
+          "y": 5.922499999999999
+        },
+        "to": {
+          "x": 12.783125,
+          "y": 5.922499999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.783125,
+          "y": 5.922499999999999
+        },
+        "to": {
+          "x": 12.783125,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 12.783125,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.7525,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 12.7525,
+          "y": 5.84
+        },
+        "to": {
+          "x": 12.71,
+          "y": 5.84
+        },
+        "is_crossing": true
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net58"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_120",
+    "source_trace_id": "schematic_port_5-schematic_port_221",
+    "edges": [
+      {
+        "from": {
+          "x": 12.045,
+          "y": 6.36125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 6.28125
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 6.28125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 6.279999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 12.815000000000001,
+          "y": 6.279999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.815000000000001,
+          "y": 6.279999999999999
+        },
+        "to": {
+          "x": 12.815000000000001,
+          "y": 6.1225000000000005
+        }
+      },
+      {
+        "from": {
+          "x": 12.815000000000001,
+          "y": 6.1225000000000005
+        },
+        "to": {
+          "x": 12.92,
+          "y": 6.1225000000000005
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.045,
+        "y": 6.279999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_121",
+    "source_trace_id": "schematic_port_72-schematic_port_5",
+    "edges": [
+      {
+        "from": {
+          "x": 11.1975,
+          "y": 6.205
+        },
+        "to": {
+          "x": 10.9975,
+          "y": 6.205
+        }
+      },
+      {
+        "from": {
+          "x": 10.9975,
+          "y": 6.205
+        },
+        "to": {
+          "x": 10.9975,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 10.9975,
+          "y": 5.665
+        },
+        "to": {
+          "x": 11.8725,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 11.8725,
+          "y": 5.665
+        },
+        "to": {
+          "x": 11.9475,
+          "y": 5.665
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 11.9475,
+          "y": 5.665
+        },
+        "to": {
+          "x": 12.045,
+          "y": 5.665
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 5.665
+        },
+        "to": {
+          "x": 12.045,
+          "y": 6.28125
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 6.28125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 6.36125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.045,
+        "y": 6.279999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net61"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_122",
+    "source_trace_id": "schematic_port_4-schematic_port_222",
+    "edges": [
+      {
+        "from": {
+          "x": 12.045,
+          "y": 6.96125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 7.04125
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 7.04125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 7.241249999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 7.241249999999999
+        },
+        "to": {
+          "x": 12.780000000000001,
+          "y": 7.241249999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.780000000000001,
+          "y": 7.241249999999999
+        },
+        "to": {
+          "x": 12.780000000000001,
+          "y": 6.522500000000001
+        }
+      },
+      {
+        "from": {
+          "x": 12.780000000000001,
+          "y": 6.522500000000001
+        },
+        "to": {
+          "x": 12.92,
+          "y": 6.522500000000001
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.045,
+        "y": 7.241249999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_123",
+    "source_trace_id": "schematic_port_68-schematic_port_4",
+    "edges": [
+      {
+        "from": {
+          "x": 11.1975,
+          "y": 6.935
+        },
+        "to": {
+          "x": 10.832499999999998,
+          "y": 6.935
+        }
+      },
+      {
+        "from": {
+          "x": 10.832499999999998,
+          "y": 6.935
+        },
+        "to": {
+          "x": 10.832499999999998,
+          "y": 8.485
+        }
+      },
+      {
+        "from": {
+          "x": 10.832499999999998,
+          "y": 8.485
+        },
+        "to": {
+          "x": 12.045,
+          "y": 8.485
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 8.485
+        },
+        "to": {
+          "x": 12.045,
+          "y": 7.04125
+        }
+      },
+      {
+        "from": {
+          "x": 12.045,
+          "y": 7.04125
+        },
+        "to": {
+          "x": 12.045,
+          "y": 6.96125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 12.045,
+        "y": 7.241249999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net62"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_124",
+    "source_trace_id": "schematic_port_175-schematic_port_157",
+    "edges": [
+      {
+        "from": {
+          "x": 10.7025,
+          "y": 7.548874999999999
+        },
+        "to": {
+          "x": 10.7025,
+          "y": 7.748874999999998
+        }
+      },
+      {
+        "from": {
+          "x": 10.7025,
+          "y": 7.748874999999998
+        },
+        "to": {
+          "x": 10.795,
+          "y": 7.748874999999998
+        }
+      },
+      {
+        "from": {
+          "x": 10.795,
+          "y": 7.748874999999998
+        },
+        "to": {
+          "x": 10.852500000000001,
+          "y": 7.748874999999998
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 10.852500000000001,
+          "y": 7.748874999999998
+        },
+        "to": {
+          "x": 10.852500000000001,
+          "y": 6.945
+        }
+      },
+      {
+        "from": {
+          "x": 10.852500000000001,
+          "y": 6.945
+        },
+        "to": {
+          "x": 11.1325,
+          "y": 6.945
+        }
+      },
+      {
+        "from": {
+          "x": 11.1325,
+          "y": 6.945
+        },
+        "to": {
+          "x": 11.1325,
+          "y": 7.145
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_125",
+    "source_trace_id": "schematic_port_251-schematic_port_62",
+    "edges": [
+      {
+        "from": {
+          "x": 7.3775,
+          "y": -4.7625
+        },
+        "to": {
+          "x": 7.36875,
+          "y": -4.7625
+        }
+      },
+      {
+        "from": {
+          "x": 7.36875,
+          "y": -4.7625
+        },
+        "to": {
+          "x": 7.29375,
+          "y": -4.7625
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.29375,
+          "y": -4.7625
+        },
+        "to": {
+          "x": 7.215,
+          "y": -4.7625
+        }
+      },
+      {
+        "from": {
+          "x": 7.215,
+          "y": -4.7625
+        },
+        "to": {
+          "x": 7.215,
+          "y": -4.953125
+        }
+      },
+      {
+        "from": {
+          "x": 7.215,
+          "y": -4.953125
+        },
+        "to": {
+          "x": 6.57,
+          "y": -4.953125
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -4.953125
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.00375
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.00375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.08375
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net66"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_126",
+    "source_trace_id": "schematic_port_132-schematic_port_131",
+    "edges": [
+      {
+        "from": {
+          "x": 6.4525,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 6.14,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.34,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_127",
+    "source_trace_id": "schematic_port_275-schematic_port_131",
+    "edges": [
+      {
+        "from": {
+          "x": 6.005,
+          "y": -3.7595
+        },
+        "to": {
+          "x": 5.85,
+          "y": -3.7595
+        }
+      },
+      {
+        "from": {
+          "x": 5.85,
+          "y": -3.7595
+        },
+        "to": {
+          "x": 5.805,
+          "y": -3.7595
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.805,
+          "y": -3.7595
+        },
+        "to": {
+          "x": 5.805,
+          "y": -4.161
+        }
+      },
+      {
+        "from": {
+          "x": 5.805,
+          "y": -4.161
+        },
+        "to": {
+          "x": 6.34,
+          "y": -4.161
+        }
+      },
+      {
+        "from": {
+          "x": 6.34,
+          "y": -4.161
+        },
+        "to": {
+          "x": 6.34,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 6.34,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 6.14,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.34,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net68"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_128",
+    "source_trace_id": "schematic_port_130-schematic_port_129",
+    "edges": [
+      {
+        "from": {
+          "x": 5.54,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 5.2875000000000005,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 5.2875000000000005,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 5.2275,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.475,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_129",
+    "source_trace_id": "schematic_port_60-schematic_port_130",
+    "edges": [
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.08375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -5.00375
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -5.00375
+        },
+        "to": {
+          "x": 5.475,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 5.475,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 5.54,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 5.475,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net71"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_130",
+    "source_trace_id": "schematic_port_196-schematic_port_195",
+    "edges": [
+      {
+        "from": {
+          "x": -3.0649999999999995,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -2.8649999999999993,
+          "y": 4.690625
+        }
+      },
+      {
+        "from": {
+          "x": -2.8649999999999993,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -2.8649999999999993,
+          "y": 4.890624999999999
+        }
+      },
+      {
+        "from": {
+          "x": -2.8649999999999993,
+          "y": 4.890624999999999
+        },
+        "to": {
+          "x": -3.0649999999999995,
+          "y": 4.890624999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.8649999999999993,
+        "y": 4.890624999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_131",
+    "source_trace_id": "schematic_port_198-schematic_port_196",
+    "edges": [
+      {
+        "from": {
+          "x": -3.109375,
+          "y": 3.0025
+        },
+        "to": {
+          "x": -5.265,
+          "y": 3.0025
+        }
+      },
+      {
+        "from": {
+          "x": -5.265,
+          "y": 3.0025
+        },
+        "to": {
+          "x": -5.265,
+          "y": 5.910625
+        }
+      },
+      {
+        "from": {
+          "x": -5.265,
+          "y": 5.910625
+        },
+        "to": {
+          "x": -2.8649999999999993,
+          "y": 5.910625
+        }
+      },
+      {
+        "from": {
+          "x": -2.8649999999999993,
+          "y": 5.910625
+        },
+        "to": {
+          "x": -2.8649999999999993,
+          "y": 4.690625
+        }
+      },
+      {
+        "from": {
+          "x": -2.8649999999999993,
+          "y": 4.690625
+        },
+        "to": {
+          "x": -3.0649999999999995,
+          "y": 4.690625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.8649999999999993,
+        "y": 4.890624999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net72"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_132",
+    "source_trace_id": "schematic_port_248-schematic_port_118",
+    "edges": [
+      {
+        "from": {
+          "x": -10.805,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -10.9675,
+          "y": -2.9025
+        }
+      },
+      {
+        "from": {
+          "x": -10.9675,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -11.0425,
+          "y": -2.9025
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -11.0425,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -12.61125,
+          "y": -2.9025
+        }
+      },
+      {
+        "from": {
+          "x": -12.61125,
+          "y": -2.9025
+        },
+        "to": {
+          "x": -12.61125,
+          "y": -1.095
+        }
+      },
+      {
+        "from": {
+          "x": -12.61125,
+          "y": -1.095
+        },
+        "to": {
+          "x": -12.8475,
+          "y": -1.095
+        }
+      },
+      {
+        "from": {
+          "x": -12.8475,
+          "y": -1.095
+        },
+        "to": {
+          "x": -12.9225,
+          "y": -1.095
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -12.9225,
+          "y": -1.095
+        },
+        "to": {
+          "x": -14.4175,
+          "y": -1.095
+        }
+      },
+      {
+        "from": {
+          "x": -14.4175,
+          "y": -1.095
+        },
+        "to": {
+          "x": -14.4175,
+          "y": -1.16
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net73"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_133",
+    "source_trace_id": "schematic_port_245-schematic_port_112",
+    "edges": [
+      {
+        "from": {
+          "x": -10.805,
+          "y": -3.102499999999999
+        },
+        "to": {
+          "x": -10.9675,
+          "y": -3.102499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -10.9675,
+          "y": -3.102499999999999
+        },
+        "to": {
+          "x": -11.0425,
+          "y": -3.102499999999999
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -11.0425,
+          "y": -3.102499999999999
+        },
+        "to": {
+          "x": -12.885,
+          "y": -3.102499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -12.885,
+          "y": -3.102499999999999
+        },
+        "to": {
+          "x": -12.885,
+          "y": -0.23000000000000065
+        }
+      },
+      {
+        "from": {
+          "x": -12.885,
+          "y": -0.23000000000000065
+        },
+        "to": {
+          "x": -14.965,
+          "y": -0.23000000000000065
+        }
+      },
+      {
+        "from": {
+          "x": -14.965,
+          "y": -0.23000000000000065
+        },
+        "to": {
+          "x": -14.965,
+          "y": -0.42999999999999994
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net74"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_134",
+    "source_trace_id": "schematic_port_151-schematic_port_165",
+    "edges": [
+      {
+        "from": {
+          "x": -1.46,
+          "y": -6.505
+        },
+        "to": {
+          "x": -1.46,
+          "y": -6.6049999999999995
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -6.6049999999999995
+        },
+        "to": {
+          "x": -1.3599999999999999,
+          "y": -6.6049999999999995
+        }
+      },
+      {
+        "from": {
+          "x": -1.3599999999999999,
+          "y": -6.6049999999999995
+        },
+        "to": {
+          "x": -1.3599999999999999,
+          "y": -6.705
+        }
+      },
+      {
+        "from": {
+          "x": -1.3599999999999999,
+          "y": -6.705
+        },
+        "to": {
+          "x": -0.6200000000000001,
+          "y": -6.705
+        }
+      },
+      {
+        "from": {
+          "x": -0.6200000000000001,
+          "y": -6.705
+        },
+        "to": {
+          "x": -0.6200000000000001,
+          "y": -5.87725
+        }
+      },
+      {
+        "from": {
+          "x": -0.6200000000000001,
+          "y": -5.87725
+        },
+        "to": {
+          "x": -0.6825000000000001,
+          "y": -5.87725
+        }
+      },
+      {
+        "from": {
+          "x": -0.6825000000000001,
+          "y": -5.87725
+        },
+        "to": {
+          "x": -0.7575000000000001,
+          "y": -5.87725
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -0.7575000000000001,
+          "y": -5.87725
+        },
+        "to": {
+          "x": -1.46,
+          "y": -5.87725
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -5.87725
+        },
+        "to": {
+          "x": -1.46,
+          "y": -5.86725
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net75"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_135",
+    "source_trace_id": "schematic_port_189-schematic_port_98",
+    "edges": [
+      {
+        "from": {
+          "x": 1.04,
+          "y": 1.4238750000000002
+        },
+        "to": {
+          "x": 0.98,
+          "y": 1.4238750000000002
+        }
+      },
+      {
+        "from": {
+          "x": 0.98,
+          "y": 1.4238750000000002
+        },
+        "to": {
+          "x": 0.78,
+          "y": 1.4238750000000002
+        }
+      },
+      {
+        "from": {
+          "x": 0.78,
+          "y": 1.4238750000000002
+        },
+        "to": {
+          "x": 0.78,
+          "y": 2.19
+        }
+      },
+      {
+        "from": {
+          "x": 0.78,
+          "y": 2.19
+        },
+        "to": {
+          "x": 1.525,
+          "y": 2.19
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net76"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_136",
+    "source_trace_id": "schematic_port_0-schematic_port_147",
+    "edges": [
+      {
+        "from": {
+          "x": -3.49375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -3.55375,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -3.55375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -5.566375,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -5.566375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -5.641375,
+          "y": 6.57
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.641375,
+          "y": 6.57
+        },
+        "to": {
+          "x": -6.715,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -6.715,
+          "y": 6.57
+        },
+        "to": {
+          "x": -6.79,
+          "y": 6.57
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -6.79,
+          "y": 6.57
+        },
+        "to": {
+          "x": -7.402500000000001,
+          "y": 6.57
+        }
+      },
+      {
+        "from": {
+          "x": -7.402500000000001,
+          "y": 6.57
+        },
+        "to": {
+          "x": -7.402500000000001,
+          "y": -0.2746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": -7.402500000000001,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": -5.025,
+          "y": -0.2746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": -5.025,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": -4.95,
+          "y": -0.2746875000000002
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -4.95,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": -1.625,
+          "y": -0.2746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": -1.625,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": -1.5500000000000007,
+          "y": -0.2746875000000002
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -1.5500000000000007,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": 1.013749999999999,
+          "y": -0.2746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": 1.013749999999999,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": 1.0887499999999983,
+          "y": -0.2746875000000002
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 1.0887499999999983,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": 11.6325,
+          "y": -0.2746875000000002
+        }
+      },
+      {
+        "from": {
+          "x": 11.6325,
+          "y": -0.2746875000000002
+        },
+        "to": {
+          "x": 11.6325,
+          "y": -5.109999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 11.6325,
+          "y": -5.109999999999999
+        },
+        "to": {
+          "x": 11.432500000000001,
+          "y": -5.109999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_137",
+    "source_trace_id": "schematic_port_114-schematic_port_190",
+    "edges": [
+      {
+        "from": {
+          "x": -9.855,
+          "y": -0.7949999999999999
+        },
+        "to": {
+          "x": -9.855,
+          "y": 0.019999999999999574
+        }
+      },
+      {
+        "from": {
+          "x": -9.855,
+          "y": 0.019999999999999574
+        },
+        "to": {
+          "x": -8.888874999999999,
+          "y": 0.019999999999999574
+        }
+      },
+      {
+        "from": {
+          "x": -8.888874999999999,
+          "y": 0.019999999999999574
+        },
+        "to": {
+          "x": -8.888874999999999,
+          "y": -0.17999999999999972
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.888874999999999,
+        "y": 0.019999999999999574
+      },
+      {
+        "x": -9.855,
+        "y": -0.1899999999999999
+      },
+      {
+        "x": -9.855,
+        "y": 0.019999999999999574
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_138",
+    "source_trace_id": "schematic_port_246-schematic_port_114",
+    "edges": [
+      {
+        "from": {
+          "x": -10.805,
+          "y": -3.3025
+        },
+        "to": {
+          "x": -11.004999999999999,
+          "y": -3.3025
+        }
+      },
+      {
+        "from": {
+          "x": -11.004999999999999,
+          "y": -3.3025
+        },
+        "to": {
+          "x": -11.004999999999999,
+          "y": -1.23
+        }
+      },
+      {
+        "from": {
+          "x": -11.004999999999999,
+          "y": -1.23
+        },
+        "to": {
+          "x": -11.5535,
+          "y": -1.23
+        }
+      },
+      {
+        "from": {
+          "x": -11.5535,
+          "y": -1.23
+        },
+        "to": {
+          "x": -11.5535,
+          "y": -0.1899999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -11.5535,
+          "y": -0.1899999999999999
+        },
+        "to": {
+          "x": -9.855,
+          "y": -0.1899999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -9.855,
+          "y": -0.1899999999999999
+        },
+        "to": {
+          "x": -9.855,
+          "y": -0.7949999999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.855,
+        "y": -0.1899999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_139",
+    "source_trace_id": "schematic_port_140-schematic_port_47",
+    "edges": [
+      {
+        "from": {
+          "x": -8.03,
+          "y": -4.6275
+        },
+        "to": {
+          "x": -8.03,
+          "y": -2.5025
+        }
+      },
+      {
+        "from": {
+          "x": -8.03,
+          "y": -2.5025
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -2.5025
+        }
+      },
+      {
+        "from": {
+          "x": -8.5775,
+          "y": -2.5025
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -1.56625
+        }
+      },
+      {
+        "from": {
+          "x": -8.5775,
+          "y": -1.56625
+        },
+        "to": {
+          "x": -8.5775,
+          "y": -1.48625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.5775,
+        "y": -1.7662499999999997
+      },
+      {
+        "x": -8.03,
+        "y": -2.5025
+      },
+      {
+        "x": -8.03,
+        "y": -4.4275
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_140",
+    "source_trace_id": "schematic_port_142-schematic_port_140",
+    "edges": [
+      {
+        "from": {
+          "x": -6.57,
+          "y": -4.6275
+        },
+        "to": {
+          "x": -6.57,
+          "y": -2.5025
+        }
+      },
+      {
+        "from": {
+          "x": -6.57,
+          "y": -2.5025
+        },
+        "to": {
+          "x": -8.03,
+          "y": -2.5025
+        }
+      },
+      {
+        "from": {
+          "x": -8.03,
+          "y": -2.5025
+        },
+        "to": {
+          "x": -8.03,
+          "y": -4.6275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -6.57,
+        "y": -4.1918750000000005
+      },
+      {
+        "x": -8.03,
+        "y": -2.5025
+      },
+      {
+        "x": -8.03,
+        "y": -4.4275
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_141",
+    "source_trace_id": "schematic_port_59-schematic_port_140",
+    "edges": [
+      {
+        "from": {
+          "x": -7.3,
+          "y": -5.31875
+        },
+        "to": {
+          "x": -7.3,
+          "y": -5.398750000000001
+        }
+      },
+      {
+        "from": {
+          "x": -7.3,
+          "y": -5.398750000000001
+        },
+        "to": {
+          "x": -7.3,
+          "y": -6.0785
+        }
+      },
+      {
+        "from": {
+          "x": -7.3,
+          "y": -6.0785
+        },
+        "to": {
+          "x": -9.409999999999998,
+          "y": -6.0785
+        }
+      },
+      {
+        "from": {
+          "x": -9.409999999999998,
+          "y": -6.0785
+        },
+        "to": {
+          "x": -9.409999999999998,
+          "y": -4.4275
+        }
+      },
+      {
+        "from": {
+          "x": -9.409999999999998,
+          "y": -4.4275
+        },
+        "to": {
+          "x": -8.797499999999998,
+          "y": -4.4275
+        }
+      },
+      {
+        "from": {
+          "x": -8.797499999999998,
+          "y": -4.4275
+        },
+        "to": {
+          "x": -8.722499999999998,
+          "y": -4.4275
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -8.722499999999998,
+          "y": -4.4275
+        },
+        "to": {
+          "x": -8.03,
+          "y": -4.4275
+        }
+      },
+      {
+        "from": {
+          "x": -8.03,
+          "y": -4.4275
+        },
+        "to": {
+          "x": -8.03,
+          "y": -4.6275
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.03,
+        "y": -4.4275
+      },
+      {
+        "x": -8.76,
+        "y": -6.0785
+      },
+      {
+        "x": -7.3,
+        "y": -6.0785
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_142",
+    "source_trace_id": "schematic_port_57-schematic_port_59",
+    "edges": [
+      {
+        "from": {
+          "x": -8.76,
+          "y": -5.31875
+        },
+        "to": {
+          "x": -8.76,
+          "y": -5.39875
+        }
+      },
+      {
+        "from": {
+          "x": -8.76,
+          "y": -5.39875
+        },
+        "to": {
+          "x": -8.76,
+          "y": -6.5785
+        }
+      },
+      {
+        "from": {
+          "x": -8.76,
+          "y": -6.5785
+        },
+        "to": {
+          "x": -7.3,
+          "y": -6.5785
+        }
+      },
+      {
+        "from": {
+          "x": -7.3,
+          "y": -6.5785
+        },
+        "to": {
+          "x": -7.3,
+          "y": -5.39875
+        }
+      },
+      {
+        "from": {
+          "x": -7.3,
+          "y": -5.39875
+        },
+        "to": {
+          "x": -7.3,
+          "y": -5.31875
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -8.76,
+        "y": -6.0785
+      },
+      {
+        "x": -7.3,
+        "y": -6.0785
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_143",
+    "source_trace_id": "schematic_port_225-schematic_port_114",
+    "edges": [
+      {
+        "from": {
+          "x": -9.82,
+          "y": 2.9674999999999994
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 2.9674999999999994
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 2.9674999999999994
+        },
+        "to": {
+          "x": -9.620000000000001,
+          "y": 1.0862499999999997
+        }
+      },
+      {
+        "from": {
+          "x": -9.620000000000001,
+          "y": 1.0862499999999997
+        },
+        "to": {
+          "x": -9.855,
+          "y": 1.0862499999999997
+        }
+      },
+      {
+        "from": {
+          "x": -9.855,
+          "y": 1.0862499999999997
+        },
+        "to": {
+          "x": -9.855,
+          "y": -0.7949999999999999
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -9.620000000000001,
+        "y": 2.9674999999999994
+      },
+      {
+        "x": -9.620000000000001,
+        "y": 1.4024999999999999
+      },
+      {
+        "x": -9.855,
+        "y": 0.019999999999999574
+      },
+      {
+        "x": -9.855,
+        "y": -0.1899999999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net30"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_144",
+    "source_trace_id": "schematic_port_45-schematic_port_38",
+    "edges": [
+      {
+        "from": {
+          "x": -5.44875,
+          "y": -0.9125
+        },
+        "to": {
+          "x": -5.286250000000001,
+          "y": -0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -5.286250000000001,
+          "y": -0.9125
+        },
+        "to": {
+          "x": -5.211250000000001,
+          "y": -0.9125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -5.211250000000001,
+          "y": -0.9125
+        },
+        "to": {
+          "x": -4.987500000000001,
+          "y": -0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -4.987500000000001,
+          "y": -0.9125
+        },
+        "to": {
+          "x": -4.987500000000001,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -4.987500000000001,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -4.52625,
+          "y": 0.9125
+        }
+      },
+      {
+        "from": {
+          "x": -4.52625,
+          "y": 0.9125
+        },
+        "to": {
+          "x": -4.40625,
+          "y": 0.9125
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -4.987500000000001,
+        "y": 0.9125
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_145",
+    "source_trace_id": "schematic_port_53-schematic_port_51",
+    "edges": [
+      {
+        "from": {
+          "x": 2.58125,
+          "y": -4.38
+        },
+        "to": {
+          "x": 2.64125,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 2.64125,
+          "y": -4.38
+        },
+        "to": {
+          "x": 2.721875,
+          "y": -4.38
+        }
+      },
+      {
+        "from": {
+          "x": 2.721875,
+          "y": -4.38
+        },
+        "to": {
+          "x": 2.721875,
+          "y": -4.92
+        }
+      },
+      {
+        "from": {
+          "x": 2.721875,
+          "y": -4.92
+        },
+        "to": {
+          "x": 3.3775,
+          "y": -4.92
+        }
+      },
+      {
+        "from": {
+          "x": 3.3775,
+          "y": -4.92
+        },
+        "to": {
+          "x": 3.4524999999999997,
+          "y": -4.92
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.4524999999999997,
+          "y": -4.92
+        },
+        "to": {
+          "x": 3.5025,
+          "y": -4.92
+        }
+      },
+      {
+        "from": {
+          "x": 3.5025,
+          "y": -4.92
+        },
+        "to": {
+          "x": 3.5025,
+          "y": -3.65
+        }
+      },
+      {
+        "from": {
+          "x": 3.5025,
+          "y": -3.65
+        },
+        "to": {
+          "x": 2.9462499999999996,
+          "y": -3.65
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 3.5025,
+        "y": -3.65
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_146",
+    "source_trace_id": "schematic_port_42-schematic_port_188",
+    "edges": [
+      {
+        "from": {
+          "x": 1.25125,
+          "y": 0.365
+        },
+        "to": {
+          "x": 1.05125,
+          "y": 0.365
+        }
+      },
+      {
+        "from": {
+          "x": 1.05125,
+          "y": 0.365
+        },
+        "to": {
+          "x": 1.05125,
+          "y": 0.8794375000000001
+        }
+      },
+      {
+        "from": {
+          "x": 1.05125,
+          "y": 0.8794375000000001
+        },
+        "to": {
+          "x": 1.77,
+          "y": 0.8794375000000001
+        }
+      },
+      {
+        "from": {
+          "x": 1.77,
+          "y": 0.8794375000000001
+        },
+        "to": {
+          "x": 1.77,
+          "y": 0.9738750000000003
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 1.77,
+        "y": 0.8794375000000001
+      },
+      {
+        "x": 1.05125,
+        "y": 0.365
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_147",
+    "source_trace_id": "schematic_port_266-schematic_port_267",
+    "edges": [
+      {
+        "from": {
+          "x": 1.9576249999999984,
+          "y": 6.089650000000001
+        },
+        "to": {
+          "x": 1.9076249999999986,
+          "y": 6.089650000000001
+        }
+      },
+      {
+        "from": {
+          "x": 1.9076249999999986,
+          "y": 6.089650000000001
+        },
+        "to": {
+          "x": 1.9076249999999986,
+          "y": 5.889650000000001
+        }
+      },
+      {
+        "from": {
+          "x": 1.9076249999999986,
+          "y": 5.889650000000001
+        },
+        "to": {
+          "x": 1.9576249999999984,
+          "y": 5.889650000000001
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_148",
+    "source_trace_id": "schematic_port_25-schematic_port_42",
+    "edges": [
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -2.3987499999999997
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -2.4787500000000002
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -2.4787500000000002
+        },
+        "to": {
+          "x": 2.7375,
+          "y": -2.6787500000000004
+        }
+      },
+      {
+        "from": {
+          "x": 2.7375,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.8624999999999998,
+          "y": -2.6787500000000004
+        }
+      },
+      {
+        "from": {
+          "x": 1.8624999999999998,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.7874999999999999,
+          "y": -2.6787500000000004
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 1.7874999999999999,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.2125,
+          "y": -2.6787500000000004
+        }
+      },
+      {
+        "from": {
+          "x": 1.2125,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.1374999999999997,
+          "y": -2.6787500000000004
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 1.1374999999999997,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.05125,
+          "y": -2.6787500000000004
+        }
+      },
+      {
+        "from": {
+          "x": 1.05125,
+          "y": -2.6787500000000004
+        },
+        "to": {
+          "x": 1.05125,
+          "y": 0.365
+        }
+      },
+      {
+        "from": {
+          "x": 1.05125,
+          "y": 0.365
+        },
+        "to": {
+          "x": 1.25125,
+          "y": 0.365
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.7375,
+        "y": -2.6787500000000004
+      },
+      {
+        "x": 1.05125,
+        "y": 0.365
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_149",
+    "source_trace_id": "schematic_port_250-schematic_port_63",
+    "edges": [
+      {
+        "from": {
+          "x": 7.3775,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 7.331250000000001,
+          "y": -4.5625
+        }
+      },
+      {
+        "from": {
+          "x": 7.331250000000001,
+          "y": -4.5625
+        },
+        "to": {
+          "x": 7.331250000000001,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 7.331250000000001,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 7.268750000000001,
+          "y": -5.96375
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 7.268750000000001,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.96375
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.96375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.76375
+        }
+      },
+      {
+        "from": {
+          "x": 6.57,
+          "y": -5.76375
+        },
+        "to": {
+          "x": 6.57,
+          "y": -5.68375
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 6.57,
+        "y": -5.96375
+      },
+      {
+        "x": 7.3775,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_150",
+    "source_trace_id": "schematic_port_249-schematic_port_250",
+    "edges": [
+      {
+        "from": {
+          "x": 7.3775,
+          "y": -4.3625
+        },
+        "to": {
+          "x": 7.3775,
+          "y": -4.5625
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 7.3775,
+        "y": -4.5625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_151",
+    "source_trace_id": "schematic_port_152-schematic_port_277",
+    "edges": [
+      {
+        "from": {
+          "x": -1.46,
+          "y": -6.8175
+        },
+        "to": {
+          "x": -1.46,
+          "y": -6.66125
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -6.66125
+        },
+        "to": {
+          "x": -1.3975,
+          "y": -6.66125
+        }
+      },
+      {
+        "from": {
+          "x": -1.3975,
+          "y": -6.66125
+        },
+        "to": {
+          "x": -1.3225,
+          "y": -6.66125
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -1.3225,
+          "y": -6.66125
+        },
+        "to": {
+          "x": -0.7200000000000001,
+          "y": -6.66125
+        }
+      },
+      {
+        "from": {
+          "x": -0.7200000000000001,
+          "y": -6.66125
+        },
+        "to": {
+          "x": -0.7200000000000001,
+          "y": -5.84
+        }
+      },
+      {
+        "from": {
+          "x": -0.7200000000000001,
+          "y": -5.84
+        },
+        "to": {
+          "x": -0.09050000000000047,
+          "y": -5.84
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -0.2905000000000011,
+        "y": -5.84
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net65"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_152",
+    "source_trace_id": "schematic_port_258-schematic_port_153",
+    "edges": [
+      {
+        "from": {
+          "x": -3.7874999999999996,
+          "y": -6.835
+        },
+        "to": {
+          "x": -4.488499999999999,
+          "y": -6.835
+        }
+      },
+      {
+        "from": {
+          "x": -4.488499999999999,
+          "y": -6.835
+        },
+        "to": {
+          "x": -4.488499999999999,
+          "y": -7.6175
+        }
+      },
+      {
+        "from": {
+          "x": -4.488499999999999,
+          "y": -7.6175
+        },
+        "to": {
+          "x": -1.46,
+          "y": -7.6175
+        }
+      },
+      {
+        "from": {
+          "x": -1.46,
+          "y": -7.6175
+        },
+        "to": {
+          "x": -1.46,
+          "y": -7.4174999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.46,
+        "y": -7.6175
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_153",
+    "source_trace_id": "schematic_port_75-schematic_port_178",
+    "edges": [
+      {
+        "from": {
+          "x": 1.03,
+          "y": 5.84
+        },
+        "to": {
+          "x": 1.140625,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 1.140625,
+          "y": 5.84
+        },
+        "to": {
+          "x": 1.140625,
+          "y": 5.3255625
+        }
+      },
+      {
+        "from": {
+          "x": 1.140625,
+          "y": 5.3255625
+        },
+        "to": {
+          "x": 1.76,
+          "y": 5.3255625
+        }
+      },
+      {
+        "from": {
+          "x": 1.76,
+          "y": 5.3255625
+        },
+        "to": {
+          "x": 1.76,
+          "y": 5.2311250000000005
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 1.140625,
+        "y": 5.3255625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_154",
+    "source_trace_id": "schematic_port_199-schematic_port_75",
+    "edges": [
+      {
+        "from": {
+          "x": -1.9093749999999998,
+          "y": 3.8025
+        },
+        "to": {
+          "x": -0.4646874999999999,
+          "y": 3.8025
+        }
+      },
+      {
+        "from": {
+          "x": -0.4646874999999999,
+          "y": 3.8025
+        },
+        "to": {
+          "x": -0.4646874999999999,
+          "y": 5.3255625
+        }
+      },
+      {
+        "from": {
+          "x": -0.4646874999999999,
+          "y": 5.3255625
+        },
+        "to": {
+          "x": 1.140625,
+          "y": 5.3255625
+        }
+      },
+      {
+        "from": {
+          "x": 1.140625,
+          "y": 5.3255625
+        },
+        "to": {
+          "x": 1.140625,
+          "y": 5.84
+        }
+      },
+      {
+        "from": {
+          "x": 1.140625,
+          "y": 5.84
+        },
+        "to": {
+          "x": 1.03,
+          "y": 5.84
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -1.7093749999999999,
+        "y": 3.8025
+      },
+      {
+        "x": 1.140625,
+        "y": 5.3255625
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net39"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_155",
+    "source_trace_id": "schematic_port_81-schematic_port_159",
+    "edges": [
+      {
+        "from": {
+          "x": -11.927499999999998,
+          "y": 5.6575
+        },
+        "to": {
+          "x": -11.7275,
+          "y": 5.6575
+        }
+      },
+      {
+        "from": {
+          "x": -11.7275,
+          "y": 5.6575
+        },
+        "to": {
+          "x": -11.7275,
+          "y": 8.385
+        }
+      },
+      {
+        "from": {
+          "x": -11.7275,
+          "y": 8.385
+        },
+        "to": {
+          "x": -10.412500000000001,
+          "y": 8.385
+        }
+      },
+      {
+        "from": {
+          "x": -10.412500000000001,
+          "y": 8.385
+        },
+        "to": {
+          "x": -10.412500000000001,
+          "y": 5.6575
+        }
+      },
+      {
+        "from": {
+          "x": -10.412500000000001,
+          "y": 5.6575
+        },
+        "to": {
+          "x": -10.6125,
+          "y": 5.6575
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net34"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_156",
+    "source_trace_id": "available-net-orientation-27-V12Vs",
+    "edges": [
+      {
+        "from": {
+          "x": -0.635,
+          "y": -4.114999999999999
+        },
+        "to": {
+          "x": -1.296,
+          "y": -4.114999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -1.296,
+          "y": -4.114999999999999
+        },
+        "to": {
+          "x": -1.296,
+          "y": -4.063999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_157",
+    "source_trace_id": "available-net-orientation-30-V20V2",
+    "edges": [
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -3.9499999999999997
+        },
+        "to": {
+          "x": 4.5625,
+          "y": -3.9999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": 4.5625,
+          "y": -3.9999999999999996
+        },
+        "to": {
+          "x": 5.7675,
+          "y": -3.9999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": 5.7675,
+          "y": -3.9999999999999996
+        },
+        "to": {
+          "x": 5.8125,
+          "y": -3.9999999999999996
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 5.8125,
+          "y": -3.9999999999999996
+        },
+        "to": {
+          "x": 5.8125,
+          "y": -3.649
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net45"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_158",
+    "source_trace_id": "available-net-orientation-71-VG_SR2",
+    "edges": [
+      {
+        "from": {
+          "x": 2.125,
+          "y": 3.8325
+        },
+        "to": {
+          "x": 2.546,
+          "y": 3.8325
+        }
+      },
+      {
+        "from": {
+          "x": 2.546,
+          "y": 3.8325
+        },
+        "to": {
+          "x": 2.546,
+          "y": 4.1834999999999996
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net51"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_159",
+    "source_trace_id": "available-net-orientation-74-VG_SR1",
+    "edges": [
+      {
+        "from": {
+          "x": 2.125,
+          "y": 2.19
+        },
+        "to": {
+          "x": 2.5959999999999996,
+          "y": 2.19
+        }
+      },
+      {
+        "from": {
+          "x": 2.5959999999999996,
+          "y": 2.19
+        },
+        "to": {
+          "x": 2.5959999999999996,
+          "y": 2.2409999999999997
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net52"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "V20V1",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -7.402500000000001,
+      "y": 6.57
+    },
+    "center": {
+      "x": -7.402500000000001,
+      "y": 6.66
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "GND1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -5.593875000000001,
+      "y": 0.2924999999999999
+    },
+    "center": {
+      "x": -5.593875000000001,
+      "y": 0.20249999999999993
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "GND1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -8.76,
+      "y": -6.5785
+    },
+    "center": {
+      "x": -8.76,
+      "y": -6.6685
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "GND1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -14.4175,
+      "y": 3.8912500000000003
+    },
+    "center": {
+      "x": -14.4175,
+      "y": 3.8012500000000005
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "GND1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -7.7524999999999995,
+      "y": -0.8125
+    },
+    "center": {
+      "x": -8.0525,
+      "y": -0.8125
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "GND1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -1.6874999999999998,
+      "y": -7.034999999999999
+    },
+    "center": {
+      "x": -1.3874999999999997,
+      "y": -7.034999999999999
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 1.25125,
+      "y": 5.84
+    },
+    "center": {
+      "x": 0.9512499999999999,
+      "y": 5.84
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 1.77,
+      "y": 4.131125000000001
+    },
+    "center": {
+      "x": 1.77,
+      "y": 4.041125000000001
+    },
+    "anchor_side": "top",
+    "source_trace_id": "source_trace_106"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 5.4775,
+      "y": 4.135256249999999
+    },
+    "center": {
+      "x": 5.7775,
+      "y": 4.135256249999999
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 7.0825,
+      "y": 7.8425
+    },
+    "center": {
+      "x": 6.7825,
+      "y": 7.8425
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": 13.91375,
+      "y": 4.38
+    },
+    "center": {
+      "x": 14.213750000000001,
+      "y": 4.38
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -0.19050000000000106,
+      "y": -5.84
+    },
+    "center": {
+      "x": -0.19050000000000106,
+      "y": -5.93
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "SGND",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -3.7874999999999996,
+      "y": -7.034999999999999
+    },
+    "center": {
+      "x": -4.0874999999999995,
+      "y": -7.034999999999999
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_79"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "C504_pin2",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38",
+    "anchor_position": {
+      "x": 1.85125,
+      "y": 5.84
+    },
+    "center": {
+      "x": 2.45125,
+      "y": 5.84
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_113"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "C504_pin2",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net38",
+    "anchor_position": {
+      "x": 0.43,
+      "y": 5.84
+    },
+    "center": {
+      "x": -0.1700000000000001,
+      "y": 5.84
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_113"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "U502_HB",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35",
+    "anchor_position": {
+      "x": -9.82,
+      "y": 3.9675
+    },
+    "center": {
+      "x": -9.34,
+      "y": 3.9675
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_93"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "U502_HB",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35",
+    "anchor_position": {
+      "x": -9.88125,
+      "y": 4.745
+    },
+    "center": {
+      "x": -10.36125,
+      "y": 4.745
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "U502_HB",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net35",
+    "anchor_position": {
+      "x": -11.6525,
+      "y": 5.6575
+    },
+    "center": {
+      "x": -12.1325,
+      "y": 5.6575
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_94"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_18",
+    "text": "V5Vs",
+    "source_net_id": "source_net_7",
+    "anchor_position": {
+      "x": 9.7225,
+      "y": 8.285
+    },
+    "center": {
+      "x": 9.7225,
+      "y": 8.375
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_19",
+    "text": "T500_CT_15",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36",
+    "anchor_position": {
+      "x": 3.4675,
+      "y": 2.8025
+    },
+    "center": {
+      "x": 3.4675,
+      "y": 2.8925
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_20",
+    "text": "T500_CT_15",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net36",
+    "anchor_position": {
+      "x": 4.5625,
+      "y": 4.677125000000001
+    },
+    "center": {
+      "x": 5.2225,
+      "y": 4.677125000000001
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_21",
+    "text": "V12Vs",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": 2.7375,
+      "y": -1.4187499999999997
+    },
+    "center": {
+      "x": 2.7375,
+      "y": -1.3287499999999997
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_22",
+    "text": "V12Vs",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": -1.296,
+      "y": -4.063999999999999
+    },
+    "center": {
+      "x": -1.296,
+      "y": -3.9739999999999993
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_23",
+    "text": "V12Vs",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": 1.2774999999999999,
+      "y": -4.2625
+    },
+    "center": {
+      "x": 1.2774999999999999,
+      "y": -4.1725
+    },
+    "anchor_side": "bottom",
+    "source_trace_id": "source_trace_61",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_24",
+    "text": "V20V2",
+    "source_net_id": "source_net_6",
+    "anchor_position": {
+      "x": 7.8475,
+      "y": 2.5549999999999997
+    },
+    "center": {
+      "x": 7.8475,
+      "y": 2.6449999999999996
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_25",
+    "text": "V20V2",
+    "source_net_id": "source_net_6",
+    "anchor_position": {
+      "x": 5.8125,
+      "y": -3.649
+    },
+    "center": {
+      "x": 5.8125,
+      "y": -3.559
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_26",
+    "text": "V20V2",
+    "source_net_id": "source_net_6",
+    "anchor_position": {
+      "x": -1.46,
+      "y": -4.827249999999999
+    },
+    "center": {
+      "x": -1.46,
+      "y": -4.7372499999999995
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_27",
+    "text": "D505_K",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13",
+    "anchor_position": {
+      "x": -5.7524999999999995,
+      "y": -0.9125
+    },
+    "center": {
+      "x": -5.3325,
+      "y": -0.9125
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_35"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_28",
+    "text": "D505_K",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13",
+    "anchor_position": {
+      "x": -6.04875,
+      "y": -0.9125
+    },
+    "center": {
+      "x": -6.46875,
+      "y": -0.9125
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_35"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_29",
+    "text": "U504_SS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+    "anchor_position": {
+      "x": -8.905000000000001,
+      "y": -2.7025
+    },
+    "center": {
+      "x": -8.425,
+      "y": -2.7025
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_30"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_30",
+    "text": "U504_SS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+    "anchor_position": {
+      "x": -8.5775,
+      "y": -0.88625
+    },
+    "center": {
+      "x": -8.5775,
+      "y": -0.79625
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_31",
+    "text": "U504_SS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12",
+    "anchor_position": {
+      "x": -8.878874999999999,
+      "y": -1.28
+    },
+    "center": {
+      "x": -8.878874999999999,
+      "y": -1.37
+    },
+    "anchor_side": "top",
+    "source_trace_id": "source_trace_31"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_32",
+    "text": "U506_REF",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26",
+    "anchor_position": {
+      "x": 0.86625,
+      "y": -5.4472499999999995
+    },
+    "center": {
+      "x": 0.32624999999999993,
+      "y": -5.4472499999999995
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_73"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_33",
+    "text": "D506_A",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19",
+    "anchor_position": {
+      "x": 3.299375,
+      "y": -3.65
+    },
+    "center": {
+      "x": 3.299375,
+      "y": -3.56
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_34",
+    "text": "D506_A",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19",
+    "anchor_position": {
+      "x": 0.86625,
+      "y": -5.24725
+    },
+    "center": {
+      "x": 0.44625,
+      "y": -5.24725
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_52"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_35",
+    "text": "D506_A",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19",
+    "anchor_position": {
+      "x": -0.5722499999999995,
+      "y": -2.92
+    },
+    "center": {
+      "x": -0.5722499999999995,
+      "y": -3.01
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_36",
+    "text": "C530_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25",
+    "anchor_position": {
+      "x": 2.8025,
+      "y": -4.38
+    },
+    "center": {
+      "x": 2.2025,
+      "y": -4.38
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_69"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_37",
+    "text": "C530_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25",
+    "anchor_position": {
+      "x": 1.98125,
+      "y": -4.38
+    },
+    "center": {
+      "x": 1.3812499999999999,
+      "y": -4.38
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_69"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_38",
+    "text": "U505_IN_MINUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69",
+    "anchor_position": {
+      "x": 9.7775,
+      "y": -4.5625
+    },
+    "center": {
+      "x": 10.6175,
+      "y": -4.5625
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_193"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_39",
+    "text": "U505_IN_MINUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69",
+    "anchor_position": {
+      "x": 10.219999999999999,
+      "y": -4.53625
+    },
+    "center": {
+      "x": 10.219999999999999,
+      "y": -4.44625
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_40",
+    "text": "U505_IN_MINUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net69",
+    "anchor_position": {
+      "x": 10.8325,
+      "y": -4.5625
+    },
+    "center": {
+      "x": 9.9925,
+      "y": -4.5625
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_194"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_41",
+    "text": "U505_IN_PLUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70",
+    "anchor_position": {
+      "x": 9.7775,
+      "y": -4.7625
+    },
+    "center": {
+      "x": 10.5575,
+      "y": -4.7625
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_195"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_42",
+    "text": "U505_IN_PLUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70",
+    "anchor_position": {
+      "x": 10.219999999999999,
+      "y": -5.1362499999999995
+    },
+    "center": {
+      "x": 10.219999999999999,
+      "y": -5.226249999999999
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_43",
+    "text": "U505_IN_PLUS",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net70",
+    "anchor_position": {
+      "x": 10.8325,
+      "y": -5.109999999999999
+    },
+    "center": {
+      "x": 10.0525,
+      "y": -5.109999999999999
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_196"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_44",
+    "text": "U504_OC",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+    "anchor_position": {
+      "x": -8.905000000000001,
+      "y": -3.3025
+    },
+    "center": {
+      "x": -8.425,
+      "y": -3.3025
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_0"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_45",
+    "text": "U504_OC",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+    "anchor_position": {
+      "x": -8.03,
+      "y": -5.2275
+    },
+    "center": {
+      "x": -8.03,
+      "y": -5.3175
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_46",
+    "text": "U504_OC",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+    "anchor_position": {
+      "x": -7.3,
+      "y": -4.71875
+    },
+    "center": {
+      "x": -7.3,
+      "y": -4.62875
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_47",
+    "text": "U504_OC",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0",
+    "anchor_position": {
+      "x": -7.7524999999999995,
+      "y": -1.0125
+    },
+    "center": {
+      "x": -8.2325,
+      "y": -1.0125
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_48",
+    "text": "D506_K",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23",
+    "anchor_position": {
+      "x": 1.2774999999999999,
+      "y": -4.8625
+    },
+    "center": {
+      "x": 1.2774999999999999,
+      "y": -4.9525
+    },
+    "anchor_side": "top",
+    "source_trace_id": "source_trace_66"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_49",
+    "text": "D506_K",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23",
+    "anchor_position": {
+      "x": 0.365,
+      "y": -5.86625
+    },
+    "center": {
+      "x": 0.365,
+      "y": -5.95625
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_50",
+    "text": "D506_K",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23",
+    "anchor_position": {
+      "x": 1.365,
+      "y": -4.015
+    },
+    "center": {
+      "x": 1.785,
+      "y": -4.015
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_67"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_51",
+    "text": "Q500_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55",
+    "anchor_position": {
+      "x": 5.045,
+      "y": 7.748874999999999
+    },
+    "center": {
+      "x": 4.445,
+      "y": 7.748874999999999
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_52",
+    "text": "Q500_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net55",
+    "anchor_position": {
+      "x": 6.14,
+      "y": 6.935
+    },
+    "center": {
+      "x": 6.74,
+      "y": 6.935
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_53",
+    "text": "Q501_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+    "anchor_position": {
+      "x": 10.7025,
+      "y": 7.748874999999998
+    },
+    "center": {
+      "x": 10.102500000000001,
+      "y": 7.748874999999998
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_54",
+    "text": "Q501_pin1",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net63",
+    "anchor_position": {
+      "x": 11.797500000000001,
+      "y": 6.935
+    },
+    "center": {
+      "x": 12.3975,
+      "y": 6.935
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_55",
+    "text": "VD_SR2",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -0.4646874999999999,
+      "y": 5.3255625
+    },
+    "center": {
+      "x": -0.4646874999999999,
+      "y": 5.4155625
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_56",
+    "text": "VG_SR2",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 2.546,
+      "y": 4.1834999999999996
+    },
+    "center": {
+      "x": 2.546,
+      "y": 4.273499999999999
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_57",
+    "text": "VG_SR1",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": 2.5959999999999996,
+      "y": 2.2409999999999997
+    },
+    "center": {
+      "x": 2.5959999999999996,
+      "y": 2.3309999999999995
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_58",
+    "text": "VD_SR1",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": 1.03,
+      "y": 0.365
+    },
+    "center": {
+      "x": 1.45,
+      "y": 0.365
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_120"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_59",
+    "text": "VD_SR1",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": 1.76,
+      "y": 2.073875
+    },
+    "center": {
+      "x": 1.76,
+      "y": 2.163875
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_60",
+    "text": "Q506_pin3",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17",
+    "anchor_position": {
+      "x": -9.608875,
+      "y": -0.83
+    },
+    "center": {
+      "x": -10.208874999999999,
+      "y": -0.83
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_61",
+    "text": "Q506_pin3",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17",
+    "anchor_position": {
+      "x": -9.855,
+      "y": -1.395
+    },
+    "center": {
+      "x": -9.855,
+      "y": -1.485
+    },
+    "anchor_side": "top",
+    "source_trace_id": "source_trace_45"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_62",
+    "text": "Q506_pin3",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17",
+    "anchor_position": {
+      "x": -10.7025,
+      "y": -0.73
+    },
+    "center": {
+      "x": -11.3025,
+      "y": -0.73
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_46"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_63",
+    "text": "U503_A",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24",
+    "anchor_position": {
+      "x": -3.7874999999999996,
+      "y": -1.5425
+    },
+    "center": {
+      "x": -4.2075,
+      "y": -1.5425
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_68"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_64",
+    "text": "U503_A",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24",
+    "anchor_position": {
+      "x": 0.2475,
+      "y": -1.46
+    },
+    "center": {
+      "x": -0.1725,
+      "y": -1.46
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_68"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_65",
+    "text": "U504_RT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+    "anchor_position": {
+      "x": -7.24875,
+      "y": -2.9025
+    },
+    "center": {
+      "x": -7.24875,
+      "y": -2.9924999999999997
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_66",
+    "text": "U504_RT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+    "anchor_position": {
+      "x": -5.84,
+      "y": -5.2275
+    },
+    "center": {
+      "x": -5.84,
+      "y": -5.3175
+    },
+    "anchor_side": "top"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_67",
+    "text": "U504_RT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11",
+    "anchor_position": {
+      "x": -1.6874999999999998,
+      "y": -6.835
+    },
+    "center": {
+      "x": -1.2074999999999998,
+      "y": -6.835
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_29"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_68",
+    "text": "U505_OUT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+    "anchor_position": {
+      "x": 9.7775,
+      "y": -4.3625
+    },
+    "center": {
+      "x": 10.317499999999999,
+      "y": -4.3625
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_188"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_69",
+    "text": "U505_OUT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+    "anchor_position": {
+      "x": 7.052499999999999,
+      "y": -4.5625
+    },
+    "center": {
+      "x": 7.592499999999999,
+      "y": -4.5625
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_70",
+    "text": "U505_OUT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net67",
+    "anchor_position": {
+      "x": 6.9174999999999995,
+      "y": -3.7595
+    },
+    "center": {
+      "x": 6.3774999999999995,
+      "y": -3.7595
+    },
+    "anchor_side": "right",
+    "source_trace_id": "source_trace_189"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_71",
+    "text": "U504_DT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10",
+    "anchor_position": {
+      "x": -8.905000000000001,
+      "y": -3.1025
+    },
+    "center": {
+      "x": -8.425,
+      "y": -3.1025
+    },
+    "anchor_side": "left",
+    "source_trace_id": "source_trace_26"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_72",
+    "text": "U504_DT",
+    "source_net_id": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10",
+    "anchor_position": {
+      "x": -6.57,
+      "y": -5.2275
+    },
+    "center": {
+      "x": -6.57,
+      "y": -5.3175
+    },
+    "anchor_side": "top",
+    "source_trace_id": "source_trace_26"
+  },
+  {
+    "type": "schematic_component_styling_warning",
+    "schematic_component_styling_warning_id": "schematic_component_styling_warning_0",
+    "warning_type": "schematic_component_styling_warning",
+    "message": "No <schematicsheet> was found. Add a <schematicsheet> to define the schematic drawing area.",
+    "schematic_component_id": "schematic_component_0",
+    "source_component_id": "source_component_0",
+    "styling_issue_type": "missing_schematic_sheet"
+  },
+  {
+    "type": "source_project_metadata",
+    "source_filesystem_md5_hash": "60b85e49f3dd80cd46f5230505b04706"
+  }
+]


### PR DESCRIPTION

<img width="729" height="423" alt="Screenshot 2026-08-25 at 11 29 34 PM" src="https://github.com/user-attachments/assets/ca14f25b-0d16-4dcc-8d7e-0c8f23779f42" />

## Summary

- add the compiled Circuit JSON for the source-derived PMP11282 isolated DC/DC sheet
- add a React Cosmos fixture that renders the complete 112-component schematic
- preserve the current 160 routed traces and 73 fallback/net labels for visual inspection
- reproduce the generic yellow component bodies around the transformer, coupled inductor, optocouplers, and dual diodes

This is reproduction-only. It does not change viewer or SVG production behavior.

## Ownership finding

`SchematicViewer` delegates schematic SVG creation to `circuit-to-svg`. In this fixture the affected Circuit JSON components have `symbol_name: null`, so the viewer has no domain symbol to render and correctly falls back to generic component bodies. T500 also arrives with an explicitly undersized `0.4 mm` body.

The fixture therefore establishes the visual case without claiming the viewer is the root cause. Follow-up work should separately address:

- missing domain symbols in `core` / `schematic-symbols`
- removal of undersized generic-body dimensions in the TI TSX
- renderer behavior only if a valid symbol/body still renders incorrectly

## Source

- TI reference: PMP11282 / PMP11064 sheet 2
- tscircuit TSX: https://github.com/tscircuit/ti/pull/115
- trace-solver reproductions: https://github.com/tscircuit/schematic-trace-solver/pull/887 and https://github.com/tscircuit/schematic-trace-solver/pull/889

## Validation

- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `bun run format:check`
- visually verified in the new Cosmos fixture
