### PR TITLE
show trace net names on schematic hover

### DIFF
--- a/lib/components/SchematicTraceNetTooltip.tsx
+++ b/lib/components/SchematicTraceNetTooltip.tsx
@@ -1,0 +1,31 @@
+import type { HoveredSchematicTrace } from "lib/hooks/useSchematicNetHover"
+import { zIndexMap } from "lib/utils/z-index-map"
+
+const POINTER_OFFSET_PX = 12
+
+export const SchematicTraceNetTooltip = ({
+  hoveredTrace,
+}: {
+  hoveredTrace: HoveredSchematicTrace
+}) => (
+  <div
+    data-schematic-trace-net-tooltip
+    style={{
+      position: "absolute",
+      left: hoveredTrace.x + POINTER_OFFSET_PX,
+      top: hoveredTrace.y + POINTER_OFFSET_PX,
+      zIndex: zIndexMap.schematicTraceNetTooltip,
+      pointerEvents: "none",
+      backgroundColor: "#f2efcc",
+      color: "black",
+      padding: "4px 6px",
+      borderRadius: "4px",
+      fontFamily: "sans-serif",
+      fontSize: "11px",
+      lineHeight: 1.2,
+      whiteSpace: "nowrap",
+    }}
+  >
+    {hoveredTrace.netName}
+  </div>
+)

--- a/lib/components/SchematicViewer.tsx
+++ b/lib/components/SchematicViewer.tsx
@@ -28,6 +28,7 @@ import { SchematicComponentMouseTarget } from "./SchematicComponentMouseTarget"
 import { SchematicPortMouseTarget } from "./SchematicPortMouseTarget"
 import { SchematicSearch } from "./SchematicSearch"
 import { SchematicSheetSelector } from "./SchematicSheetSelector"
+import { SchematicTraceNetTooltip } from "./SchematicTraceNetTooltip"
 import { ViewMenu } from "./ViewMenu"
 
 interface Props {
@@ -479,8 +480,9 @@ export const SchematicViewer = ({
 
   // Fade unrelated nets/chips when hovering a wire or net label (JS-driven; the
   // base SVG carries no interaction).
-  useSchematicNetHover({
+  const hoveredSchematicTrace = useSchematicNetHover({
     svgDivRef,
+    containerRef,
     circuitJson,
     circuitJsonKey: `${circuitJsonKey}_${activeSheetId ?? ""}`,
     enabled: netHoverHighlightEnabled,
@@ -688,6 +690,9 @@ export const SchematicViewer = ({
           />
         ))}
         {svgDiv}
+        {hoveredSchematicTrace && (
+          <SchematicTraceNetTooltip hoveredTrace={hoveredSchematicTrace} />
+        )}
         {selectedComponentDetails && componentTooltipLayout && (
           <SchematicComponentDetailsTooltip
             sourceComponent={selectedComponentDetails.sourceComponent}

--- a/lib/hooks/useSchematicNetHover.ts
+++ b/lib/hooks/useSchematicNetHover.ts
@@ -1,6 +1,6 @@
 import { su } from "@tscircuit/soup-util"
 import type { CircuitJson } from "circuit-json"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 const FADED_CLASS = "sch-net-faded"
 
@@ -8,6 +8,14 @@ const TRACE_SELECTOR =
   "g.trace[data-subcircuit-connectivity-map-key], g.trace-overlays[data-subcircuit-connectivity-map-key]"
 
 const NET_LABEL_SELECTOR = "[data-schematic-net-label-id]"
+
+type SubcircuitConnectivityMapKey = string
+
+export interface HoveredSchematicTrace {
+  netName: string
+  x: number
+  y: number
+}
 
 /**
  * Net highlighting on hover, done entirely in JS (the base SVG carries no
@@ -24,20 +32,29 @@ const NET_LABEL_SELECTOR = "[data-schematic-net-label-id]"
  */
 export const useSchematicNetHover = ({
   svgDivRef,
+  containerRef,
   circuitJson,
   circuitJsonKey,
   enabled,
 }: {
   svgDivRef: React.RefObject<HTMLDivElement | null>
+  containerRef: React.RefObject<HTMLDivElement | null>
   circuitJson: CircuitJson
   circuitJsonKey: string
   enabled: boolean
 }) => {
+  const [hoveredTrace, setHoveredTrace] =
+    useState<HoveredSchematicTrace | null>(null)
+
   useEffect(() => {
     const svgDiv = svgDivRef.current
-    if (!enabled || !svgDiv) return
+    if (!enabled || !svgDiv) {
+      setHoveredTrace(null)
+      return
+    }
 
-    const { componentIdToKeys, netLabelIdToKey } = buildNetRegistry(circuitJson)
+    const { componentIdToKeys, netLabelIdToKey, netNameByKey } =
+      buildNetRegistry(circuitJson)
 
     // Every net element and the net key(s) it belongs to, plus each hover
     // trigger's net key. Rebuilt from the SVG whenever it re-renders; the
@@ -51,6 +68,7 @@ export const useSchematicNetHover = ({
       netElements = []
       triggerNetKeys.clear()
       hoveredNetKey = null
+      setHoveredTrace(null)
 
       const svg = svgDiv.querySelector("svg")
       if (!svg) return
@@ -92,20 +110,47 @@ export const useSchematicNetHover = ({
       }
     }
 
-    const handleMouseOver = (e: Event) => {
-      const target = e.target
+    const handleMouseOver = (event: Event) => {
+      const target = event.target
       if (!(target instanceof Element)) {
         highlightNet(null)
+        setHoveredTrace(null)
         return
       }
       const trigger = target.closest(`${TRACE_SELECTOR}, ${NET_LABEL_SELECTOR}`)
       if (!trigger) {
         highlightNet(null)
+        setHoveredTrace(null)
         return
       }
-      highlightNet(triggerNetKeys.get(trigger) ?? null)
+      const netKey = triggerNetKeys.get(trigger)
+      highlightNet(netKey ?? null)
+
+      if (!trigger.matches(TRACE_SELECTOR) || !(event instanceof MouseEvent)) {
+        setHoveredTrace(null)
+        return
+      }
+
+      let netName: string | undefined
+      if (netKey) {
+        netName = netNameByKey.get(netKey)
+      }
+      const containerRect = containerRef.current?.getBoundingClientRect()
+      if (!netName || !containerRect) {
+        setHoveredTrace(null)
+        return
+      }
+
+      setHoveredTrace({
+        netName,
+        x: event.clientX - containerRect.left,
+        y: event.clientY - containerRect.top,
+      })
     }
-    const handleMouseLeave = () => highlightNet(null)
+    const handleMouseLeave = () => {
+      highlightNet(null)
+      setHoveredTrace(null)
+    }
 
     collectNetElements()
     svgDiv.addEventListener("mouseover", handleMouseOver)
@@ -125,7 +170,9 @@ export const useSchematicNetHover = ({
     }
     // Keyed on circuitJsonKey (content hash) rather than the circuitJson
     // reference, matching the other post-render SVG hooks.
-  }, [svgDivRef, circuitJsonKey, enabled])
+  }, [svgDivRef, containerRef, circuitJsonKey, enabled])
+
+  return hoveredTrace
 }
 
 /**
@@ -175,5 +222,32 @@ function buildNetRegistry(circuitJson: CircuitJson) {
     netLabelIdToKey.set(label.schematic_net_label_id, key)
   }
 
-  return { componentIdToKeys, netLabelIdToKey }
+  const netNameByKey = new Map<SubcircuitConnectivityMapKey, string>()
+  for (const sourceNet of cju.source_net.list()) {
+    const netName = sourceNet.name.trim()
+    if (!netName) continue
+    const key =
+      sourceNet.subcircuit_connectivity_map_key ?? sourceNet.source_net_id
+    netNameByKey.set(key, netName)
+  }
+
+  for (const sourceTrace of cju.source_trace.list()) {
+    const key = sourceTrace.subcircuit_connectivity_map_key
+    if (!key) continue
+
+    const traceName = sourceTrace.name?.trim()
+    if (traceName) {
+      netNameByKey.set(key, traceName)
+      continue
+    }
+
+    for (const sourceNetId of sourceTrace.connected_source_net_ids) {
+      const netName = cju.source_net.get(sourceNetId)?.name.trim()
+      if (!netName) continue
+      netNameByKey.set(key, netName)
+      break
+    }
+  }
+
+  return { componentIdToKeys, netLabelIdToKey, netNameByKey }
 }

--- a/lib/utils/z-index-map.ts
+++ b/lib/utils/z-index-map.ts
@@ -4,6 +4,7 @@ export const zIndexMap = {
   viewMenuIcon: 48,
   clickToInteractOverlay: 100,
   schematicComponentDetailsTooltip: 105,
+  schematicTraceNetTooltip: 104,
   schematicComponentHoverOutline: 47,
   schematicPortHoverOutline: 48,
   schematicSearch: 101,

--- a/tests/schematic-trace-net-tooltip.test.tsx
+++ b/tests/schematic-trace-net-tooltip.test.tsx
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { JSDOM } from "jsdom"
+import { act, useRef } from "react"
+import { createRoot } from "react-dom/client"
+import { SchematicTraceNetTooltip } from "../lib/components/SchematicTraceNetTooltip"
+import { useSchematicNetHover } from "../lib/hooks/useSchematicNetHover"
+
+const circuitJson: CircuitJson = [
+  {
+    type: "source_net",
+    source_net_id: "source_net_vcc",
+    name: "VCC",
+    member_source_group_ids: [],
+    subcircuit_connectivity_map_key: "net_vcc",
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_vcc",
+    connected_source_port_ids: [],
+    connected_source_net_ids: ["source_net_vcc"],
+    subcircuit_connectivity_map_key: "net_vcc",
+  },
+]
+
+const Harness = () => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const svgDivRef = useRef<HTMLDivElement>(null)
+  const hoveredTrace = useSchematicNetHover({
+    svgDivRef,
+    containerRef,
+    circuitJson,
+    circuitJsonKey: "trace-tooltip",
+    enabled: true,
+  })
+
+  return (
+    <div ref={containerRef}>
+      <div ref={svgDivRef} data-svg-container>
+        <svg>
+          <g className="trace" data-subcircuit-connectivity-map-key="net_vcc">
+            <path data-trace-path />
+          </g>
+        </svg>
+      </div>
+      {hoveredTrace && <SchematicTraceNetTooltip hoveredTrace={hoveredTrace} />}
+    </div>
+  )
+}
+
+test("reports a trace net name and pointer position on hover", async () => {
+  const dom = new JSDOM('<div id="root"></div>')
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    Element: globalThis.Element,
+    MouseEvent: globalThis.MouseEvent,
+    MutationObserver: globalThis.MutationObserver,
+  }
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    Element: dom.window.Element,
+    MouseEvent: dom.window.MouseEvent,
+    MutationObserver: dom.window.MutationObserver,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })
+
+  const reactRoot = createRoot(document.getElementById("root")!)
+
+  try {
+    await act(async () => reactRoot.render(<Harness />))
+    const container = document.querySelector("#root > div")!
+    container.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        right: 210,
+        bottom: 120,
+        width: 200,
+        height: 100,
+        x: 10,
+        y: 20,
+        toJSON: () => {},
+      }) as DOMRect
+
+    await act(async () => {
+      document.querySelector("[data-trace-path]")!.dispatchEvent(
+        new dom.window.MouseEvent("mouseover", {
+          bubbles: true,
+          clientX: 42,
+          clientY: 84,
+        }),
+      )
+    })
+
+    const tooltip = document.querySelector(
+      "[data-schematic-trace-net-tooltip]",
+    ) as HTMLDivElement
+    expect(tooltip.textContent).toBe("VCC")
+    expect(tooltip.style.left).toBe("44px")
+    expect(tooltip.style.top).toBe("76px")
+
+    await act(async () => {
+      document
+        .querySelector("[data-svg-container]")!
+        .dispatchEvent(new dom.window.MouseEvent("mouseleave"))
+    })
+    expect(
+      document.querySelector("[data-schematic-trace-net-tooltip]"),
+    ).toBeNull()
+  } finally {
+    await act(async () => reactRoot.unmount())
+    Object.assign(globalThis, {
+      ...previousGlobals,
+      IS_REACT_ACT_ENVIRONMENT: false,
+    })
+    dom.window.close()
+  }
+})


### PR DESCRIPTION
### Motivation
- Make schematic trace nets as easy to identify as PCB trace nets.

### Before
- Hovering a schematic trace highlighted its connected net without showing the net name.

### After
- Hovering a named schematic trace shows its net name in a small pointer tooltip.